### PR TITLE
Fix the dependency is re-installed even though it is not needed

### DIFF
--- a/src/dependency_lockfile.rs
+++ b/src/dependency_lockfile.rs
@@ -178,6 +178,10 @@ impl DependecyLockFile {
                 repo.checkout_tree(&commit.into_object(), Some(&mut checkout_opts))
                     .map_err(|e| Errors::from_msg(format!("Failed to checkout commit: {:?}", e)))?;
 
+                // Set HEAD to the target revision.
+                repo.set_head_detached(target_rev)
+                    .map_err(|e| Errors::from_msg(format!("Failed to set head: {:?}", e)))?;
+
                 // Load the project file and validate whether it satisfies the dependency.
                 dep.check_name_version_match_proj_file()?;
 


### PR DESCRIPTION
# 概要

依存先プロジェクトの指定リビジョンが head と異なる場合、
`fix run`, `fix test` を実行するたびに依存先プロジェクトが再インストールされる問題がありました。

(つまり、`Dependency "xxxxx@x.x.x" installed successfully at ".fixlang/deps/xxxxx_x.x.x".`等が毎回表示されていました)

この pull request ではその問題の修正を試みます。

# 原因
- `DependencyLockFile::install()`では、最初に、依存先プロジェクトがインストール済みか以下のように確認している。
  - 依存先プロジェクトのディレクトリが存在すること
  - リポジトリの `head()` が指定リビジョンと一致すること
  - 依存先プロジェクトの `general.name`, `general.version` が期待通りであること
- 上記の条件を満たさない場合、依存先プロジェクトをインストールする。(つまり、ディレクトリを再作成してリポジトリをクローンし、指定リビジョンをチェックアウトする)
- しかし、`repo.checkout_tree()` では、作業ディレクトリのファイルは更新されるが、head は更新されない。(`.git/HEAD`ファイルが更新されない)

# 対策
- `repo.checkout_tree()` の後に `repo.set_head_detached()` を呼ぶようにした。

