### PR TITLE
Suppress the benign Iterator::advance union-padding read under memcheck

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -46,3 +46,4 @@ mod test_union_catchall_match;
 mod test_union_layout;
 mod test_union_match;
 mod test_util;
+mod test_valgrind_suppression;

--- a/src/tests/test_valgrind_suppression.rs
+++ b/src/tests/test_valgrind_suppression.rs
@@ -1,0 +1,32 @@
+use crate::{configuration::Configuration, tests::test_util::test_source};
+
+// The `fix-iterator-advance-uninitialised-union-padding` entry in the repo-root `valgrind.supp`
+// silences a benign uninitialised-value read. At `-O max` / `-O experimental` an iterator whose
+// state holds a union (here a nested `flat_map`) is passed to `Iterator::advance` by value; the
+// unused tail of a small variant's payload buffer is uninitialised, and LLVM speculatively reads it
+// above the tag check. The `freeze` LLVM inserts makes the branch well-defined and the result
+// correct, so the read is benign — valgrind reports it only because `freeze` lowers to reading that
+// uninitialised stack slot. This runs the program under `develop_mode`'s memcheck, which loads that
+// `valgrind.supp` (the test process runs from the repo root), and asserts it stays clean — so a
+// change to `advance`'s mangled name that stops the suppression matching is caught here.
+#[test]
+pub fn test_iterator_advance_union_padding_suppressed() {
+    let source = r#"
+        module Main;
+
+        main : IO ();
+        main = (
+            let table : Array (Array I64) = Iterator::range(0, 8).map(|i|
+                Iterator::range(0, i).to_array
+            ).to_array;
+            let flattened = Iterator::range(0, table.@size).flat_map(|ti|
+                Iterator::range(0, table.@(ti).@size).flat_map(|bi|
+                    Iterator::range(0, table.@(ti).@(bi) + 1)
+                )
+            ).fold(Array::empty(0), |x, acc| acc.push_back(x));
+            assert_eq(|_| "flattened size", flattened.@size, 84);;
+            pure()
+        );
+    "#;
+    test_source(&source, Configuration::develop_mode());
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -7,3 +7,22 @@
    fun:_IO_file_xsputn@@GLIBC_2.2.5
    fun:fputs
 }
+
+# Iterator::advance reads uninitialised union padding speculatively at -O max /
+# -O experimental. An iterator whose state holds a union (such as a nested
+# flat_map's inner iterator) is passed to `advance` by value; when the active
+# variant is smaller than the union's payload buffer, the unused tail of the
+# buffer is uninitialised — Fix leaves union padding uninitialised, as C and Rust
+# do. LLVM hoists the payload read above the tag check and inserts a `freeze`, so
+# the branch is well-defined and the computed result is correct; valgrind still
+# reports it because `freeze` lowers to reading that uninitialised stack slot, so
+# the read is benign. (This also hides a genuine uninitialised read that lands in
+# an `advance` funptr, so drop it when auditing the iterator runtime itself.)
+#
+# Copy this entry into the `valgrind.supp` at the root of any project you check
+# under memcheck; fix auto-loads that file (see `Configuration::valgrind_command`).
+{
+   fix-iterator-advance-uninitialised-union-padding
+   Memcheck:Cond
+   fun:Std::Iterator::advance#*
+}


### PR DESCRIPTION
## What

Adds a valgrind suppression for a benign uninitialised-value read that memcheck reports on optimised Fix programs, so it stops cluttering memcheck sweeps (e.g. minilib).

## Background

At `-O max` / `-O experimental`, an iterator whose state holds a union (such as a nested `flat_map`'s inner iterator) is passed to `Iterator::advance` by value. When the active variant is smaller than the union's payload buffer, the unused tail of the buffer is uninitialised — Fix leaves union padding uninitialised, as C and Rust do. LLVM hoists the payload read above the tag check and inserts a `freeze`, so the branch is well-defined and the computed result is correct; valgrind still reports "Conditional jump or move depends on uninitialised value(s)" because `freeze` lowers to reading that uninitialised stack slot. The read is benign (see #92, closed as not-a-bug).

## Change

- Add an entry to the repo-root `valgrind.supp`, which `fix` auto-loads under memcheck (see `Configuration::valgrind_command`). Copy this entry into the `valgrind.supp` at the root of any project you check under memcheck.
- Add a test that runs a nested-`flat_map` program under `develop_mode`'s memcheck and asserts it stays clean, so a change to `advance`'s mangled name that stops the suppression matching is caught (verified: the test fails when the entry is removed).

## Scope note

The suppression is narrow (`Memcheck:Cond` in `Std::Iterator::advance#*`). It also hides a genuine uninitialised read that happens to land in an `advance` funptr, so the comment says to drop it when auditing the iterator runtime itself. The memcheck detection tests (`test_use_undefined_value`) still pass — the suppression does not mask real uninitialised-value errors elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
