### PR TITLE
Test that a main loop re-entering main runs in constant stack

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod test_hole_priority;
 mod test_import;
 mod test_index_syntax;
 mod test_lsp;
+mod test_main_loop;
 mod test_match_result_alias;
 mod test_match_return_outer;
 mod test_memcheck;

--- a/src/tests/test_main_loop.rs
+++ b/src/tests/test_main_loop.rs
@@ -1,0 +1,34 @@
+use crate::{configuration::Configuration, tests::test_util::test_source};
+
+// A game's main loop, in the shape Fix lets one write it: `main` re-enters `main` until a deadline
+// passes, threading no state and using no loop combinator. `Std::IO`'s `bind` leaves
+// `(f(a).@runner)(iostate)` in tail position, so the self-entry is a tail call that has to lower to
+// a jump; a frame kept per iteration overflows the stack long before the deadline.
+//
+// The deadline is CPU time consumed, which advances at the same rate however loaded the machine is,
+// so the iteration count reached does not depend on the tests running beside this one. Ten seconds
+// buys tens of millions of iterations natively and millions under valgrind, both far past the
+// hundred thousand or so frames an 8 MiB stack holds — a lost tail call therefore ends the process
+// on a signal rather than at the deadline, whatever the machine's speed.
+
+/// Verifies that a `main` whose only loop is a self-entry runs in constant stack and exits normally.
+#[test]
+fn test_main_self_entry_runs_in_constant_stack() {
+    let source = r#"
+    module Main;
+
+    // Seconds of CPU time this process has consumed since it started.
+    process_time : IO F64;
+    process_time = (
+        let clocks = *FFI_CALL_IO[I64 fixruntime_clock()];
+        pure $ FFI_CALL[F64 fixruntime_clocks_to_sec(I64), clocks]
+    );
+
+    main : IO ();
+    main = (
+        let t = *process_time;
+        if t < 10.0 { main } else { pure() }
+    );
+    "#;
+    test_source(source, Configuration::develop_mode());
+}


### PR DESCRIPTION
Adds a test for the loop shape a game writes: `main` re-enters `main` until a deadline passes, threading no state and using no loop combinator.

```fix
main : IO ();
main = (
    let t = *process_time;
    if t < 10.0 { main } else { pure() }
);
```

`Std::IO`'s `bind` leaves `(f(a).@runner)(iostate)` in tail position, so the self-entry is a tail call that has to lower to a jump. The deadline is the CPU time the process has consumed, read through the runtime's `fixruntime_clock` / `fixruntime_clocks_to_sec` (libc `clock()`), so no extra C code is linked and the iteration count reached does not depend on how loaded the machine is.

The loop already runs in constant stack at every optimization level, `none` included — the backend turns the `tail`-marked call into a jump even at `-O0`. Measured on this branch with a C probe that counts iterations and watches the frame address:

| level | iterations per CPU-second (native) | stack drift |
| ----- | ---------------------------------- | ----------- |
| none  | 2.2 M | 0 bytes |
| basic | 3.7 M | 0 bytes |
| max   | 4.9 M | 0 bytes |

Under valgrind, which is how `develop_mode` runs it, the rate is about a tenth of that, so the ten-second deadline still buys millions of iterations. A variant made genuinely non-tail (work after the recursive call) overflows the 8 MiB stack in under 100k iterations, which is the margin the deadline is chosen against.

Test passes at `max`, `basic` and `none`, with no leak reported by memcheck (the loop allocates nothing).


https://claude.ai/code/session_01LAa4vvmJ8KWESYposht3vX
