### PR TITLE
runner.rs: fix dynamic libs issue

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -62,6 +62,7 @@ fn execute_main_module<'c>(ee: &ExecutionEngine<'c>, config: &Configuration) -> 
         }
         // Load dynamically linked libraries specified by user.
         for (lib_name, _) in &config.linked_libraries {
+            com = com.arg(format!("-Wl,--no-as-needed"));
             com = com.arg(format!("-l{}", lib_name));
         }
         let output = com.output().expect("Failed to run cc.");
@@ -508,7 +509,6 @@ pub fn build_file(mut config: Configuration) {
     }
 
     let output = Command::new("gcc")
-        .args(libs_opts)
         .arg("-Wno-unused-command-line-argument")
         .arg("-no-pie")
         .arg("-Wl,--gc-sections")
@@ -516,6 +516,7 @@ pub fn build_file(mut config: Configuration) {
         .arg(exec_path.to_str().unwrap())
         .arg(obj_path.to_str().unwrap())
         .arg(runtime_obj_path.to_str().unwrap())
+        .args(libs_opts)
         .output()
         .expect("Failed to run gcc.");
     if output.stderr.len() > 0 {


### PR DESCRIPTION
execute_main_module(): add `-Wl,--no-as-needed` so that the library name is put into DT_NEEDED record of fixruntime*.so
build_file(): move libs_opts to the last so that the symbols of the library is searched after obj_path is linked

日本語による説明:
動的ライブラリのリンクがうまく動かない件の対策です。

例えば、fix run -d lib_name -f prog_name.fix とした場合、
ランタイムライブラリをコンパイルする際に `-Wl,--no-as-needed` フラグを付ける必要がありました。
このフラグを付けると、ランタイムライブラリの DT_NEEDED フィールドに指定した動的ライブラリが追加されます。
(`objdump -p libfixruntime.*.so | grep NEEDED` で確認できます)

また、fix build -d lib_name -f prog_name.fix とした場合も、ライブラリを最後に指定する必要がありました。

ただ、既存のコードに対する影響が大きいと思われますので、
main ブランチにマージするかどうかはお任せいたします。


