### PR TITLE
Fix -O max uninitialised-value read from small-variant union payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 #### Tool
 
+- Programs compiled with `-O max` or `-O experimental` no longer read an uninitialised value while running certain iterator pipelines, such as a nested `flat_map` folded into an array. The computed result was already correct, but the read was undefined behavior (reported by valgrind).
 - Building with debug information (`-g`) no longer crashes on a program that uses a recursive type, such as `type Tree = box union { leaf : (), node : (Tree, Tree) };`.
 - Debug information (`-g`) records every `Array` as having 100 elements, since the actual element count is only determined at run time. The byte sizes recorded for the array debug types covered only a single element, contradicting that element count: gdb refused to display the elements with an "access outside bounds of object" error, and recent lldb displayed wrong values for all elements after the first. The byte sizes now cover the 100 elements, so debuggers display them, the first `<array size>` of which are the valid values. This also applies to the byte array inside a `String`.
 - A source file listed in `fixproj.toml` that does not exist on disk now produces a clear error that points at the offending entry in the project file (e.g. `files = ["test.fix"]`), instead of an opaque, location-less "Failed to canonicalize path" message.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2115,6 +2115,16 @@ impl<'c, 'm> Generator<'c, 'm> {
         let (from_bits, to_bits) = (self.sizeof(&from_ty), self.sizeof(&to_ty));
         let larger_ty = if from_bits > to_bits { from_ty } else { to_ty };
         let ptr = self.build_alloca_at_entry(larger_ty, "alloca@bit_cast");
+        if to_bits > from_bits {
+            // `to_ty` is wider than `val`, so loading it back reads bytes `val` never wrote. Zero the
+            // buffer first, leaving those bytes defined (zero) rather than undef. Reinterpreting a
+            // union's payload into its buffer takes this path when the variant is smaller than the
+            // buffer; the buffer later crosses a function boundary as scalar leaves, so an undef byte
+            // there would be a read of an uninitialised value.
+            self.builder()
+                .build_store(ptr, larger_ty.const_zero())
+                .unwrap();
+        }
         self.builder().build_store(ptr, val).unwrap();
         self.builder().build_load(to_ty, ptr, "bit_cast").unwrap()
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod test_specialize_uninit_repro;
 mod test_abs_path_dep_hash;
 mod test_array_bounds_check;
 mod test_array_builder;

--- a/src/tests/test_specialize_uninit_repro.rs
+++ b/src/tests/test_specialize_uninit_repro.rs
@@ -1,11 +1,12 @@
 use crate::{configuration::Configuration, tests::test_util::test_source};
 
-// A fold over a nested `flat_map` iterator into a growing array reads an uninitialised stack value
-// at `-O max` / `experimental`. The `specialize` pass clones the fold on input uniqueness and the
-// specialized clone leaves the value undef in a `MapIterator::advance`, so valgrind reports a
-// "Conditional jump or move depends on uninitialised value(s)". The computed result is correct, so
-// this is a memory-safety (undefined-behavior) defect rather than a miscompilation. Runs under
-// `develop_mode`'s memcheck; it fails until the `specialize` pass no longer emits the undef.
+// Constructing a union whose active variant is smaller than the union's payload buffer must leave no
+// uninitialised bytes in the buffer. A nested `flat_map` folded into a growing array builds such
+// unions and passes them across a function boundary as scalar leaves; at `-O max` / `experimental`
+// the consumer (`Iterator::advance`) speculatively reads the payload before checking its tag, so an
+// undef tail byte surfaces as a valgrind "Conditional jump or move depends on uninitialised
+// value(s)". The computed result is correct either way, so this guards against a memory-safety
+// (undefined-behavior) regression rather than a miscompilation. Runs under `develop_mode`'s memcheck.
 #[test]
 pub fn test_specialize_nested_flat_map_uninitialised_value() {
     let source = r#"

--- a/src/tests/test_specialize_uninit_repro.rs
+++ b/src/tests/test_specialize_uninit_repro.rs
@@ -1,0 +1,29 @@
+use crate::{configuration::Configuration, tests::test_util::test_source};
+
+// A fold over a nested `flat_map` iterator into a growing array reads an uninitialised stack value
+// at `-O max` / `experimental`. The `specialize` pass clones the fold on input uniqueness and the
+// specialized clone leaves the value undef in a `MapIterator::advance`, so valgrind reports a
+// "Conditional jump or move depends on uninitialised value(s)". The computed result is correct, so
+// this is a memory-safety (undefined-behavior) defect rather than a miscompilation. Runs under
+// `develop_mode`'s memcheck; it fails until the `specialize` pass no longer emits the undef.
+#[test]
+pub fn test_specialize_nested_flat_map_uninitialised_value() {
+    let source = r#"
+        module Main;
+
+        main : IO ();
+        main = (
+            let table : Array (Array I64) = Iterator::range(0, 8).map(|i|
+                Iterator::range(0, i).to_array
+            ).to_array;
+            let flattened = Iterator::range(0, table.@size).flat_map(|ti|
+                Iterator::range(0, table.@(ti).@size).flat_map(|bi|
+                    Iterator::range(0, table.@(ti).@(bi) + 1)
+                )
+            ).fold(Array::empty(0), |x, acc| acc.push_back(x));
+            assert_eq(|_| "flattened size", flattened.@size, 84);;
+            pure()
+        );
+    "#;
+    test_source(&source, Configuration::develop_mode());
+}

--- a/std_doc/Std.md
+++ b/std_doc/Std.md
@@ -775,6 +775,8 @@ Type: `[a : Std::Boxed] Std::Lazy Std::String -> a -> a`
 Asserts that the given boxed value is unique, and returns the given value.
 If the assertion failed, prints a message to the stderr and aborts the program.
 
+To assert the same for an `Array`, use `assert_unique_array`.
+
 The `[a : Boxed]` constraint was added in Fix 1.5.0. Before 1.5.0 the constraint was absent
 and this treated any unboxed value as unique, so it never aborted for an unboxed argument.
 
@@ -784,6 +786,24 @@ This function should be limited to temporary use for debugging purposes and shou
 
 * `lazy_msg`
 * `value`
+
+#### assert_unique_array
+
+Type: `Std::Lazy Std::String -> Std::Array a -> Std::Array a`
+
+Asserts that the storage buffer of the given array is uniquely referenced (not shared),
+and returns the array. If the assertion failed, prints a message to the stderr and aborts
+the program.
+
+Use this for an `Array`, whose value holds the reference count in its storage buffer;
+`assert_unique` requires `Boxed` and so covers boxed values instead.
+
+This function should be limited to temporary use for debugging purposes and should be removed from the final code.
+
+##### Parameters
+
+* `lazy_msg`
+* `array`
 
 #### consumed_time_while_io
 


### PR DESCRIPTION
## What

Fixes the uninitialised-value read that `-O max` / `-O experimental` produced on certain iterator pipelines (a nested `flat_map` folded into a growing array), reported by valgrind as "Conditional jump or move depends on uninitialised value(s)" inside `Iterator::advance`. The computed result was already correct; the read was undefined behavior.

Closes #92.

## Root cause

`Generator::bit_cast` reinterprets a value by storing it into an alloca of the larger of the two types and loading the target type back. When widening (target wider than the value), the loaded bytes past the value were never written — undef. Constructing a union whose active variant is smaller than its payload buffer takes this path (via `set_union_value`), leaving the buffer's tail undef. That undef crosses a function boundary as scalar leaves, and at `-O max` the consumer speculatively reads the payload before checking the tag it belongs to, so the undef reaches a conditional branch.

The `specialize` pass named in the issue is only the trigger — it enables the `-O max` optimization that speculates the read. The undef itself is created at union construction, at every optimization level; the lower levels just never speculate the read.

## Fix

Zero the buffer before storing the value when the bit-cast widens, so the bytes past the value are defined. `bit_cast`'s only two callers both convert a union's payload, and only the variant-into-buffer direction widens, so this affects union construction alone.

## Verification

- valgrind memcheck on the minimal reproduction: clean at `-O none` / `-O basic` / `-O max` / `-O experimental` (was 2 errors at max/experimental); the result is unchanged.
- The repository's memcheck harness: the previously-red `test_specialize_nested_flat_map_uninitialised_value` now passes, and the full suite is 994 passed / 0 failed at `-O experimental` (which runs memcheck on Linux).

## Performance

cachegrind I refs at `-O max`, before vs after: `binary_trees` +0.27% (it builds ~1M empty-variant `leaf()` unions, each now zeroing its 16-byte payload buffer); `option_plumbing`, `sum_by_range_fold`, `write_by_range_fold` unchanged. The cost is bounded to zeroing the unused tail of a small-variant union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
