### PR TITLE
fix IO::read_bytes()

### DIFF
--- a/BuiltinLibraries.md
+++ b/BuiltinLibraries.md
@@ -1161,15 +1161,13 @@ This function is almost the same as `Array::act`, but it panics if the given arr
 
 #### `append : Array a -> Array a -> Array a`
 Append an array to an array.
-Note 1: Since `a1.append(a2)` puts `a2` after `a1`, `append(lhs, rhs)` puts `lhs` after `rhs`.
-Note 2: 
-As an optimization, when `a1` is empty, `a1.append(a2)` may return `a2` itself.
-So even if you call `append` on an unique empty array, the returned array can be a shared one.
+Note: Since `a1.append(a2)` puts `a2` after `a1`, `append(lhs, rhs)` puts `lhs` after `rhs`.
 
 #### `append! : Array a -> Array a -> Array a`
 Append an array to an array.
 This is similar to `Array::append`, but `a1.append!(a2)` panics if this function has to clone `a1` due to it being shared.
-Note that, when the capacity of `a1` is less than `a1.get_size + a2.get_size`, then `a1.append!(a2)` will not panic even if `a1` is shared, because in this case cloning is inevitable whether or not `a1` is shared.
+Note that, when the capacity of `a1` is less than `a1.get_size + a2.get_size`, then `a1.append!(a2)` will not panic even if `a1` is shared, 
+because in this case cloning is inevitable whether or not `a1` is shared.
 
 #### `borrow_ptr : (Ptr -> b) -> Array a -> b`
 Call a function with a pointer to the memory region where elements are stored.

--- a/src/fix/std.fix
+++ b/src/fix/std.fix
@@ -98,23 +98,19 @@ namespace Array {
     );
 
     // Append an array to an array.
-    // Note 1: Since `a1.append(a2)` puts `a2` after `a1`, `append(lhs, rhs)` puts `lhs` after `rhs`.
-    // Note 2: 
-    // As an optimization, when `a1` is empty, `a1.append(a2)` may return `a2` itself.
-    // So even if you call `append` on an unique empty array, the returned array can be a shared one.
+    // Note: Since `a1.append(a2)` puts `a2` after `a1`, `append(lhs, rhs)` puts `lhs` after `rhs`.
     append : Array a -> Array a -> Array a;
     append = |v2, v1| (
-        // if v2 is empty, return early to avoid unnecessary clone.
-        let v2_len = v2.get_size;
-        if v2_len == 0 { v1 };
-
-        // if v1 is empty, return early to avoid unnecessary clone.
         let v1_len = v1.get_size;
-        if v1_len == 0 { v2 };
+        let v2_len = v2.get_size;
 
-        // Reserve v1's buffer and force uniqueness.
+        // Reserve v1's buffer and force uniqueness.        
         let len = v1_len + v2_len;
-        let v1 = v1.reserve(len).force_unique;
+        let v1 = if v1.get_capacity < len {
+            v1.reserve(max(len, 2 * v1.get_capacity))
+        } else {
+            v1.force_unique
+        };
         
         // Set length.
         let v1 = v1._unsafe_set_size(len);
@@ -129,20 +125,20 @@ namespace Array {
 
     // Append an array to an array.
     // This is similar to `Array::append`, but `a1.append!(a2)` panics if this function has to clone `a1` due to it being shared.
-    // Note that, when the capacity of `a1` is less than `a1.get_size + a2.get_size`, then `a1.append!(a2)` will not panic even if `a1` is shared, because in this case cloning is inevitable whether or not `a1` is shared.
+    // Note that, when the capacity of `a1` is less than `a1.get_size + a2.get_size`, then `a1.append!(a2)` will not panic even if `a1` is shared, 
+    // because in this case cloning is inevitable whether or not `a1` is shared.
     append! : Array a -> Array a -> Array a;
     append! = |v2, v1| (
-        // if v2 is empty, return early to avoid unnecessary clone.
-        let v2_len = v2.get_size;
-        if v2_len == 0 { v1 };
-
-        // if v1 is empty, return early to avoid unnecessary clone.
         let v1_len = v1.get_size;
-        if v1_len == 0 { v2 };
+        let v2_len = v2.get_size;
 
         // Reserve v1's buffer and force uniqueness.
         let len = v1_len + v2_len;
-        let v1 = v1.reserve(len).force_unique!;
+        let v1 = if v1.get_capacity < len {
+            v1.reserve(max(len, 2 * v1.get_capacity))
+        } else {
+            v1.force_unique!
+        };
         
         // Set length.
         let v1 = v1._unsafe_set_size(len);
@@ -644,7 +640,7 @@ namespace IO {
         ));
         // Concatenate bytes.
         let res = Array::empty(len);
-        pure $ iter.fold(res, |res, bytes| res.append!(bytes).reserve(len))
+        pure $ iter.fold(res, |res, bytes| res.append!(bytes))
     );
 
     // Read at most n bytes from an IOHandle.

--- a/src/fix/std.fix
+++ b/src/fix/std.fix
@@ -644,7 +644,7 @@ namespace IO {
         ));
         // Concatenate bytes.
         let res = Array::empty(len);
-        pure $ iter.fold(res, |res, bytes| res.append!(bytes))
+        pure $ iter.fold(res, |res, bytes| res.append!(bytes).reserve(len))
     );
 
     // Read at most n bytes from an IOHandle.


### PR DESCRIPTION
IO::read_bytes() was slow when reading a file of a few megabytes or more.

日本語による説明:

`IO::read_file_bytes()`で5MB程度のファイルを読み込むと、かなり処理時間がかかる場合があります。具体的には、以下のテストコードを実行すると、reading done が表示されるまで75秒程度かかります。

```
module Main;

main: IO ();
main = (
    do {
        let path = Path::parse("tmp.dat").as_some;
        let size = 5 * 1000 * 1000;
        let bytes = Array::fill(size, 0_U8);
        let _ = *println("writing " + size.to_string + "bytes").lift;
        let _ = *write_file_bytes(path, bytes);
        let _ = *println("writing done").lift;
        let _ = *println("reading " + size.to_string + "bytes").lift;
        let bytes = *read_file_bytes(path);
        let _ = *println("reading done").lift;
        pure()
    }.try(eprintln)
);
```

原因調査の結果、`IO::read_bytes()` の最後に `Array::empty(len)` でキャパシティを確保していますが、`res.append!()` の直後にキャパシティが切り詰められていることが分かりました。

```
    read_bytes : IOHandle -> IOFail (Array U8);
        ...
        // Concatenate bytes.
        let res = Array::empty(len);
        pure $ iter.fold(res, |res, bytes| res.append!(bytes))
```

`Array::append!()`を確認したところ、`v1`(=res)のキャパシティが十分でもサイズが0のときは`v2`(=bytes)が返されるため、キャパシティが切り詰められたようです。

```
    append! : Array a -> Array a -> Array a;
        ...
        // if v1 is empty, return early to avoid unnecessary clone.
        let v1_len = v1.get_size;
        if v1_len == 0 { v2 };
```

対策として、`res.append!()`の後にキャパシティを再確保するようにしたところ、`IO::read_bytes()`がほぼ一瞬で完了するようになりました。

