### PR TITLE
Pin external-project tests to the released 1.5.0-compatible versions

### DIFF
--- a/src/tests/test_external_projects.rs
+++ b/src/tests/test_external_projects.rs
@@ -2,18 +2,17 @@ use std::{fs, path::PathBuf, process::Command};
 
 use crate::{constants::COMPILER_TEST_WORKING_PATH, env_vars, tests::test_util::fix_command};
 
-// Several projects are pinned to their `array-storage-migration` revision. The array/storage
-// redesign made `Array` unboxed and dropped its `Boxed` instance, so projects that used `Array`'s
-// FFI (`borrow_boxed` / `mutate_boxed` on an array), called `unsafe_is_unique` on their own unbox
-// structs, or used the removed unsafe primitives were migrated to the array-specific helpers on that
-// branch and are pinned to it here. Projects passing `None` build against their default branch.
+// Several projects had a breaking migration to the unboxed-Array API of Fix 1.5.0 — `Array` became
+// unboxed, lost its `Boxed` instance, and some unsafe primitives were removed. Each such project is
+// pinned to the first released version that carries the migration, so the test builds a fixed,
+// known-compatible release. Projects passing `None` build against their default branch.
 
 #[test]
 pub fn test_external_project_math() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-math.git",
         "fixlang-math",
-        Some("c25c6a34fe3405ad6db6c704765de02b9b11efe4"),
+        Some("2.0.0"),
     );
 }
 
@@ -49,7 +48,7 @@ pub fn test_external_project_time() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-time.git",
         "fixlang-time",
-        Some("776ded3f005be3102f898c5892873f41e085f0e2"),
+        Some("2.0.0"),
     );
 }
 
@@ -67,7 +66,7 @@ pub fn test_external_project_subprocess() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-subprocess.git",
         "fixlang-subprocess",
-        Some("f3bf2fe37c8c79547afea487be8822fef64f14b8"),
+        Some("2.0.0"),
     );
 }
 
@@ -89,7 +88,7 @@ pub fn test_external_project_asynctask() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-asynctask.git",
         "fixlang-asynctask",
-        Some("bd3fb3750e771ddf42aa37be722ab4ab5ba1092a"),
+        Some("2.0.0"),
     );
 }
 
@@ -98,7 +97,7 @@ pub fn test_external_project_gmp() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-gmp.git",
         "fixlang-gmp",
-        Some("002065bd9884066715f26858b79d787ef14cf380"),
+        Some("0.10.0"),
     );
 }
 
@@ -107,7 +106,7 @@ pub fn test_external_project_mpfr() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-mpfr.git",
         "fixlang-mpfr",
-        Some("9e833af4cb1a129423b56e259066d0c304021f36"),
+        Some("0.7.0"),
     );
 }
 
@@ -116,7 +115,7 @@ pub fn test_external_project_misc_algos() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-misc-algos.git",
         "fixlang-misc-algos",
-        Some("0ef6b5e75b78bc6c35392c48541a7d60edb73019"),
+        Some("0.12.0"),
     );
 }
 
@@ -138,7 +137,7 @@ pub fn test_external_project_cp_library() {
     test_external_project(
         "https://github.com/tttmmmyyyy/cp-library",
         "cp-library",
-        Some("f538b64ae07cb225fcf497ca783fb303b315508a"),
+        Some("0.13.0"),
     );
 }
 


### PR DESCRIPTION
## What

`src/tests/test_external_projects.rs` pinned eight projects to their
`array-storage-migration` **branch revisions** while the unboxed-Array migration
was unreleased. Those libraries are now released, so this moves each pin to its
release **tag**:

| project | tag |
| --- | --- |
| gmp | 0.10.0 |
| mpfr | 0.7.0 |
| math | 2.0.0 |
| misc-algos | 0.12.0 |
| subprocess | 2.0.0 |
| asynctask | 2.0.0 |
| time | 2.0.0 |
| cp-library | 0.13.0 |

The head comment is refreshed to match. Projects passing `None` (hashmap, hashset,
random, character, regexp, binary-heap) are unchanged.

## Verification

All eight pinned tests pass against the freshly-built compiler:
`test_external_project_cp_library` (100s, exercising cp-library's IO test that
shells out to `fix`) and the other seven run sequentially (81.79s).

Note: running the seven in parallel once hit a transient `git clone` failure that
surfaces as a confusing "Failed to run git checkout" — a pre-existing fragility
(`test_external_project` ignores the clone's exit status), independent of this
change. Left as a possible follow-up.

## Context

Part of the post-merge ecosystem finalization for the bce (unboxed-Array) work.
All nine libraries are released and tagged. Deferred: moving the `speedtest`
`cp_lib_*` cases from 0.7.4 to 0.13.0 (a benchmark rebaseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQdwsZDXAY6BkN7kerZ8Ft