### PR TITLE
use fputs() instead of fprintf(), printf()

### DIFF
--- a/src/fix/std.fix
+++ b/src/fix/std.fix
@@ -455,7 +455,7 @@ namespace IO {
     eprint = |str| (
         IO { _data : |_| (
             eval str.borrow_c_str(|c_ptr|
-                CALL_C[I32 fprintf(Ptr, Ptr, ...), stderr._file_ptr, c_ptr]
+                CALL_C[I32 fputs(Ptr, Ptr), c_ptr, stderr._file_ptr]
             );
             ()
         )}
@@ -595,7 +595,7 @@ namespace IO {
     print = |str| (
         IO { _data : |_| (
             eval str.borrow_c_str(|c_ptr|
-                CALL_C[I32 printf(Ptr, ...), c_ptr]
+                CALL_C[I32 fputs(Ptr, Ptr), c_ptr, stdout._file_ptr]
             );
             ()
         )}


### PR DESCRIPTION
For `IO::println()` and `IO::eprintln()`, unexpected output is produced if the string contains a percent sign.

```
module Main;
main: IO ();
main = (
    let _ = *println ("%d%x%f");
    let _ = *eprintln ("%d%x%f");
    let _ = *println ("abc%20%21%22%23def");
    let _ = *eprintln ("abc%20%21%22%23def");
    pure()
);
```

This is because `IO::print()` and `IO::eprint()` call the C functions `printf()` and `fprintf()`, respectively.

This problem was resolved by using `fputs()` instead of `printf()` or `fprintf()`.