### PR TITLE
improve comparison of local project sources

### DIFF
--- a/src/dependency_lockfile.rs
+++ b/src/dependency_lockfile.rs
@@ -14,7 +14,7 @@ use crate::{
     dependency_resolver::{self, Dependency, Package, PackageName},
     error::Errors,
     project_file::{ProjectFile, ProjectFileDependency, ProjectName},
-    EXTERNAL_PROJ_INSTALL_PATH, LOCK_FILE_PATH, PROJECT_FILE_PATH,
+    to_absolute_path, EXTERNAL_PROJ_INSTALL_PATH, LOCK_FILE_PATH, PROJECT_FILE_PATH,
 };
 
 #[derive(Deserialize, Serialize, Default)]
@@ -433,9 +433,21 @@ pub enum ProjectSource {
 }
 
 impl ProjectSource {
+    // Stringify the source for display.
+    fn to_string(&self) -> String {
+        match self {
+            ProjectSource::Local(path_buf) => {
+                to_absolute_path(path_buf).to_string_lossy().to_string()
+            }
+            ProjectSource::Git(url, _repo) => url.clone(),
+        }
+    }
+
     fn equivalent(&self, other: &Self) -> bool {
         match (self, other) {
-            (ProjectSource::Local(path1), ProjectSource::Local(path2)) => path1.canonicalize().unwrap() == path2.canonicalize().unwrap(),
+            (ProjectSource::Local(path1), ProjectSource::Local(path2)) => {
+                to_absolute_path(path1) == to_absolute_path(path2)
+            }
             (ProjectSource::Git(url1, _), ProjectSource::Git(url2, _)) => url1 == url2,
             _ => false,
         }
@@ -542,8 +554,10 @@ fn create_package_retriever(
                     continue;
                 }
                 return Err(Errors::from_msg(format!(
-                    "Project \"{}\" is required twice with different sources.",
-                    dep.name
+                    "Project \"{}\" is required twice with different sources: \"{}\" and \"{}\".",
+                    dep.name,
+                    prj.source.to_string(),
+                    dep_src.to_string()
                 )));
             }
             let prj = ProjectInfo {

--- a/src/dependency_lockfile.rs
+++ b/src/dependency_lockfile.rs
@@ -435,7 +435,7 @@ pub enum ProjectSource {
 impl ProjectSource {
     fn equivalent(&self, other: &Self) -> bool {
         match (self, other) {
-            (ProjectSource::Local(path1), ProjectSource::Local(path2)) => path1 == path2,
+            (ProjectSource::Local(path1), ProjectSource::Local(path2)) => path1.canonicalize().unwrap() == path2.canonicalize().unwrap(),
             (ProjectSource::Git(url1, _), ProjectSource::Git(url2, _)) => url1 == url2,
             _ => false,
         }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -117,7 +117,7 @@ pub fn number_to_varname(n: usize) -> String {
 
 // Converts a path to an absolute path.
 pub fn to_absolute_path(path: &Path) -> PathBuf {
-    if path.is_absolute() {
+    let abs = if path.is_absolute() {
         path.to_path_buf()
     } else {
         match std::env::current_dir() {
@@ -126,5 +126,12 @@ pub fn to_absolute_path(path: &Path) -> PathBuf {
             }
             Ok(cur_dir) => cur_dir.join(path),
         }
-    }
+    };
+    abs.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "Failed to canonicalize path \"{}\": {}",
+            abs.to_string_lossy(),
+            e
+        )
+    })
 }


### PR DESCRIPTION
Resolve "required twice" error in LocalFileSystem project.

日本語による説明:
`[[dependencies]]` の `path = ` でローカルファイルシステム上のプロジェクトを参照できますが、下記の例のように、親から子と孫、子から孫、という参照があると、`～ is required twice with different sources.` のようなエラーが出ます。

projects/
  proj1
  proj2
  proj3

proj2 から ../proj1 に依存関係がある
proj3 から ../proj1, ../proj2 に依存関係がある

おそらく、"proj2/../proj1" と "proj3/../proj1" を比較して不一致になっていると思います。

対策として、プロジェクトのファイルパスを正規化してから比較するようにしたところ、問題が解決しました。