### PR TITLE
change TypeNode::to_string

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -801,9 +801,9 @@ impl TypeNode {
                 let tycon = self.toplevel_tycon();
                 if tycon.is_some() {
                     match get_tuple_n(&tycon.unwrap().name) {
-                        Some(n) => {
+                        Some(_n) => {
                             let args = self.collect_type_argments();
-                            assert_eq!(args.len(), n as usize);
+                            //assert_eq!(args.len(), n as usize);
                             let arg_strs =
                                 args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
                             return format!("({})", arg_strs.join(", "));

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -801,11 +801,16 @@ impl TypeNode {
                 let tycon = self.toplevel_tycon();
                 if tycon.is_some() {
                     match get_tuple_n(&tycon.unwrap().name) {
-                        Some(_n) => {
+                        Some(n) => {
                             let args = self.collect_type_argments();
-                            //assert_eq!(args.len(), n as usize);
-                            let arg_strs =
+                            let mut arg_strs =
                                 args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+                            assert!(args.len() <= n as usize);
+                            // If args.len() < n, then `self` is a partial application to a tuple.
+                            // In this case, we show missing arguments by `*` (e.g., `(Std::I64, *)`).
+                            for _ in args.len()..n as usize {
+                                arg_strs.push("*".to_string());
+                            }
                             return format!("({})", arg_strs.join(", "));
                         }
                         None => {}


### PR DESCRIPTION
comment out assertion for length of tuple type args.

日本語による説明:
型チェックエラーを表示する際に、タプルの型を表示しています。
その際、型引数の数とタプルの n が一致しないためパニックする場合があるようです。


```
// tuple_len.fix
module Main;

main: IO ();
main = (
    let a = ([0], 0);
    println(a.map(to_string).to_iter.join(","))
);
```

```
$ fix run -f tuple_len.fix
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`', src/ast/types.rs:806:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

上記のタプルの型引数の数を検証するアサーションをコメントアウトしたところ、以下のように正しいエラーメッセージが表示されるようになりました。

```
$ fix run -f tuple_len.fix
error: No value named `map` matches the expected type `t1 -> (Std::Array Std::I64, Std::I64) -> t0`.
- `Std::Functor::map` of type `[t0 : Std::Functor] (t1 -> t2) -> t0 t1 -> t0 t2` does not match since the constraint `(Std::Array Std::I64) : Std::Functor` is not satisifed.

At 6:15-6:18 in "tuple_len.fix",
  |
6 |     println(a.map(to_string).to_iter.join(","))
  |               ^^^

```

