### PR TITLE
benchmark: give fib its counterparts, link the page, count allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Concepts:
 - **Performance** 
   - While Fix is still undergoing benchmarking and optimization, Fix can achieve performance comparable to C++ in a few simple programs that I have tested.
   - One of Fix's goals is to compile high-level code into high-performance code without introducing low-level concepts such as "reference" and "lifetime" into the language.
+  - [Benchmark history](https://tttmmmyyyy.github.io/fixlang/benchmark/)
 
 The following is an example program that calculates the Fibonacci sequence using Fix:
 ```

--- a/benchmark/crosslang/.gitignore
+++ b/benchmark/crosslang/.gitignore
@@ -1,1 +1,2 @@
 bin/
+allocations.so

--- a/benchmark/crosslang/README.md
+++ b/benchmark/crosslang/README.md
@@ -36,6 +36,17 @@ and is included in the wall-clock figure, and cachegrind counts it in the instru
 as well; the cases carrying counterparts today all run for hundreds of millions of
 instructions, where that is under a percent.
 
+## Counting allocations
+
+`allocations.c` interposes on the allocator and reports the counts at exit, which is the
+question a reference-counted language raises constantly and neither of the measurements above
+answers.
+
+```
+gcc -shared -fPIC -O2 allocations.c -o allocations.so -ldl
+LD_PRELOAD=$PWD/allocations.so ./bin/fannkuch_fix
+```
+
 ## Two measurements, two questions
 
 **Instruction counts** (from `../speedtest`) are deterministic: the same program and input

--- a/benchmark/crosslang/allocations.c
+++ b/benchmark/crosslang/allocations.c
@@ -1,0 +1,45 @@
+// Count the allocations a program makes, by interposing on the allocator.
+//
+// "How many times does this allocate" is a question a reference-counted language raises
+// constantly, and neither the instruction count nor the wall clock answers it directly.
+// Two defects in these benchmarks were found this way: a counterpart allocating half as
+// often as the case it was compared against, and a case allocating once per iteration
+// where its counterparts allocate not at all.
+//
+//   gcc -shared -fPIC -O2 allocations.c -o allocations.so -ldl
+//   LD_PRELOAD=$PWD/allocations.so ./bin/fannkuch_fix
+//
+// The counts are written to stderr when the program exits.
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static long n_malloc, n_realloc, n_aligned;
+static void *(*real_malloc)(size_t);
+static void *(*real_realloc)(void *, size_t);
+static void *(*real_aligned_alloc)(size_t, size_t);
+
+void *malloc(size_t size) {
+    if (!real_malloc) real_malloc = dlsym(RTLD_NEXT, "malloc");
+    n_malloc++;
+    return real_malloc(size);
+}
+
+void *realloc(void *ptr, size_t size) {
+    if (!real_realloc) real_realloc = dlsym(RTLD_NEXT, "realloc");
+    n_realloc++;
+    return real_realloc(ptr, size);
+}
+
+void *aligned_alloc(size_t alignment, size_t size) {
+    if (!real_aligned_alloc) real_aligned_alloc = dlsym(RTLD_NEXT, "aligned_alloc");
+    n_aligned++;
+    return real_aligned_alloc(alignment, size);
+}
+
+__attribute__((destructor)) static void report(void) {
+    fprintf(stderr, "malloc=%ld realloc=%ld aligned_alloc=%ld\n",
+            n_malloc, n_realloc, n_aligned);
+}

--- a/benchmark/speedtest/cases/fib/ref.c
+++ b/benchmark/speedtest/cases/fib/ref.c
@@ -1,0 +1,22 @@
+// The C counterpart of `main.fix`, on the same input, so the log can carry a
+// reference the Fix line is read against. It checks the answer and prints nothing, as the
+// Fix case does: a reference that computed something else would otherwise pass unnoticed.
+
+#include <stdint.h>
+#include <stdio.h>
+
+static int64_t fib(int64_t n) {
+    return n <= 1 ? n : fib(n - 1) + fib(n - 2);
+}
+
+int main(void) {
+    // `volatile` keeps the compiler from folding the whole call tree to a constant, which
+    // is what the Fix case gets from taking `n` off the argument count.
+    volatile int64_t n = 34;
+    int64_t answer = fib(n);
+    if (answer != 5702887) {
+        fprintf(stderr, "fib: %lld\n", (long long)answer);
+        return 1;
+    }
+    return 0;
+}

--- a/benchmark/speedtest/cases/fib/ref.rs
+++ b/benchmark/speedtest/cases/fib/ref.rs
@@ -1,0 +1,15 @@
+// The Rust counterpart of `main.fix`, on the same input, so the log can carry a
+// reference the Fix line is read against. It checks the answer and prints nothing, as the
+// Fix case does: a reference that computed something else would otherwise pass unnoticed.
+
+use std::hint::black_box;
+
+fn fib(n: i64) -> i64 {
+    if n <= 1 { n } else { fib(n - 1) + fib(n - 2) }
+}
+
+fn main() {
+    // `black_box` keeps the compiler from folding the whole call tree to a constant, which
+    // is what the Fix case gets from taking `n` off the argument count.
+    assert_eq!(fib(black_box(34)), 5_702_887);
+}


### PR DESCRIPTION
Follow-ups to #133, and the last thing worth rescuing from the out-of-repository benchmark directory before it is deleted.

`fib` was the one comparable case carrying no `ref.c` / `ref.rs`. With them:

| | instructions | vs C | vs Rust |
|---|--:|--:|--:|
| Fix | 200,988,973 | 1.17x | 1.07x |
| C | 171,679,753 | 1.00x | 0.92x |
| Rust | 187,064,310 | 1.09x | 1.00x |

Both counterparts carry an optimization barrier, which is what the Fix case gets from taking `n` off the argument count: without one the whole call tree folds to a constant.

`allocations.c` interposes on the allocator and reports the counts at exit. Two defects in these benchmarks were found that way — Rust's `binary_trees` allocating half as often as C and Fix, and `fannkuch` allocating once per permutation where its counterparts allocate not at all — so it is worth keeping beside the harnesses rather than rewriting each time.

The README links the published page.

https://claude.ai/code/session_01LAa4vvmJ8KWESYposht3vX