### PR TITLE
probe: AArch64 tailcc diagnosis (do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        opt-level: [max, basic, none]
+        os: [macos-latest]
+        opt-level: [basic]
     env:
       FIX_MAX_OPT_LEVEL: ${{ matrix.opt-level }}
     steps:
@@ -61,4 +61,13 @@ jobs:
           sudo apt-get install -y valgrind=1:3.22.*
 
       - name: Run tests
-        run: cargo test --release
+        run: cargo test --release test_external_project_regexp -- --nocapture
+
+      - name: Show crash reports
+        if: always()
+        run: |
+          ls -la ~/Library/Logs/DiagnosticReports/ 2>/dev/null || true
+          for f in ~/Library/Logs/DiagnosticReports/*.ips; do
+            echo "===== $f"
+            cat "$f" | head -200
+          done 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: [macos-latest]
         opt-level: [basic]
+        variant: [outptr, nooutptr]
     env:
       FIX_MAX_OPT_LEVEL: ${{ matrix.opt-level }}
     steps:
@@ -59,6 +60,22 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install -y valgrind=1:3.22.*
+
+      - name: Apply the variant
+        shell: bash
+        run: |
+          if [ "${{ matrix.variant }}" = "nooutptr" ]; then
+            python3 - <<'PY'
+          p = 'src/return_abi.rs'
+          s = open(p).read()
+          marker = 'pub fn returns_through_out_pointer(leaf_tys: &[BasicTypeEnum], budget: ReturnRegisters) -> bool {'
+          i = s.index(marker) + len(marker)
+          j = s.index('\n}', i)
+          s = s[:i] + '\n    let _ = (leaf_tys, budget);\n    false' + s[j:]
+          open(p, 'w').write(s)
+          PY
+            grep -A 3 "pub fn returns_through_out_pointer" src/return_abi.rs
+          fi
 
       - name: Fault site of the arm64 tailcc crash
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        opt-level: [basic]
+        opt-level: [basic, max, none]
     env:
       FIX_MAX_OPT_LEVEL: ${{ matrix.opt-level }}
     steps:
@@ -60,14 +60,63 @@ jobs:
         run: |
           sudo apt-get install -y valgrind=1:3.22.*
 
-      - name: Run tests
-        run: cargo test --release test_external_project_regexp -- --nocapture
-
-      - name: Show crash reports
-        if: always()
+      - name: Narrow the regexp failure
+        shell: bash
         run: |
-          ls -la ~/Library/Logs/DiagnosticReports/ 2>/dev/null || true
-          for f in ~/Library/Logs/DiagnosticReports/*.ips; do
-            echo "===== $f"
-            cat "$f" | head -200
-          done 2>/dev/null || true
+          cargo build --release
+          FIX="$GITHUB_WORKSPACE/target/release/fix"
+          git clone --depth 1 https://github.com/tttmmmyyyy/fixlang-regexp.git "$RUNNER_TEMP/regexp"
+          cd "$RUNNER_TEMP/regexp"
+          cat > p1.fix <<'EOF'
+          module Main;
+          import RegExp::RegExp::{compile, match_one};
+          import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
+          main : IO ();
+          main = (
+              println("p1: compile");;
+              let regexp = RegExp::compile("[a-z]+([0-9]+)", "").as_ok;
+              println("p1: match_one");;
+              let groups = regexp.match_one("abc012 def345").as_ok;
+              assert_eq(|_|"p1", groups, ["abc012", "012"]);;
+              println("p1: ok");;
+              pure()
+          );
+          EOF
+          cat > p2.fix <<'EOF'
+          module Main;
+          import RegExp::RegExp::{compile, match_one};
+          import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
+          main : IO ();
+          main = (
+              println("p2: compile");;
+              let regexp = RegExp::compile("[a-z]+([0-9]+)", "g").as_ok;
+              println("p2: match_one");;
+              let groups = regexp.match_one("abc012 def345").as_ok;
+              assert_eq(|_|"p2", groups, ["abc012", "def345"]);;
+              println("p2: ok");;
+              pure()
+          );
+          EOF
+          cat > p3.fix <<'EOF'
+          module Main;
+          import RegExp::RegExp::{compile, replace_all};
+          import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
+          main : IO ();
+          main = (
+              println("p3: compile");;
+              let regexp = RegExp::compile("(\\w\\w)(\\w)", "").as_ok;
+              println("p3: replace_all");;
+              let result = regexp.replace_all("abc def ijk", "$2$1");
+              assert_eq(|_|"p3", result, "cab fde kij");;
+              println("p3: ok");;
+              pure()
+          );
+          EOF
+          for p in p1 p2 p3; do
+            echo "##### $p at -O ${{ matrix.opt-level }}"
+            "$FIX" run -f $p.fix -O ${{ matrix.opt-level }} --allow-preliminary-commands --allow-deprecated --backtrace && echo "##### $p PASSED" || echo "##### $p FAILED with $?"
+          done
+
+      - name: Run the regexp project test
+        if: always()
+        run: cargo test --release test_external_project_regexp -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        opt-level: [basic, max, none]
+        opt-level: [basic]
     env:
       FIX_MAX_OPT_LEVEL: ${{ matrix.opt-level }}
     steps:
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt-get install -y valgrind=1:3.22.*
 
-      - name: Narrow the regexp failure
+      - name: Fault site of the arm64 tailcc crash
         shell: bash
         run: |
           cargo build --release
@@ -73,50 +73,12 @@ jobs:
           import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
           main : IO ();
           main = (
-              println("p1: compile");;
               let regexp = RegExp::compile("[a-z]+([0-9]+)", "").as_ok;
-              println("p1: match_one");;
               let groups = regexp.match_one("abc012 def345").as_ok;
               assert_eq(|_|"p1", groups, ["abc012", "012"]);;
-              println("p1: ok");;
               pure()
           );
           EOF
-          cat > p2.fix <<'EOF'
-          module Main;
-          import RegExp::RegExp::{compile, match_one};
-          import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
-          main : IO ();
-          main = (
-              println("p2: compile");;
-              let regexp = RegExp::compile("[a-z]+([0-9]+)", "g").as_ok;
-              println("p2: match_one");;
-              let groups = regexp.match_one("abc012 def345").as_ok;
-              assert_eq(|_|"p2", groups, ["abc012", "def345"]);;
-              println("p2: ok");;
-              pure()
-          );
-          EOF
-          cat > p3.fix <<'EOF'
-          module Main;
-          import RegExp::RegExp::{compile, replace_all};
-          import Std::{IO, Debug::assert_eq, Monad::pure, Result::as_ok, IO::println};
-          main : IO ();
-          main = (
-              println("p3: compile");;
-              let regexp = RegExp::compile("(\\w\\w)(\\w)", "").as_ok;
-              println("p3: replace_all");;
-              let result = regexp.replace_all("abc def ijk", "$2$1");
-              assert_eq(|_|"p3", result, "cab fde kij");;
-              println("p3: ok");;
-              pure()
-          );
-          EOF
-          for p in p1 p2 p3; do
-            echo "##### $p at -O ${{ matrix.opt-level }}"
-            "$FIX" run -f $p.fix -O ${{ matrix.opt-level }} --allow-preliminary-commands --allow-deprecated --backtrace && echo "##### $p PASSED" || echo "##### $p FAILED with $?"
-          done
-
-      - name: Run the regexp project test
-        if: always()
-        run: cargo test --release test_external_project_regexp -- --nocapture
+          "$FIX" build -f p1.fix -O basic --allow-preliminary-commands --allow-deprecated --emit-symbols
+          ls -la a.out
+          lldb -b -o run -o "bt all" -o "register read sp x29 x30 pc" -o "disassemble --frame --count 40" -o quit ./a.out 2>&1 | tail -120

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -522,7 +522,7 @@ impl Configuration {
 
     pub fn get_llvm_opt_level(&self) -> OptimizationLevel {
         match self.fix_opt_level {
-            FixOptimizationLevel::None => OptimizationLevel::None,
+            FixOptimizationLevel::None => OptimizationLevel::Less,
             FixOptimizationLevel::Basic => OptimizationLevel::Default,
             FixOptimizationLevel::Max => OptimizationLevel::Default,
             FixOptimizationLevel::Experimental => OptimizationLevel::Default,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1081,19 +1081,26 @@ impl<'c, 'm> Generator<'c, 'm> {
         tail: bool,
     ) -> PointerValue<'c> {
         if tail {
-            let func = self.current_function();
-            // A function whose result goes through an out-pointer returns `void` and takes the
-            // pointer first. Checked under develop mode (the unit tests).
-            if self.config.develop_mode {
-                assert!(
-                    func.get_type().get_return_type().is_none() && func.count_params() >= 1,
-                    "a tail call forwards the out-pointer of a function that has one"
-                );
-            }
-            return func.get_nth_param(0).unwrap().into_pointer_value();
+            return self.own_out_pointer();
         }
         let buf_ty = out_pointer_buffer_type(ret_leaf_tys, self);
         self.build_alloca_at_entry(buf_ty, "out@call_lambda")
+    }
+
+    // The out-pointer parameter of the function being generated, the buffer its result is written
+    // through. A function whose result goes through an out-pointer returns `void` and takes the
+    // pointer before every other parameter (see `lambda_function_type`). Checked under develop mode
+    // (the unit tests).
+    fn own_out_pointer(&self) -> PointerValue<'c> {
+        let func = self.current_function();
+        if self.config.develop_mode {
+            assert!(
+                func.get_type().get_return_type().is_none() && func.count_params() >= 1,
+                "`{}` returns through an out-pointer: it must return `void` and take it first",
+                func.get_name().to_str().unwrap()
+            );
+        }
+        func.get_nth_param(0).unwrap().into_pointer_value()
     }
 
     // Read back the leaves a callee wrote through the out-pointer, as the object of type `ret_ty`
@@ -1919,11 +1926,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         let leaves: Vec<BasicValueEnum<'c>> = obj.leaves().to_vec();
         let leaf_tys: Vec<BasicTypeEnum<'c>> = leaves.iter().map(|l| l.get_type()).collect();
         if self.returns_through_out_pointer(&leaf_tys) {
-            let out_ptr = self
-                .current_function()
-                .get_nth_param(0)
-                .unwrap()
-                .into_pointer_value();
+            let out_ptr = self.own_out_pointer();
             let buf_ty = out_pointer_buffer_type(&leaf_tys, self);
             for (i, leaf) in leaves.iter().enumerate() {
                 let field = self
@@ -1943,8 +1946,6 @@ impl<'c, 'm> Generator<'c, 'm> {
                 self.builder().build_return(Some(&leaves[0])).unwrap();
             }
             _ => {
-                let leaf_tys: Vec<BasicTypeEnum<'c>> =
-                    leaves.iter().map(|l| l.get_type()).collect();
                 let struct_ty = self.context.struct_type(&leaf_tys, false);
                 let mut val = struct_ty.get_undef();
                 for (i, leaf) in leaves.iter().enumerate() {

--- a/src/object.rs
+++ b/src/object.rs
@@ -19,7 +19,6 @@ use crate::fixstd::runtime::{
     RUNTIME_INDEX_OUT_OF_RANGE, RUNTIME_MALLOC, RUNTIME_NEGATIVE_ARRAY_SIZE,
 };
 use crate::generator::{is_const_one, Generator, Object};
-
 use inkwell::context::Context;
 use inkwell::types::{BasicTypeEnum, FunctionType, IntType, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue};

--- a/src/return_abi.rs
+++ b/src/return_abi.rs
@@ -60,7 +60,7 @@ pub fn lambda_calling_convention_of_target(triple: &str) -> u32 {
 
 /// The architecture a target triple names.
 fn architecture_of_target(triple: &str) -> &str {
-    triple.split('-').next().unwrap_or("")
+    triple.split('-').next().unwrap()
 }
 
 /// How many registers of each class a target returns a value in.

--- a/src/return_abi.rs
+++ b/src/return_abi.rs
@@ -53,7 +53,7 @@ const CCC: u32 = 0;
 /// uniform, since a tail call between two conventions becomes an ordinary call in both directions.
 pub fn lambda_calling_convention_of_target(triple: &str) -> u32 {
     match architecture_of_target(triple) {
-        "x86_64" => TAILCC,
+        "x86_64" | "aarch64" | "arm64" => TAILCC,
         _ => CCC,
     }
 }


### PR DESCRIPTION
Temporary probe to reproduce the AArch64 `-O basic` failure with `tailcc` enabled there. Matrix trimmed to macOS + basic, and only the regexp external-project test runs. Close once diagnosed.