### PR TITLE
Test external projects against their default branch

### DIFF
--- a/src/tests/test_external_projects.rs
+++ b/src/tests/test_external_projects.rs
@@ -2,18 +2,11 @@ use std::{fs, path::PathBuf, process::Command};
 
 use crate::{constants::COMPILER_TEST_WORKING_PATH, env_vars, tests::test_util::fix_command};
 
-// Several projects are pinned to their `array-storage-migration` revision. The array/storage
-// redesign made `Array` unboxed and dropped its `Boxed` instance, so projects that used `Array`'s
-// FFI (`borrow_boxed` / `mutate_boxed` on an array), called `unsafe_is_unique` on their own unbox
-// structs, or used the removed unsafe primitives were migrated to the array-specific helpers on that
-// branch and are pinned to it here. Projects passing `None` build against their default branch.
-
 #[test]
 pub fn test_external_project_math() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-math.git",
         "fixlang-math",
-        Some("c25c6a34fe3405ad6db6c704765de02b9b11efe4"),
     );
 }
 
@@ -22,7 +15,6 @@ pub fn test_external_project_hashmap() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-hashmap.git",
         "fixlang-hashmap",
-        None,
     );
 }
 
@@ -31,7 +23,6 @@ pub fn test_external_project_hashset() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-hashset.git",
         "fixlang-hashset",
-        None,
     );
 }
 
@@ -40,7 +31,6 @@ pub fn test_external_project_random() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-random.git",
         "fixlang-random",
-        None,
     );
 }
 
@@ -49,7 +39,6 @@ pub fn test_external_project_time() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-time.git",
         "fixlang-time",
-        Some("776ded3f005be3102f898c5892873f41e085f0e2"),
     );
 }
 
@@ -58,7 +47,6 @@ pub fn test_external_project_character() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-character.git",
         "fixlang-character",
-        None,
     );
 }
 
@@ -67,7 +55,6 @@ pub fn test_external_project_subprocess() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-subprocess.git",
         "fixlang-subprocess",
-        Some("f3bf2fe37c8c79547afea487be8822fef64f14b8"),
     );
 }
 
@@ -76,7 +63,6 @@ pub fn test_external_project_regexp() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-regexp.git",
         "fixlang-regexp",
-        None,
     );
 }
 
@@ -89,7 +75,6 @@ pub fn test_external_project_asynctask() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-asynctask.git",
         "fixlang-asynctask",
-        Some("bd3fb3750e771ddf42aa37be722ab4ab5ba1092a"),
     );
 }
 
@@ -98,7 +83,6 @@ pub fn test_external_project_gmp() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-gmp.git",
         "fixlang-gmp",
-        Some("002065bd9884066715f26858b79d787ef14cf380"),
     );
 }
 
@@ -107,7 +91,6 @@ pub fn test_external_project_mpfr() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-mpfr.git",
         "fixlang-mpfr",
-        Some("9e833af4cb1a129423b56e259066d0c304021f36"),
     );
 }
 
@@ -116,7 +99,6 @@ pub fn test_external_project_misc_algos() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-misc-algos.git",
         "fixlang-misc-algos",
-        Some("0ef6b5e75b78bc6c35392c48541a7d60edb73019"),
     );
 }
 
@@ -125,7 +107,6 @@ pub fn test_external_project_binary_heap() {
     test_external_project(
         "https://github.com/tttmmmyyyy/fixlang-binary-heap.git",
         "fixlang-binary-heap",
-        None,
     );
 }
 
@@ -135,15 +116,11 @@ pub fn test_external_project_cp_library() {
         // Skip this test when the optimization level is low since it takes too long time.
         return;
     }
-    test_external_project(
-        "https://github.com/tttmmmyyyy/cp-library",
-        "cp-library",
-        Some("f538b64ae07cb225fcf497ca783fb303b315508a"),
-    );
+    test_external_project("https://github.com/tttmmmyyyy/cp-library", "cp-library");
 }
 
-/// Clone `url`, check out `git_ref` (the default branch when `None`), and run `fix test`.
-pub fn test_external_project(url: &str, test_name: &str, git_ref: Option<&str>) {
+/// Clone `url` and run `fix test` in the cloned project's default branch.
+pub fn test_external_project(url: &str, test_name: &str) {
     println!("Testing external project: {}", url);
 
     // Recreate working directory for this test.
@@ -167,23 +144,6 @@ pub fn test_external_project(url: &str, test_name: &str, git_ref: Option<&str>) 
         .to_string()
         .replace(".git", "");
     let repo_dir = work_dir.join(dir_name);
-
-    // Check out the requested revision.
-    if let Some(git_ref) = git_ref {
-        let output = Command::new("git")
-            .arg("checkout")
-            .arg(git_ref)
-            .current_dir(&repo_dir)
-            .output()
-            .expect("Failed to run git checkout.");
-        assert!(
-            output.status.success(),
-            "Failed to check out \"{}\" of \"{}\":\n{}",
-            git_ref,
-            url,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
 
     // Run `fix test`. `--allow-preliminary-commands` is supplied because this test is
     // non-interactive and some external projects legitimately ship `preliminary_commands`


### PR DESCRIPTION
## What

`src/tests/test_external_projects.rs` pinned eight projects to their
`array-storage-migration` branch revisions while the unboxed-Array migration was
unreleased. The migration is now released, so this drops the pinning entirely:
the `git_ref` parameter and its checkout are removed, and every project is
cloned and tested at its **default branch**, with no version requirement (the
same way the never-pinned projects were already tested).

Net effect from `main`: 3 insertions, 43 deletions.

## Verification

`test_external_project_cp_library` (exercises cp-library's IO test that shells
out to `fix`), `test_external_project_gmp`, and `test_external_project_misc_algos`
(pulls `math` transitively) pass against their default branches (run
sequentially; the tests can flake on a transient parallel `git clone`).

## Context

Part of the post-merge ecosystem finalization for the bce (unboxed-Array) work;
all nine libraries are released. This supersedes #81 (which pinned to release
tags). Deferred: moving the `speedtest` `cp_lib_*` cases off 0.7.4 (a benchmark
rebaseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQdwsZDXAY6BkN7kerZ8Ft