### PR TITLE
Add Debug::assert_unique_array for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `Array::swap` and `Array::unsafe_swap_bounds_unchecked`, which swap the two elements of an array at given indices. `swap` bounds-checks the indices; `unsafe_swap_bounds_unchecked` omits that check (the caller must ensure the indices are in range).
 - Added `Array::unsafe_set_bounds_unchecked`, which sets the element at a given index like `set` but omits the bounds check (the caller must ensure the index is in range). It is the counterpart of `unsafe_swap_bounds_unchecked`, for in-place write loops whose indices are already known to be in range.
 - Added `Array::borrow_elements` and `Array::mutate_elements` (with `_io` variants), which call a function with a pointer to the first element of an array's element buffer. `borrow_elements` borrows the array for read-only access; `mutate_elements` clones the array first if it is shared, for in-place writes. Use these for FFI that needs a raw pointer to an array's elements.
+- Added `Debug::assert_unique_array`, the `Array` counterpart of `Debug::assert_unique`: it asserts that an array's storage buffer is uniquely referenced (not shared), returns the array, and aborts otherwise. Use it for arrays, whose value holds the reference count in the storage buffer; `assert_unique` covers `Boxed` values.
 
 ### Changed
 

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -4137,6 +4137,26 @@ namespace Debug {
         x
     );
 
+    // Asserts that the storage buffer of the given array is uniquely referenced (not shared),
+    // and returns the array. If the assertion failed, prints a message to the stderr and aborts
+    // the program.
+    //
+    // Use this for an `Array`, whose value holds the reference count in its storage buffer;
+    // `assert_unique` requires `Boxed` and so covers boxed values instead.
+    //
+    // This function should be limited to temporary use for debugging purposes and should be removed from the final code.
+    //
+    // # Parameters
+    //
+    // * `lazy_msg`
+    // * `array`
+    assert_unique_array : Lazy String -> Array a -> Array a;
+    assert_unique_array = |msg, arr| (
+        let (unique, arr) = arr._unsafe_is_storage_unique;
+        if !unique { undefined("Array storage is not unique: " + msg()) };
+        arr
+    );
+
     // Get clocks (cpu time) elapsed while executing an I/O action.
     //
     // # Parameters

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -4121,6 +4121,8 @@ namespace Debug {
     // Asserts that the given boxed value is unique, and returns the given value.
     // If the assertion failed, prints a message to the stderr and aborts the program.
     //
+    // To assert the same for an `Array`, use `assert_unique_array`.
+    //
     // The `[a : Boxed]` constraint was added in Fix 1.5.0. Before 1.5.0 the constraint was absent
     // and this treated any unboxed value as unique, so it never aborted for an unboxed argument.
     //

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -3020,6 +3020,48 @@ pub fn test95() {
     test_source(&source, Configuration::develop_mode());
 }
 
+#[test]
+pub fn test_assert_unique_array() {
+    // A fresh array's storage is uniquely referenced, so `Debug::assert_unique_array` returns it and
+    // the following in-place writes see a unique array.
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr = Array::fill(4, 0);
+                let arr = arr.assert_unique_array(|_| "should be unique").set(0, 10);
+                let arr = arr.assert_unique_array(|_| "should be unique").set(1, 20);
+                assert_eq(|_| "sum", arr.to_iter.sum, 30);;
+                pure()
+            );
+        "#;
+    test_source(&source, Configuration::develop_mode());
+}
+
+#[test]
+pub fn test_assert_unique_array_aborts_when_shared() {
+    // Another live binding keeps a reference to the same storage, so `Debug::assert_unique_array`
+    // finds the array shared and aborts with its message.
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr = Array::fill(4, 7);
+                let shared = arr;
+                let arr = arr.assert_unique_array(|_| "arr must be unique");
+                assert_eq(|_| "unreachable", arr.@(0) + shared.@(0), 14);;
+                pure()
+            );
+        "#;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Array storage is not unique",
+    );
+}
+
 /// Verifies that a write in the `true` branch of an `unsafe_is_unique` still clones when the value
 /// is shared between the check and the branch.
 ///


### PR DESCRIPTION
## What

Adds `Debug::assert_unique_array : Lazy String -> Array a -> Array a` to the standard library. It asserts that an array's storage buffer is uniquely referenced (not shared) and returns the array, aborting with the given message otherwise. It is implemented on top of the existing `Array::_unsafe_is_storage_unique` builtin.

## Why

After the array/storage flip, an `Array` is no longer `Boxed`, and `Debug::assert_unique` now carries an `[a : Boxed]` constraint — so it no longer accepts an array. Code that used `assert_unique` to check that an array mutates in place (rather than copying) lost that capability. `Debug::assert_unique_array` restores it for arrays, mirroring `Debug::assert_unique` for `Boxed` values.

This is also a prerequisite for migrating `fixlang_minilib` (whose `ioref` tests assert array uniqueness) to compile against the post-flip standard library.

## Tests

- `test_assert_unique_array` — a fresh (unique) array passes and the following in-place writes see a unique array.
- `test_assert_unique_array_aborts_when_shared` — a second live binding shares the storage, so the assertion aborts with its message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQdwsZDXAY6BkN7kerZ8Ft