### PR TITLE
深くネストした式でのコンパイラのスタックオーバーフローを修正 (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 #### Tool
 
+- The compiler no longer aborts with a stack overflow when compiling a module whose expressions nest very deeply — for example a module with several hundred top-level values all sequenced from `main`, or a single deep `let` / `;;` chain. Such a module previously overflowed the small default stack of the compiler's type-checking and code-generation worker threads (most readily at `-O max` and `-O experimental`); the compiler now runs type checking, optimization, and code generation on threads sized for deep recursion.
 - Building with debug information (`-g`) no longer crashes on a program that uses a recursive type, such as `type Tree = box union { leaf : (), node : (Tree, Tree) };`.
 - Debug information (`-g`) records every `Array` as having 100 elements, since the actual element count is only determined at run time. The byte sizes recorded for the array debug types covered only a single element, contradicting that element count: gdb refused to display the elements with an "access outside bounds of object" error, and recent lldb displayed wrong values for all elements after the first. The byte sizes now cover the 100 elements, so debuggers display them, the first `<array size>` of which are the valid values. This also applies to the byte array inside a `String`.
 - A source file listed in `fixproj.toml` that does not exist on disk now produces a clear error that points at the offending entry in the project file (e.g. `files = ["test.fix"]`), instead of an opaque, location-less "Failed to canonicalize path" message.

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -33,7 +33,7 @@ use crate::fixstd::builtin::{
     union_new,
 };
 use crate::graph::Graph;
-use crate::misc::{collect_results, spawn_compiler_worker, to_absolute_path, Map, Set};
+use crate::misc::{collect_results, spawn_compiler_thread, to_absolute_path, Map, Set};
 use crate::parse::sourcefile::{SourcePos, Span};
 use crate::printer::Text;
 use serde::{Deserialize, Serialize};
@@ -1352,7 +1352,7 @@ impl Program {
             let mut threads = vec![];
             for _ in 0..tc.num_worker_threads {
                 let queue = queue.clone();
-                let thread = spawn_compiler_worker(move || {
+                let thread = spawn_compiler_thread(move || {
                     let mut results = vec![];
                     loop {
                         let task = match queue.lock().unwrap().pop() {

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -33,7 +33,7 @@ use crate::fixstd::builtin::{
     union_new,
 };
 use crate::graph::Graph;
-use crate::misc::{collect_results, to_absolute_path, Map, Set};
+use crate::misc::{collect_results, spawn_compiler_worker, to_absolute_path, Map, Set};
 use crate::parse::sourcefile::{SourcePos, Span};
 use crate::printer::Text;
 use serde::{Deserialize, Serialize};
@@ -42,7 +42,6 @@ use std::io::Write;
 use std::mem::replace;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::vec;
 
 #[derive(Clone)]
@@ -1353,7 +1352,7 @@ impl Program {
             let mut threads = vec![];
             for _ in 0..tc.num_worker_threads {
                 let queue = queue.clone();
-                let thread = thread::spawn(move || {
+                let thread = spawn_compiler_worker(move || {
                     let mut results = vec![];
                     loop {
                         let task = match queue.lock().unwrap().pop() {

--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -14,7 +14,7 @@ use crate::{
         runtime::{self, BuildMode},
     },
     generator::Generator,
-    misc::{info_msg, spawn_compiler_worker, warn_msg, Set},
+    misc::{info_msg, spawn_compiler_thread, warn_msg, Set},
     optimization,
     rc_ir::{
         ast::RcProgram,
@@ -291,7 +291,7 @@ pub fn build_object_files<'c>(
         };
 
         let entry_io_value = program.entry_io_value.clone();
-        threads.push(spawn_compiler_worker(move || {
+        threads.push(spawn_compiler_thread(move || {
             // Create GenerationContext.
             let context = Context::create();
             let target_machine = get_target_machine(config.get_llvm_opt_level(), &config);

--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -14,7 +14,7 @@ use crate::{
         runtime::{self, BuildMode},
     },
     generator::Generator,
-    misc::{info_msg, warn_msg, Set},
+    misc::{info_msg, spawn_compiler_worker, warn_msg, Set},
     optimization,
     rc_ir::{
         ast::RcProgram,
@@ -291,7 +291,7 @@ pub fn build_object_files<'c>(
         };
 
         let entry_io_value = program.entry_io_value.clone();
-        threads.push(std::thread::spawn(move || {
+        threads.push(spawn_compiler_worker(move || {
             // Create GenerationContext.
             let context = Context::create();
             let target_machine = get_target_machine(config.get_llvm_opt_level(), &config);

--- a/src/commands/lsp/server.rs
+++ b/src/commands/lsp/server.rs
@@ -17,7 +17,7 @@ use crate::elaboration::elaborate_via_config;
 use crate::elaboration::typecheckcache::{self, SharedTypeCheckCache};
 use crate::error::{any_to_string, Error, Errors, Severity, WARN_DEPRECATED};
 use crate::metafiles::project_file::ProjectFile;
-use crate::misc::{to_absolute_path, Map, Set};
+use crate::misc::{spawn_compiler_thread, to_absolute_path, Map, Set};
 use crate::parse::parser::{parse_str_import_statements, parse_str_module_defn};
 use crate::write_log;
 use lsp_types::{
@@ -859,8 +859,10 @@ fn handle_initialized(
     typecheck_cache: SharedTypeCheckCache,
     debounce_ms: Arc<AtomicU64>,
 ) {
-    // Launch the diagnostics thread.
-    std::thread::spawn(move || {
+    // Launch the diagnostics thread. It type-checks the user's program, recursing over an
+    // expression tree of unbounded depth, so it gets the same deep-recursion stack as the batch
+    // compiler's threads.
+    spawn_compiler_thread(move || {
         let res = std::panic::catch_unwind(move || {
             diagnostics_thread(diag_req_recv, diag_res_send, typecheck_cache, debounce_ms);
         });

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -255,8 +255,8 @@ pub const DEFAULT_COMPILATION_UNIT_MAX_SIZE_STR: &str = "128";
 /// generation recurse over the user program's expression tree, whose nesting depth (deeply nested
 /// `let` or `;;` chains) is unbounded, so a worker needs far more stack than the default thread
 /// stack gives. The stack is reserved as virtual address space and backed by physical memory only
-/// for the pages a thread actually touches, so this large reservation costs real memory in
-/// proportion to the recursion depth reached, not to its size.
+/// for the pages a thread actually touches, so this large reservation costs real memory only in
+/// proportion to the recursion depth reached.
 pub const COMPILER_WORKER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
 
 pub fn chars_allowed_in_identifiers() -> String {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -251,6 +251,14 @@ pub const GLOBAL_VAR_NAME_ARGV: &str = "fixruntime_argv";
 pub const DEFAULT_COMPILATION_UNIT_MAX_SIZE: usize = 128;
 pub const DEFAULT_COMPILATION_UNIT_MAX_SIZE_STR: &str = "128";
 
+/// Stack size, in bytes, of each compiler worker thread. Parallel type checking and per-unit code
+/// generation recurse over the user program's expression tree, whose nesting depth (deeply nested
+/// `let` or `;;` chains) is unbounded, so a worker needs far more stack than the default thread
+/// stack gives. The stack is reserved as virtual address space and backed by physical memory only
+/// for the pages a thread actually touches, so this large reservation costs real memory in
+/// proportion to the recursion depth reached, not to its size.
+pub const COMPILER_WORKER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
+
 pub fn chars_allowed_in_identifiers() -> String {
     // If you add a new character, please also update `name_char` in `grammar.pest`.
     let mut chars = String::new();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -257,7 +257,7 @@ pub const DEFAULT_COMPILATION_UNIT_MAX_SIZE_STR: &str = "128";
 /// stack gives. The stack is reserved as virtual address space and backed by physical memory only
 /// for the pages a thread actually touches, so this large reservation costs real memory only in
 /// proportion to the recursion depth reached.
-pub const COMPILER_WORKER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
+pub const COMPILER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
 
 pub fn chars_allowed_in_identifiers() -> String {
     // If you add a new character, please also update `name_char` in `grammar.pest`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
     }
 }
 
+/// Build the command-line interface, parse the invocation, and run the selected subcommand.
 fn run_cli() {
     disable_colored_no_tty();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ mod tests;
 mod tool;
 
 use crate::error::Errors;
-use crate::misc::disable_colored_no_tty;
+use crate::misc::{disable_colored_no_tty, spawn_compiler_worker};
 use clap::ArgMatches;
 use clap::PossibleValue;
 use clap::{App, AppSettings, Arg};
@@ -76,6 +76,17 @@ static GLOBAL: MiMalloc = MiMalloc;
 const GIT_VERSION: &str = git_version!(args = ["--abbrev=7", "--always", "--dirty", "--broken"]);
 
 fn main() {
+    // The compiler recurses over the user program's expression tree, whose nesting depth is
+    // unbounded, so it runs on a thread with a stack sized for that recursion — the size its
+    // type-checking and code-generation workers already use — instead of the smaller default
+    // main-thread stack. `run_cli` reports any failure through the panic hook before unwinding, so
+    // a panicked join only needs to become a non-zero exit here.
+    if spawn_compiler_worker(run_cli).join().is_err() {
+        process::exit(1);
+    }
+}
+
+fn run_cli() {
     disable_colored_no_tty();
 
     // Options

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ mod tests;
 mod tool;
 
 use crate::error::Errors;
-use crate::misc::{disable_colored_no_tty, spawn_compiler_worker};
+use crate::misc::{disable_colored_no_tty, spawn_compiler_thread};
 use clap::ArgMatches;
 use clap::PossibleValue;
 use clap::{App, AppSettings, Arg};
@@ -81,7 +81,7 @@ fn main() {
     // type-checking and code-generation workers already use — instead of the smaller default
     // main-thread stack. `run_cli` reports any failure through the panic hook before unwinding, so
     // a panicked join only needs to become a non-zero exit here.
-    if spawn_compiler_worker(run_cli).join().is_err() {
+    if spawn_compiler_thread(run_cli).join().is_err() {
         process::exit(1);
     }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,5 +1,8 @@
 use crate::{
-    ast::name::Name, constants::TEMPORARY_SRC_PATH, error::Errors, parse::sourcefile::SourceFile,
+    ast::name::Name,
+    constants::{COMPILER_WORKER_THREAD_STACK_SIZE, TEMPORARY_SRC_PATH},
+    error::Errors,
+    parse::sourcefile::SourceFile,
 };
 use colored::Colorize;
 use std::io::IsTerminal;
@@ -7,6 +10,7 @@ use std::{
     env, fs,
     hash::Hash,
     path::{Path, PathBuf},
+    thread::{self, JoinHandle},
 };
 
 pub type Map<K, V> = fxhash::FxHashMap<K, V>;
@@ -35,6 +39,22 @@ pub fn make_set<T: Eq + Hash>(iter: impl IntoIterator<Item = T>) -> Set<T> {
 pub fn grow_stack<R>(f: impl FnOnce() -> R) -> R {
     // Allocate another 1 MiB of stack whenever less than 64 KiB of it remains.
     stacker::maybe_grow(64 * 1024, 1024 * 1024, f)
+}
+
+/// Spawn a thread whose stack (`COMPILER_WORKER_THREAD_STACK_SIZE`) is large enough for the
+/// compiler's recursion over deeply nested user expressions. The parallel type checker, the
+/// per-unit code generator, and the top-level compilation all descend the program's expression
+/// tree, whose depth is unbounded, so a thread spawned with the default stack overflows on deep
+/// inputs.
+pub fn spawn_compiler_worker<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    thread::Builder::new()
+        .stack_size(COMPILER_WORKER_THREAD_STACK_SIZE)
+        .spawn(f)
+        .expect("failed to spawn a compiler thread")
 }
 
 pub fn temporary_source_name(file_name: &str, hash: &str) -> String {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -42,10 +42,8 @@ pub fn grow_stack<R>(f: impl FnOnce() -> R) -> R {
 }
 
 /// Spawn a thread whose stack (`COMPILER_WORKER_THREAD_STACK_SIZE`) is large enough for the
-/// compiler's recursion over deeply nested user expressions. The parallel type checker, the
-/// per-unit code generator, and the top-level compilation all descend the program's expression
-/// tree, whose depth is unbounded, so a thread spawned with the default stack overflows on deep
-/// inputs.
+/// compiler's recursion over deeply nested user expressions. The program's expression tree has
+/// unbounded depth, so a thread spawned with the default stack overflows on deep inputs.
 pub fn spawn_compiler_worker<F, T>(f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::name::Name,
-    constants::{COMPILER_WORKER_THREAD_STACK_SIZE, TEMPORARY_SRC_PATH},
+    constants::{COMPILER_THREAD_STACK_SIZE, TEMPORARY_SRC_PATH},
     error::Errors,
     parse::sourcefile::SourceFile,
 };
@@ -41,16 +41,16 @@ pub fn grow_stack<R>(f: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(64 * 1024, 1024 * 1024, f)
 }
 
-/// Spawn a thread whose stack (`COMPILER_WORKER_THREAD_STACK_SIZE`) is large enough for the
+/// Spawn a thread whose stack (`COMPILER_THREAD_STACK_SIZE`) is large enough for the
 /// compiler's recursion over deeply nested user expressions. The program's expression tree has
 /// unbounded depth, so a thread spawned with the default stack overflows on deep inputs.
-pub fn spawn_compiler_worker<F, T>(f: F) -> JoinHandle<T>
+pub fn spawn_compiler_thread<F, T>(f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
     thread::Builder::new()
-        .stack_size(COMPILER_WORKER_THREAD_STACK_SIZE)
+        .stack_size(COMPILER_THREAD_STACK_SIZE)
         .spawn(f)
         .expect("failed to spawn a compiler thread")
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod test_basic;
 mod test_bool_union;
 mod test_check;
 mod test_debug_info;
+mod test_deep_expression;
 mod test_defunctionalize_fix;
 mod test_dependencies;
 mod test_deprecation;

--- a/src/tests/test_deep_expression.rs
+++ b/src/tests/test_deep_expression.rs
@@ -11,8 +11,9 @@ mod integration_tests {
     use std::fs;
     use tempfile::TempDir;
 
-    // Deep enough to need the enlarged compiler-thread stack, shallow enough to
-    // keep the `-O max` build time modest.
+    // 300 exceeds the few-hundred nesting depth at which the compiler overflows a
+    // worker thread without the enlarged stack, so this build fails if the fix
+    // regresses; it stays shallow enough to keep the `-O max` build time modest.
     const DEPTH: usize = 300;
 
     #[test]

--- a/src/tests/test_deep_expression.rs
+++ b/src/tests/test_deep_expression.rs
@@ -1,0 +1,48 @@
+// The compiler compiles a deeply nested expression without overflowing its own
+// stack. Type checking and code generation recurse to the expression's nesting
+// depth; they run on worker threads sized for that recursion via
+// `COMPILER_WORKER_THREAD_STACK_SIZE`, and the whole compilation runs on a
+// thread of the same size, so a deep `let`/`;;` chain compiles rather than
+// aborting with a stack overflow.
+
+#[cfg(test)]
+mod integration_tests {
+    use crate::tests::test_util::fix_command;
+    use tempfile::TempDir;
+
+    // Deep enough to need the enlarged compiler-thread stack, shallow enough to
+    // keep the `-O max` build time modest.
+    const DEPTH: usize = 300;
+
+    #[test]
+    fn test_deeply_nested_expression_compiles_without_stack_overflow() {
+        // A single global whose body is a `DEPTH`-deep chain of monadic binds.
+        let mut source = String::from("module Main;\nmain : IO ();\nmain = (\n");
+        for i in 0..DEPTH {
+            source.push_str(&format!("    println(\"{}\");;\n", i));
+        }
+        source.push_str("    pure()\n);\n");
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let src_path = temp_dir.path().join("deep.fix");
+        std::fs::write(&src_path, source).expect("Failed to write source file");
+
+        let output = fix_command()
+            .arg("build")
+            .arg("--file")
+            .arg(&src_path)
+            .arg("-O")
+            .arg("max")
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("Failed to execute fix build");
+
+        assert!(
+            output.status.success(),
+            "compiling a {}-deep expression failed (stack overflow?):\nstdout: {}\nstderr: {}",
+            DEPTH,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}

--- a/src/tests/test_deep_expression.rs
+++ b/src/tests/test_deep_expression.rs
@@ -8,6 +8,7 @@
 #[cfg(test)]
 mod integration_tests {
     use crate::tests::test_util::fix_command;
+    use std::fs;
     use tempfile::TempDir;
 
     // Deep enough to need the enlarged compiler-thread stack, shallow enough to
@@ -25,7 +26,7 @@ mod integration_tests {
 
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let src_path = temp_dir.path().join("deep.fix");
-        std::fs::write(&src_path, source).expect("Failed to write source file");
+        fs::write(&src_path, source).expect("Failed to write source file");
 
         let output = fix_command()
             .arg("build")

--- a/src/tests/test_deep_expression.rs
+++ b/src/tests/test_deep_expression.rs
@@ -1,7 +1,7 @@
 // The compiler compiles a deeply nested expression without overflowing its own
 // stack. Type checking and code generation recurse to the expression's nesting
 // depth; they run on worker threads sized for that recursion via
-// `COMPILER_WORKER_THREAD_STACK_SIZE`, and the whole compilation runs on a
+// `COMPILER_THREAD_STACK_SIZE`, and the whole compilation runs on a
 // thread of the same size, so a deep `let`/`;;` chain compiles rather than
 // aborting with a stack overflow.
 


### PR DESCRIPTION
Fixes #101.

## 問題

コンパイラは型検査・最適化・コード生成でユーザプログラムの式の木を深さぶん再帰する。このうち 2 つのフェーズは `std::thread::spawn` の worker thread 上で走り (per-symbol の並列型検査、per-unit のコード生成)、これらは既定の ~2 MiB スタックしか持たない。最適化 (`optimization::run`) は 8 MiB の main スレッド上で走る。そのため式が非常に深くネストしたモジュールはいずれかのスタックを溢れさせ、コンパイラが `fatal runtime error: stack overflow` で異常終了する。

深さに達する形は 2 つ:

- **多数の top-level 値**。`main` が N 個の global を `;;` で連ねると、その本体は N 段の monadic-bind 鎖になる。`-O max` / `-O experimental` では数百値でコード生成 worker が溢れた。同じモジュールが `-O none` / `-O basic` では通る。
- **単一の深い `let` / `;;` 鎖**。十分深ければ任意のレベルで溢れる。

gdb で確認: `-O max` では worker が `ExprNode::resolve_namespace` の中と、型検査キャッシュを serde_pickle で serialize する `save_cache` の中で溢れる。`-O max` の閾値が低いのは、codegen worker (`lower` / RC-IR) も small-stack だから。

なお issue 本文の再現スクリプトは `main = eval compute0` を書くため、`-O max` では dead symbol elimination が他の値を刈り、そのままでは再現しない。`main` から全値を参照させると再現する。

## 修正

コンパイラのスレッドに、その再帰に見合ったスタック `COMPILER_THREAD_STACK_SIZE` を与える:

- 新しい `spawn_compiler_thread` ヘルパが 2 つの worker 箇所の素の `thread::spawn` を置き換える。
- CLI 全体をそのスレッド上で走らせる (`main` が `run_cli` を spawn)。
- LSP の diagnostics スレッド (エディタ上で同じ型検査を行う) も同ヘルパで spawn する。

スレッドスタックは仮想アドレス空間として予約され、触れたページだけ物理メモリに割り当てられる (demand paging)。よって大きめの予約でも実メモリ増は到達した再帰深さぶんに比例するだけ (実測: 1 GiB x 12 予約で RSS 増は数 MiB のみ)。

これは各再帰降下に `stacker::maybe_grow` を撒く案 (`fix-resolve-namespace-stack-overflow` の WIP) を置き換える: 型検査キャッシュ経路の再帰は serde derive の (de)serialize の内側にあり `maybe_grow` が届かない。加えて各パスは共通トラバーサルを持たないため per-site のガードは構造的に漏れる (WIP をビルドして実測しても依然 overflow した)。

## 検証

- 新しい統合テスト `test_deep_expression` が 300 段の式を `-O max` でビルドする (修正前は overflow した深さ)。CI の opt-level matrix により none/basic/max の各セルで実行される。
- 再現ケースがコンパイルできることを確認: 120 値のモジュールを `-O none` / `-O basic` / `-O max`、800 段の鎖を `-O max`、3000 段の鎖を `-O none`。同一プログラムで `-O none` と `-O max` の出力が一致する。
- `test_basic` 388/0 (`-O none`)、`test_get_args`、`test_check` が pass。compile error は依然として非ゼロ終了で単一のクリーンなメッセージを出す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156CQViFqpENm76NN9P7cRS
