### PR TITLE
add line comment and block comment definition to pest file

### DIFF
--- a/src/grammer.pest
+++ b/src/grammer.pest
@@ -1,4 +1,4 @@
-sep = _{ " " | "\t" | NEWLINE }
+sep = _{ " " | "\t" | NEWLINE | block_comment | line_comment }
 
 int_lit_expr = { "-"? ~ ASCII_DIGIT ~ ASCII_DIGIT* }
 
@@ -29,3 +29,11 @@ bracket_expr = { "(" ~ sep* ~ expr ~ sep* ~ ")" }
 expr = { app_expr | not_app_expr }
 
 file = _{ SOI ~ sep* ~ expr ~ sep* ~ EOI }
+
+block_comment = _{ "{-"  ~ block_commented_character*  ~ "-}" }
+
+block_commented_character = _{ !"-}" ~ ANY }
+
+line_comment = _{"//" ~ line_commented_character* ~ ( NEWLINE | EOI )}
+
+line_commented_character = _{ !(NEWLINE | EOI) ~ ANY }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -328,3 +328,41 @@ pub fn test28() {
     let answer = 832040;
     test_run_source(source, answer, OptimizationLevel::Default);
 }
+
+#[test]
+#[serial]
+pub fn test29() {
+    // block comment
+    let source = r"{- head -}
+            let x = 5 in 
+            let y = -3 in
+            {- If the closing symbol is put on the end of this line, g will evaluate.
+            let g = fix \f -> \x -> if eq x 0 then 0 else add x (f (add x -1));
+            g 100
+            {--}
+            {- 
+            multiple line 
+            block comment
+            -}
+            {- sub 1 -}add x{- This comment is parsed as a separater -}y{- comment -}
+
+
+        {-tail-}";
+    let answer = 2;
+    test_run_source(source, answer, OptimizationLevel::Default);
+}
+
+#[test]
+#[serial]
+pub fn test30() {
+    // ilne comment
+    let source = r"////
+            let x = 5 in
+            // let x = 3 in
+// some excellent and brilliant comment
+            let y = -3 in// comment
+            add x y
+        //";
+    let answer = 2;
+    test_run_source(source, answer, OptimizationLevel::Default);
+}


### PR DESCRIPTION
append pest definition of commets and its test.

Block comments are written using {- -} same as in Haskell. But nested comment is not allowed. Line comments begin with //. 