### PR TITLE
use fputs() instead of fprintf() in `Debug::_debug_print_to_stream()`.

### DIFF
--- a/src/fix/debug.fix
+++ b/src/fix/debug.fix
@@ -7,7 +7,7 @@ _debug_print_to_stream : IOHandle -> String -> ();
 _debug_print_to_stream = |hdl, msg| (
     msg.borrow_c_str(|str| (
         let hdl = hdl._file_ptr;
-        eval CALL_C[I32 fprintf(Ptr, Ptr, ...), hdl, str];
+        eval CALL_C[I32 fputs(Ptr, Ptr), str, hdl];
         eval CALL_C[I32 fflush(Ptr), hdl];
         ()
     ))


### PR DESCRIPTION
For `Debug::debug_println()` and `Debug::debug_eprintln()`, unexpected output is produced if the string contains a percent sign.
This problem was resolved by using fputs() instead of fprintf().

Test code:
```
module Main;
import Debug;
main: IO ();
main = (
    eval debug_println("Hello %d%x%f%g%e");
    eval debug_eprintln("World %d%x%f%g%e");
    pure()
);
```
