### PR TITLE
fix IO::_read_line_inner()

### DIFF
--- a/src/fix/std.fix
+++ b/src/fix/std.fix
@@ -441,6 +441,9 @@ namespace IO {
                     if last_byte == '\n' { break $ Result::ok(str) };
                     continue $ str
                 } else {
+                    let str = if str.@_data.get_capacity == str.@_data.get_size {
+                        str.mod__data(|data| data.reserve(data.get_size * 2))
+                    } else { str };
                     continue $ str
                 }
             )


### PR DESCRIPTION
IO::read_file_string() was slow when reading a file of 100000 lines or more.

日本語による説明:

`IO::read_file_string()`で10万行程度のテキストファイルを読み込むと、かなり処理時間がかかる場合があります。具体的には、以下のテストコードを実行すると、reading done が表示されるまで180秒程度かかります。

```
module Main;

main: IO ();
main = (
    do {
        let path = Path::parse("tmp.txt").as_some;
        let num_lines = 100000;
        let _ = *println("writing " + num_lines.to_string + " lines").lift;
        let fh = *open_file(path, "w");
        let _ = *Iterator::range(0, num_lines).fold_m(
            (), |_, i|
            write_string(fh, i.to_string + "\n")
        );
        let _ = *close_file(fh).lift;
        let _ = *println("writing done").lift;
        let _ = *println("reading " + num_lines.to_string + " lines").lift;
        let str = *read_file_string(path);
        let _ = *println("reading done").lift;
        pure()
    }.try(eprintln)
);
```

原因を調査したところ、IO::_read_line_inner() の中で文字列を結合していますが、
この文字列結合の実体は`String::concat()`で、 `Array::append()`を呼び出しているようです。
```
_read_line_inner : Bool -> IOHandle -> IOFail String;
    ...
    let str = str + read;
```

`Array::append()`では、結合後のサイズに合わせてキャパシティを確保しています。
このため、文字列結合を繰り返すとその都度再確保が行われるようです。
```
append : Array a -> Array a -> Array a;
        ...
        // Reserve v1's buffer and force uniqueness.
        let len = v1_len + v2_len;
        let v1 = v1.reserve(len).force_unique;
```

対策として、upto_newline が false のときはキャパシティを2倍ずつ増加させるようにしたところ、
`IO::read_file_string()`がほぼ一瞬で完了するようになりました。