### PR TITLE
Match lldb's array-element format in the array-elements debug test

### DIFF
--- a/src/tests/test_debug_info.rs
+++ b/src/tests/test_debug_info.rs
@@ -446,14 +446,15 @@ mod debug_info_tests {
                 );
             }
             Debugger::Lldb => {
+                // lldb lists array elements as `[i] = value`, one per line, so match a few by index.
                 assert_contains(&out, "<array size> = 3", "3-element array size");
-                assert_contains(&out, "10, 20, 30", "3-element array valid elements");
+                for elem in ["[0] = 10", "[1] = 20", "[2] = 30"] {
+                    assert_contains(&out, elem, "3-element array valid elements");
+                }
                 assert_contains(&out, "<array size> = 150", "150-element array size");
-                assert_contains(
-                    &out,
-                    "980, 990, 1000",
-                    "150-element array up to its 100th element",
-                );
+                for elem in ["[97] = 980", "[98] = 990", "[99] = 1000"] {
+                    assert_contains(&out, elem, "150-element array up to its 100th element");
+                }
                 assert_contains(&out, "hello", "string bytes");
             }
         }


### PR DESCRIPTION
Follow-up to #86. On that PR's CI run, all six jobs passed 988 tests with a single failure: `test_debug_info_array_elements_lldb`. Everything else the PR set out to fix is confirmed working — macOS `-O none`/`-O basic` now run the whole suite to completion (the GlobalISel SIGBUS is gone), the external-project tests skip at `-O none`, and the other three lldb debug-info tests pass on both Linux and macOS.

The one miss was the array-elements assertions for lldb, which were calibrated blind (lldb cannot launch a process in the dev environment). lldb does not print gdb's comma-separated element list (`980, 990, 1000`); it lists elements as `[i] = value`, one per line. The 3-element check also only passed by coincidence, matching the `[10, 20, 30]` source line echoed at the breakpoint rather than the array display. This asserts the lldb `[i] = value` form instead — `[0] = 10`..`[2] = 30` for the 3-element array and `[97] = 980`..`[99] = 1000` (the 100th displayed element) for the 150-element array — taken from the actual lldb output in the #86 CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)