### PR TITLE
fix Time::get_now

### DIFF
--- a/src/fix/time.fix
+++ b/src/fix/time.fix
@@ -90,9 +90,11 @@ from_utc = _datetime_to_time_inner(false);
 // Get current time.
 get_now : IO Time;
 get_now = (
-    let buf: Array I64 = Array::empty(2)._unsafe_set_size(2); // sec, usec.
-    eval CALL_C[() fixruntime_clock_gettime(Ptr), buf._get_ptr];
-    pure $ Time { sec : buf.@(0), nanosec : buf.@(1).to_U32 }
+    IO { _data : |_| (
+        let buf: Array I64 = Array::empty(2)._unsafe_set_size(2); // sec, usec.
+        eval CALL_C[() fixruntime_clock_gettime(Ptr), buf._get_ptr];
+        Time { sec : buf.@(0), nanosec : buf.@(1).to_U32 }
+    )}
 );
 
 // Convert time to 64-bit floating value.


### PR DESCRIPTION
Time::get_now() did not return the current time.

Test code:
```
module Main;
import Time;
main: IO ();
main = (
    loop_m(
        0, |i|
        if i >= 20 { break_m $ () };
        let now = *Time::get_now;
        let _ = *println("sec=" + now.@sec.to_string + " nanosec=" + now.@nanosec.to_string);
        eval CALL_C[U32 sleep(U32), 1_U32];
        continue_m $ i + 1
    )
);
```