### PR TITLE
Allows an extra comma in pattern_struct

### DIFF
--- a/src/grammer.pest
+++ b/src/grammer.pest
@@ -193,7 +193,7 @@ pattern_var = { name ~ (sep* ~ ":" ~ sep* ~ type_expr)? }
 
 pattern_tuple = { "(" ~ sep* ~ ")" | "(" ~ sep* ~ pattern_nounion ~ (sep* ~ "," ~ sep* ~ pattern_nounion)* ~ (sep* ~ ",")? ~ sep* ~ ")" }
 
-pattern_struct = { type_tycon ~ sep* ~ "{" ~ sep* ~ type_field_name ~ sep* ~ ":" ~ sep* ~ pattern_nounion ~ (sep* ~ "," ~ sep* ~ type_field_name ~ sep* ~ ":" ~ sep* ~ pattern_nounion)* ~ sep* ~ "}" }
+pattern_struct = { type_tycon ~ sep* ~ "{" ~ sep* ~ type_field_name ~ sep* ~ ":" ~ sep* ~ pattern_nounion ~ (sep* ~ "," ~ sep* ~ type_field_name ~ sep* ~ ":" ~ sep* ~ pattern_nounion)* ~ (sep* ~ ",")? ~ sep* ~ "}" }
 
 pattern_union = { (capital_name ~ "::")* ~ type_field_name ~ sep* ~ "(" ~ sep* ~ pattern_nounion? ~ sep* ~ ")" }
 

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5821,7 +5821,8 @@ pub fn test_extra_comma() {
 
     main : IO ();
     main = (
-        let _ = MyStruct0 { fst : 0, snd : false, };
+        let x = MyStruct0 { fst : 0, snd : false, };
+        let MyStruct0 { fst : fst_val, snd : snd_val , } = x;
 
         assert_eq(|_|"", [1, 2, 3,], [1, 2, 3]);;
         assert_eq(|_|"", [1, 2, 3, ], [1, 2, 3]);;


### PR DESCRIPTION
Struct の パターンマッチの際に余分なコンマがあるとシンタックスエラーになっていたため、
余分なコンマを許容するように変更しました。

Example:
```
module Main;
type S = unbox struct { a:I64, b:String };
main: IO () = (
    let s = S { a:42, b:"foo" };
    let S { a:a, b:b, } = s;      // ここでエラーになっていた
    pure()
);
```