### PR TITLE
fix read_library_options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,8 @@ fn main() {
         ] {
             options.append(
                 &mut m
-                    .get_many::<String>(opt_id)
+                    .try_get_many::<String>(opt_id)
+                    .unwrap_or_default()
                     .unwrap_or_default()
                     .map(|v| (v.clone(), link_type))
                     .collect::<Vec<_>>(),


### PR DESCRIPTION
For subcommand "run", static-link-library is not specified in arg list. So, if you execute "fix run" after debug build,
such as "target/debug/fix run -f examples/fib_fix.fix" arg_matches.get_many() panicks.
In release build, arg_matches.get_many() does not panick, but I don't know why.

日本語による説明:

static-link-library は run サブコマンドには存在しないため、`arg_matches.get_many()` がパニックする場合があります。
DEBUGビルドした後に実行すると特に発生するようです。RELEASEビルドではなぜか発生しません。
`try_get_many()` を使うようにしたところ、問題が解決しました。

```
$ cargo build
Compiling fixlang v0.1.1 (/home/user/fixlang/fixlang)
Finished dev [unoptimized + debuginfo] target(s) in 7.55s

$ target/debug/fix run -f examples/fib_fix.fix
thread 'main' panicked at 'Mismatch between definition and access of `static-link-library`. Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
', src/main.rs:163:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
