### PR TITLE
make IO::write_string, write_bytes etc. to be guarded

### DIFF
--- a/src/fix/std.fix
+++ b/src/fix/std.fix
@@ -495,6 +495,7 @@ namespace IO {
     // Get the number of command line arguments.
     get_arg_count : IO I64;
     get_arg_count = (
+        eval *pure();
         let argc = CALL_C[I32 fixruntime_get_argc()].to_I64;
         pure $ argc
     );
@@ -526,7 +527,10 @@ namespace IO {
 
     // Check if an `IOHandle` reached to the EOF.
     is_eof : IOHandle -> IO Bool;
-    is_eof = |handle| pure $ CALL_C[I32 feof(Ptr), handle._file_ptr] != 0_I32;
+    is_eof = |handle| (
+        eval *pure();
+        pure $ CALL_C[I32 feof(Ptr), handle._file_ptr] != 0_I32
+    );
 
     // Loop on lines read from an `IOHandle`.
     // `loop_lines(handle, initial_state, worker)` calls `worker` on the pair of current state and a line string read from `handle`.
@@ -535,6 +539,7 @@ namespace IO {
     // Note that the line string passed to `worker` may contain a newline code at the end. To remove it, use `String::strip_last_spaces`.
     loop_lines : IOHandle -> s -> (s -> String -> LoopResult s s) -> IOFail s;
     loop_lines = |handle, state, worker| (
+        eval *pure();
         if is_eof(handle)._unsafe_perform {
             pure $ state
         };
@@ -555,6 +560,7 @@ namespace IO {
     // Similar to `loop_lines`, but the worker function can perform an IO action.
     loop_lines_io : IOHandle -> s -> (s -> String -> IOFail (LoopResult s s)) -> IOFail s;
     loop_lines_io = |handle, state, worker| (
+        eval *pure();
         if is_eof(handle)._unsafe_perform {
             pure $ state
         };
@@ -629,6 +635,7 @@ namespace IO {
     // Read all bytes from an IOHandle.
     read_bytes : IOHandle -> IOFail (Array U8);
     read_bytes = |handle| (
+        eval *pure();
         // Get Iterator of Arrays.
         let (iter, len) = *loop_m((Iterator::empty, 0), |(iter, len)| (
             let bytes = *read_n_bytes(handle, 1024);
@@ -646,6 +653,7 @@ namespace IO {
     // Read at most n bytes from an IOHandle.
     read_n_bytes : IOHandle -> I64 -> IOFail (Array U8);
     read_n_bytes = |handle, n| (
+        eval *pure();
         let buf = Array::empty(n);
         let len = buf.borrow_ptr(|ptr| (
             CALL_C[I64 fread(Ptr, I64, I64, Ptr), ptr, 1, n, handle._file_ptr]
@@ -698,6 +706,7 @@ namespace IO {
     // Write a byte array into an IOHandle.
     write_bytes : IOHandle -> Array U8 -> IOFail ();
     write_bytes = |handle, array| (
+        eval *pure();
         let res = array.borrow_ptr(|ptr| (
             let n = array.get_size;
             let res = CALL_C[I64 fwrite(Ptr, I64, I64, Ptr), ptr, 1, n, handle._file_ptr];
@@ -718,6 +727,7 @@ namespace IO {
     // Write a string into an IOHandle.
     write_string : IOHandle -> String -> IOFail ();
     write_string = |handle, content| (
+        eval *pure();
         let res = content.borrow_c_str(|c_str| (
             let file_ptr = handle._file_ptr;
             let res = CALL_C[I32 fputs(Ptr, Ptr), c_str, handle._file_ptr];


### PR DESCRIPTION
`write_string()`, `write_bytes()`, `read_bytes()` etc. did IO operations without performing the IO/IOFail monad.

This problem is solved by putting `eval *pure()` before IO operations.

日本語による説明:

下記のサンプルコードでは、`write_string()`, `write_bytes()`, `read_bytes()` は単にevalされているだけですが、実際には副作用のある処理が実行されるようです。
(ファイル出力を行うプログラムを書いているときに、`write_string()` の前に `*` を付け忘れたのにも関わらず、何故か文字列が出力されたために気がつきました。)

```
module Main;
foo: () -> I64;
foo = |_| (
    eval write_string(IO::stdout, "Hello World\n");
    eval write_bytes(IO::stdout, "Please type something and Ctrl-D.\n".get_bytes.pop_back);
    eval read_bytes(IO::stdin);
    123
);
main: IO ();
main = (
    let x: I64 = foo();
    println("x="+x.to_string)
);
```

std.fix を確認したところ、上記の関数は副作用のある処理が `IO { _data: ... }` 等で囲まれていませんでした。他にもいくつか同様の関数がありました。

修正方法として、副作用のある処理を`IO { _data: ... }` 等で囲む案を検討しましたが、少し長くなるため
同じ効果を持つ `eval *pure();` を関数の先頭に追加する方法を採用しました。
修正後に確認したところ、上記のサンプルコードでIOオペレーションが実行されないようになりました。
