### PR TITLE
Document the array element pointer and fix the retained-pointer example

### DIFF
--- a/Document-ja.md
+++ b/Document-ja.md
@@ -77,6 +77,7 @@
         - [Fixで外部リソースを管理する](#fixで外部リソースを管理する)
         - [外部言語でFixのボックス型の値を管理する](#外部言語でfixのボックス型の値を管理する)
         - [CからFixの構造体値のフィールドにアクセスする](#cからfixの構造体値のフィールドにアクセスする)
+        - [CからFixの配列の要素にアクセスする](#cからfixの配列の要素にアクセスする)
     - [`eval`構文](#eval構文)
     - [身代わりパターン](#身代わりパターン)
     - [演算子と構文の優先度](#演算子と構文の優先度)
@@ -2361,18 +2362,20 @@ Fixコンパイラは、`Destructor a`をヒープメモリから解放する際
 そして、渡されたポインタに`boxed_from_retained_ptr`を適用し、得た値を使って何らかの処理をするようなFixの関数を外部言語にエクスポートすることで、
 外部言語からFixの値を利用することができるようになります。
 
+`Array`はアンボックス型なので、配列をretainedポインタとして渡すには、`Std::Box`のようなボックス構造体に包みます。
+
 ```
 create_fix_array : IO Ptr;
 create_fix_array = (
-    let arr = [1,2,3,4,5];
+    let arr = Box::make([1,2,3,4,5]);
     arr.boxed_to_retained_ptr
 );
 FFI_EXPORT[create_fix_array, create_fix_array]; // void* create_fix_array(void); がC言語から呼び出せるようになります。
 
 get_fix_array_element : Ptr -> I64 -> IO I64;
 get_fix_array_element = |ptr, idx| (
-    let arr : Array I64 = *boxed_from_retained_ptr(ptr);
-    pure $ arr.@(idx)
+    let arr : Box (Array I64) = *boxed_from_retained_ptr(ptr);
+    pure $ arr.@value.@(idx)
 );
 FFI_EXPORT[get_fix_array_element, get_fix_array_element]; // int64_t get_fix_array_element(void* ptr, int64_t idx); がC言語から呼び出せるようになります。
 ```
@@ -2455,6 +2458,38 @@ Fixのオブジェクト`vec`のフィールド`x`および`y`にC側からア�
 注意：
 少なくとも現在のFixのバージョンでは、Fixの構造体のメモリレイアウトはLLVMのデフォルトの動作によって決定されており、私の知る限りではCの構造体のメモリレイアウトと同等です。
 将来のバージョンでは状況が変わる可能性があります。プログラマーがレイアウトがCと同等であることを保証するための指定子（仮に`expr_c`と記述されるとします）を導入し、`expr_c`指定子のない構造体レイアウトは最適化される（例：フィールド順序の再配置）可能性があります。
+
+### CからFixの配列の要素にアクセスする
+
+配列は要素をヒープ上のバッファに保持しており、以下の関数がそのバッファの先頭要素へのポインタをコールバックに渡します。
+
+- `Std::Array::borrow_elements : (Ptr -> b) -> Array a -> b`は、配列を読み取り専用で借用します。
+- `Std::Array::mutate_elements : (Ptr -> IO b) -> Array a -> (Array a, b)`は、配列が共有されていれば先に複製するので、コールバックはポインタを通じて書き込めます。変更後の配列とコールバックの結果の組を返します。
+- `Std::Array::mutate_elements_io`は、既に`IO`コンテキストにいる場合に使う版です。
+
+ポインタが有効なのはコールバックの実行中だけなので、保存してはいけません。
+
+```
+// C言語の`memset`を使って、バイト配列の要素を`c`で埋めます。
+fill_bytes : U8 -> Array U8 -> Array U8;
+fill_bytes = |c, arr| (
+    let n = arr.@size.c_size_t;
+    let (arr, _) = arr.mutate_elements(|p|
+        pure $ FFI_CALL[Ptr memset(Ptr, CInt, CSizeT), p, c.c_int, n]
+    );
+    arr
+);
+
+// C言語の`memchr`を読み取り専用の借用に対して使い、バイト配列が`c`を含むかを判定します。
+contains_byte : U8 -> Array U8 -> Bool;
+contains_byte = |c, arr| (
+    let n = arr.@size.c_size_t;
+    let found = arr.borrow_elements(|p|
+        FFI_CALL[Ptr memchr(Ptr, CInt, CSizeT), p, c.c_int, n]
+    );
+    found != nullptr
+);
+```
 
 ## `eval`構文
 

--- a/Document.md
+++ b/Document.md
@@ -77,6 +77,7 @@
         - [Managing External Resources in Fix](#managing-external-resources-in-fix)
         - [Managing ownership of Fix's boxed value in a foreign language](#managing-ownership-of-fixs-boxed-value-in-a-foreign-language)
         - [Accessing fields of Fix's struct value from C](#accessing-fields-of-fixs-struct-value-from-c)
+        - [Accessing elements of Fix's array from C](#accessing-elements-of-fixs-array-from-c)
     - [`eval` syntax](#eval-syntax)
     - [Substitute Pattern](#substitute-pattern)
     - [Operator and Syntax Precedence](#operator-and-syntax-precedence)
@@ -2248,18 +2249,20 @@ By converting a boxed type value to a pointer, you can pass Fix values to a fore
 Then, by exporting a Fix function that applies `boxed_from_retained_ptr` to the passed pointer and uses the resulting value to perform some processing,
 you can enable the foreign language to use Fix values.
 
+`Array` is an unboxed type, so wrap an array in a boxed struct such as `Std::Box` to hand it over as a retained pointer.
+
 ```
 create_fix_array : IO Ptr;
 create_fix_array = (
-    let arr = [1,2,3,4,5];
+    let arr = Box::make([1,2,3,4,5]);
     arr.boxed_to_retained_ptr
 );
 FFI_EXPORT[create_fix_array, create_fix_array]; // void* create_fix_array(void); can be called from C.
 
 get_fix_array_element : Ptr -> I64 -> IO I64;
 get_fix_array_element = |ptr, idx| (
-    let arr : Array I64 = *boxed_from_retained_ptr(ptr);
-    pure $ arr.@(idx)
+    let arr : Box (Array I64) = *boxed_from_retained_ptr(ptr);
+    pure $ arr.@value.@(idx)
 );
 FFI_EXPORT[get_fix_array_element, get_fix_array_element]; // int64_t get_fix_array_element(void* ptr, int64_t idx); can be called from C.
 ```
@@ -2342,6 +2345,38 @@ If you want to access to the fields `x` and `y` of Fix's object `vec` from C sid
 NOTE: 
 At least in the current version of Fix, the memory layout of Fix's struct is determined by the default behaviour of LLVM, and as long as I know it is equivalent to C's struct memory layout. 
 In a future version, the situation may be changed. I may introduce a specifier (suppose it is written as `expr_c`) for a programmer to assure that the layout is equivalent to C, and the struct layout with no `expr_c` specifier may be optimized (e.g., reorder field ordering).
+
+### Accessing elements of Fix's array from C
+
+An array keeps its elements in a heap buffer, and the following functions hand a pointer to the first element of that buffer to a callback.
+
+- `Std::Array::borrow_elements : (Ptr -> b) -> Array a -> b` borrows the array for read-only access.
+- `Std::Array::mutate_elements : (Ptr -> IO b) -> Array a -> (Array a, b)` clones the array first if it is shared, so the callback may write through the pointer. It returns the mutated array paired with the callback's result.
+- `Std::Array::mutate_elements_io` is the variant to use when you are already in an `IO` context.
+
+The pointer is valid only while the callback runs, so do not store it.
+
+```
+// Overwrite the elements of a byte array with `c`, using C's `memset`.
+fill_bytes : U8 -> Array U8 -> Array U8;
+fill_bytes = |c, arr| (
+    let n = arr.@size.c_size_t;
+    let (arr, _) = arr.mutate_elements(|p|
+        pure $ FFI_CALL[Ptr memset(Ptr, CInt, CSizeT), p, c.c_int, n]
+    );
+    arr
+);
+
+// Tell whether a byte array contains `c`, using C's `memchr` on a read-only borrow.
+contains_byte : U8 -> Array U8 -> Bool;
+contains_byte = |c, arr| (
+    let n = arr.@size.c_size_t;
+    let found = arr.borrow_elements(|p|
+        FFI_CALL[Ptr memchr(Ptr, CInt, CSizeT), p, c.c_int, n]
+    );
+    found != nullptr
+);
+```
 
 ## `eval` syntax
 


### PR DESCRIPTION
`Array` is an unboxed type, so `boxed_to_retained_ptr` does not accept an array. The manual's example still handed `[1,2,3,4,5]` to it, so the code a reader copies out of the FFI section does not compile. It now wraps the array in `Std::Box`.

The manual also never mentioned how to get a pointer to an array's elements. Added a section for `Array::borrow_elements` / `mutate_elements` / `mutate_elements_io`, with a `memset` / `memchr` example.

Both snippets were compiled and run against this branch's compiler before being pasted in.

Same changes in `Document.md` and `Document-ja.md`, table of contents included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQdwsZDXAY6BkN7kerZ8Ft
