### PR TITLE
test: pin defunctionalize_fix invariants found during a bug hunt

### DIFF
--- a/src/tests/test_defunctionalize_fix.rs
+++ b/src/tests/test_defunctionalize_fix.rs
@@ -327,3 +327,292 @@ fn test_fix_captures_from_nontrivial_binders_compute_correctly() {
     "#;
     test_source(source, Configuration::develop_mode());
 }
+
+// A cycle of six globals that fix each other round-robin. Each lifted function is deduplicated per
+// global, so the `run` fixpoint terminates instead of lifting without end. Each hop adds one, so
+// `fix(g0)(20)` counts down to 0 and yields 20, which also checks the rewrite preserves the value.
+#[test]
+fn test_mutual_global_fix_cycle_terminates() {
+    let source = r#"
+    module Main;
+
+    g0 : (I64 -> I64) -> I64 -> I64;
+    g0 = |self, x| if x <= 0 { 0 } else { 1 + fix(g1)(x - 1) };
+    g1 : (I64 -> I64) -> I64 -> I64;
+    g1 = |self, x| if x <= 0 { 0 } else { 1 + fix(g2)(x - 1) };
+    g2 : (I64 -> I64) -> I64 -> I64;
+    g2 = |self, x| if x <= 0 { 0 } else { 1 + fix(g3)(x - 1) };
+    g3 : (I64 -> I64) -> I64 -> I64;
+    g3 = |self, x| if x <= 0 { 0 } else { 1 + fix(g4)(x - 1) };
+    g4 : (I64 -> I64) -> I64 -> I64;
+    g4 = |self, x| if x <= 0 { 0 } else { 1 + fix(g5)(x - 1) };
+    g5 : (I64 -> I64) -> I64 -> I64;
+    g5 = |self, x| if x <= 0 { 0 } else { 1 + fix(g0)(x - 1) };
+
+    cycle_res : I64;
+    cycle_res = fix(g0)(20);
+
+    main : IO ();
+    main = (
+        assert_eq(|_|"cycle web", cycle_res, 20);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}
+
+// A saturated tail self-call buried below a `let` chain inside a `match` arm still lowers to a direct
+// self-call, so it runs in constant stack.
+#[test]
+fn test_deep_tail_position_fix_runs_in_constant_stack() {
+    if should_skip_at_none() {
+        return;
+    }
+    let source = r#"
+    module Main;
+
+    count : I64 -> (I64, Array I64);
+    count = |n| (
+        let go = fix(|go, i, arr| (
+            if i >= n { (i, arr) };
+            let j = i + 1;
+            match Option::some(j) {
+                some(k) => (
+                    let m = k;
+                    go(m, arr)
+                ),
+                none() => (i, arr)
+            }
+        ));
+        go(0, Array::empty(0))
+    );
+
+    main : IO ();
+    main = (
+        let (last, arr) = count(1000000);
+        assert_eq(|_|"unexpected result", last + arr.@size, 1000000);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}
+
+// A `fix` whose recursion takes three arguments (four with the capture struct) lowers each self-call
+// to a direct call, so it runs in constant stack.
+#[test]
+fn test_three_arg_fix_runs_in_constant_stack() {
+    if should_skip_at_none() {
+        return;
+    }
+    let source = r#"
+    module Main;
+
+    count : I64 -> (I64, Array I64);
+    count = |n| (
+        let go = fix(|go, i, acc, arr| (
+            if i >= n { (acc, arr) };
+            go(i + 1, acc + 1, arr)
+        ));
+        go(0, 0, Array::empty(0))
+    );
+
+    main : IO ();
+    main = (
+        let (acc, arr) = count(1000000);
+        assert_eq(|_|"unexpected result", acc + arr.@size, 1000000);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}
+
+// Two nested `fix`es where the inner one carries the deep recursion. The outer entry folds into the
+// inner and the inner self-call stays direct, so it runs in constant stack.
+#[test]
+fn test_nested_fix_inner_deep_runs_in_constant_stack() {
+    if should_skip_at_none() {
+        return;
+    }
+    let source = r#"
+    module Main;
+
+    count : I64 -> (I64, Array I64);
+    count = |n| (
+        let outer = fix(|outer, seed| (
+            let inner = fix(|inner, i, arr| (
+                if i >= n { (i, arr) };
+                inner(i + 1, arr)
+            ));
+            inner(seed, Array::empty(0))
+        ));
+        outer(0)
+    );
+
+    main : IO ();
+    main = (
+        let (last, arr) = count(1000000);
+        assert_eq(|_|"unexpected result", last + arr.@size, 1000000);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}
+
+// Captures of exotic value types, an empty capture, `self` used both as a tail self-call and as a
+// bare value, a polymorphic `fix` instantiated at two types, and a `fix` inside an iterator fold.
+// Each must compute the same value the closure form does. It runs at every optimization level.
+#[test]
+fn test_fix_exotic_captures_and_dual_use_self_compute_correctly() {
+    let source = r#"
+    module Main;
+
+    type Cfg = unbox struct { base : I64, step : I64 };
+    type Choice = union { add : I64, mul : I64 };
+
+    applyit : (I64 -> I64) -> I64 -> I64;
+    applyit = |h, x| h(x);
+
+    empty_cap : I64;
+    empty_cap = (fix(|self, x| if x <= 0 { 7 } else { self(x - 1) + 1 }))(5);
+
+    dual_self : I64 -> I64;
+    dual_self = |n| (
+        (fix(|self, x|
+            if x <= 0 { 0 };
+            if x % 2 == 0 { self(x - 1) } else { applyit(self, x - 1) + 1 }
+        ))(n)
+    );
+
+    cap_fun : (I64 -> I64) -> I64 -> I64;
+    cap_fun = |transform, n| (
+        (fix(|self, x, acc| if x <= 0 { acc } else { self(x - 1, acc + transform(x)) }))(n, 0)
+    );
+
+    cap_struct : Cfg -> I64 -> I64;
+    cap_struct = |cfg, n| (
+        (fix(|self, x, acc| if x <= 0 { acc } else { self(x - 1, acc + cfg.@base + x * cfg.@step) }))(n, 0)
+    );
+
+    cap_union : Choice -> I64 -> I64;
+    cap_union = |ch, n| (
+        (fix(|self, x, acc|
+            if x <= 0 { acc };
+            self(x - 1, if ch.is_add { acc + ch.as_add } else { acc * ch.as_mul })
+        ))(n, 1)
+    );
+
+    cap_tuple : (I64, I64, I64) -> I64 -> I64;
+    cap_tuple = |t, n| (
+        let (a, b, c) = t;
+        (fix(|self, x, acc| if x <= 0 { acc } else { self(x - 1, acc + a * x + b - c) }))(n, 0)
+    );
+
+    sum_via : [a : Add] Array a -> a -> a;
+    sum_via = |tbl, zero| (
+        (fix(|self, i, acc| if i >= tbl.@size { acc } else { self(i + 1, acc + tbl.@(i)) }))(0, zero)
+    );
+
+    fix_in_fold : I64 -> I64;
+    fix_in_fold = |n| (
+        Iterator::range(0, n).fold(0, |k, acc|
+            acc + (fix(|self, j| if j <= 0 { 0 } else { k + self(j - 1) }))(3)
+        )
+    );
+
+    main : IO ();
+    main = (
+        assert_eq(|_|"empty_cap", empty_cap, 12);;
+        assert_eq(|_|"dual_self", dual_self(21), 11);;
+        assert_eq(|_|"cap_fun", cap_fun(|y| y * y, 5), 55);;
+        assert_eq(|_|"cap_struct", cap_struct(Cfg { base : 10, step : 2 }, 4), 60);;
+        assert_eq(|_|"cap_union_add", cap_union(Choice::add(3), 4), 13);;
+        assert_eq(|_|"cap_union_mul", cap_union(Choice::mul(2), 4), 16);;
+        assert_eq(|_|"cap_tuple", cap_tuple((2, 5, 1), 3), 24);;
+        let ints : Array I64 = [1, 2, 3, 4];
+        assert_eq(|_|"sum_via_int", sum_via(ints, 0), 10);;
+        let flts : Array F64 = [1.5, 2.5, 3.0];
+        assert_eq(|_|"sum_via_flt", sum_via(flts, 0.0), 7.0);;
+        assert_eq(|_|"fix_in_fold", fix_in_fold(5), 30);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}
+
+// `self` and boxed captures crossing the direct self-call in demanding ways: `self` escaping into a
+// returned closure and into a returned boxed struct field called after the `fix` returns, a
+// triple-nested `fix` whose innermost closes over both outer self-references and a boxed capture, a
+// boxed state plus an array threaded through and returned together, and two `fix` expressions sharing
+// one boxed capture. `develop_mode` runs this under valgrind, so an unbalanced retain/release shows.
+#[test]
+fn test_fix_self_escape_and_boxed_captures_are_memory_safe() {
+    let source = r#"
+    module Main;
+
+    type Holder = box struct { fn : I64 -> I64, tag : I64 };
+    type State = box struct { acc : I64, cnt : I64 };
+
+    escape_closure : Array I64 -> (I64 -> I64);
+    escape_closure = |tbl| (
+        (fix(|self, x|
+            if x <= 0 { |z| z + tbl.@(0) };
+            |z| self(x - 1)(z) + tbl.@(x % tbl.@size)
+        ))(3)
+    );
+
+    escape_struct : Array I64 -> Holder;
+    escape_struct = |tbl| (
+        (fix(|self, x|
+            if x <= 0 { Holder { fn : |z| z + tbl.@(0), tag : 0 } };
+            Holder { fn : |z| (self(x - 1).@fn)(z) + tbl.@(x % tbl.@size), tag : x }
+        ))(3)
+    );
+
+    triple_nested : Array I64 -> I64;
+    triple_nested = |tbl| (
+        (fix(|a, x|
+            if x <= 0 { tbl.@(0) };
+            (fix(|b, y|
+                if y <= 0 { a(x - 1) };
+                (fix(|c, z|
+                    if z <= 0 { b(y - 1) + tbl.@(z % tbl.@size) };
+                    c(z - 1) + tbl.@(z % tbl.@size)
+                ))(2)
+            ))(2)
+        ))(3)
+    );
+
+    state_array : Array I64 -> I64 -> (State, Array I64);
+    state_array = |seed, depth| (
+        (fix(|go, i, st, arr|
+            if i >= depth { (st, arr) };
+            let st = State { acc : st.@acc + seed.@(i % seed.@size), cnt : st.@cnt + 1 };
+            go(i + 1, st, arr.push_back(i))
+        ))(0, State { acc : 0, cnt : 0 }, Array::empty(0))
+    );
+
+    two_share : Array I64 -> I64;
+    two_share = |tbl| (
+        let a = (fix(|self, x| if x <= 0 { 0 } else { tbl.@(x % tbl.@size) + self(x - 1) }))(6);
+        let b = (fix(|self, x| if x <= 0 { 0 } else { tbl.@(x % tbl.@size) * 2 + self(x - 1) }))(6);
+        a + b + tbl.@(0)
+    );
+
+    main : IO ();
+    main = (
+        let tbl = Array::from_map(4, |i| i + 1);
+        let f = escape_closure(tbl);
+        assert_eq(|_|"escape_closure", f(10) + f(20) + tbl.@(3), 54);;
+        let h = escape_struct(tbl);
+        assert_eq(|_|"escape_struct", (h.@fn)(5) + h.@tag + tbl.@(1), 20);;
+        let tbl3 = Array::from_map(3, |i| i + 1);
+        assert_eq(|_|"triple_nested", triple_nested(tbl3) + tbl3.@(2), 40);;
+        let seed = Array::from_map(4, |i| i + 1);
+        let (st, arr) = state_array(seed, 50);
+        assert_eq(|_|"state_array", st.@acc + st.@cnt + arr.@size + seed.@(0), 224);;
+        assert_eq(|_|"two_share", two_share(tbl3), 37);;
+        pure()
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}


### PR DESCRIPTION
バグハントで `src/optimization/defunctionalize_fix.rs` (PR #95) を調べた際に、パスが実際に満たしている不変条件のうちテストスイート未カバーだったものを pin する green な回帰テスト 6 本を追加します。テスト追加のみで、コンパイラの挙動は変更しません。

追加テスト (すべて `-O none`/`basic`/`max` で pass):

- `test_mutual_global_fix_cycle_terminates` — 6 個の global が round-robin で互いを `fix` する循環。lifted 関数が global ごとに dedup され `run` の fixpoint が停止することと、値の保存を確認。
- `test_deep_tail_position_fix_runs_in_constant_stack` — `let`/`match` チェーンの奥にある saturated tail self-call が direct になり定数スタックで走る。
- `test_three_arg_fix_runs_in_constant_stack` — 3 引数 `fix` の各 self-call が direct call になる。
- `test_nested_fix_inner_deep_runs_in_constant_stack` — 内側が深い再帰を担うネスト `fix` で内側 self-call が direct のまま。
- `test_fix_exotic_captures_and_dual_use_self_compute_correctly` — 空 capture、unbox struct/union/tuple/関数型/Array/多相 capture、`self` の tail+bare 両用、`fix`-in-fold が closure 形と同じ値を計算する。
- `test_fix_self_escape_and_boxed_captures_are_memory_safe` — 返り値の closure や struct フィールドへ escape する `self`、direct self-call を跨ぐ boxed capture が valgrind でメモリ安全。

同じ wave が見つけたパスの欠陥 2 件は別 issue (#99 指数 lift 爆発、#100 multi-use partial-self の lost-TCO) で追跡しています。本 PR には含めません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
