### PR TITLE
speedtest: measure in a fixed environment, and record what start-up costs

### DIFF
--- a/benchmark/speedtest/cachegrind-benchmarking/cachegrind.py
+++ b/benchmark/speedtest/cachegrind-benchmarking/cachegrind.py
@@ -44,6 +44,13 @@ from tempfile import NamedTemporaryFile
 ARCH = check_output(["uname", "-m"]).strip()
 
 
+# Cachegrind counts the dynamic loader and libc start-up along with the program, and both
+# walk the environment, so the count carries about 600 instructions per variable the caller
+# happened to export. Rows measured from different shells were then not subtractable. The
+# measured command gets this fixed environment instead, which makes start-up a constant.
+MEASUREMENT_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C"}
+
+
 def run_with_cachegrind(args_list: List[str]) -> Dict[str, int]:
     """
     Run the the given program and arguments under Cachegrind, parse the
@@ -52,7 +59,7 @@ def run_with_cachegrind(args_list: List[str]) -> Dict[str, int]:
     For now we just ignore program output, and in general this is not robust.
     """
     temp_file = NamedTemporaryFile("r+")
-    check_call([
+    check_call(env=MEASUREMENT_ENV, args=[
         # Disable ASLR:
         "setarch",
         ARCH,

--- a/benchmark/speedtest/cases/startup/fixproj.toml
+++ b/benchmark/speedtest/cases/startup/fixproj.toml
@@ -1,0 +1,91 @@
+[general]
+## Project name. This is a required field.
+name = "myproject"
+
+## Project version (in semver). This is a required field.
+version = "0.1.0"
+
+## Fix version requirement. Default is "*".
+fix_version = "1.1.0"
+
+## Project authors.
+# authors = ["Alice", "Bob"]
+
+## Project description.
+# description = "This is a Fix project."
+
+## Project license.
+# license = "MIT"
+
+[build]
+## Fix source files to be compiled.
+## Merged with files specified in the command line argument.
+files = ["main.fix"]
+
+## Object files to be linked.
+## Merged with object files specified in the command line argument.
+# objects = ["lib.o"]
+
+## Libraries to be linked statically.
+## Merged with libraries specified in the command line argument.
+# static_links = ["abc"] # link "libabc.a" statically.
+
+## Libraries to be linked dynamically.
+## Merged with libraries specified in the command line argument.
+# dynamic_links = ["xyz"] # link "libxyz.so" dynamically.
+
+## Library search paths passed to the linker.
+## Merged with paths specified in the command line argument.
+# library_paths = ["."]
+
+## Other linker options.
+# ld_flags = ["-L/usr/lib", "-lijk"]
+
+## Whether to generate debug information.
+## Overwritten by the command line argument.
+# debug = true
+
+## Optimization level.
+## One of "none", "basic", "max".
+## Overwritten by the command line argument.
+# opt_level = "max"
+
+## Output file name.
+## Overwritten by the command line argument.
+# output = "myprogram.out"
+
+## Whether to use the thread-safe reference counting.
+## Overwritten by the command line argument.
+# threaded = false
+
+## Preliminary commands to be executed before the Fix program is compiled.
+## This is useful when you need to compile a object files / library before compiling the Fix program.
+## (Experimental) Furthermore, you can change the Fix compiler options by outputting lines with specific formats in the preliminary commands.
+## At the moment, the following formats are supported.
+## - `fix.ld_flags=(...)`: Specify flags to pass to the linker. Specify flags separated by spaces in `...`. Example: `fix.ld_flags=-L/path/to/lib -lmylib`.
+## This is useful when you need to get the path to the library dynamically, e.g., using pkg-config.
+# preliminary_commands = [["make", "lib.o"]]
+
+# Additional build options when running `fix test`.
+# Available fields are almost the same as ones in "[build]".
+[build.test]
+files = ["test.fix"]
+
+## By "[[dependencies]]" array, you can add a Fix project as a dependency.
+## Each dependency must have "fixproj.toml" file at the project root directory.
+## If a dependency also has their dependencies, "fix" will consider them recursively.
+## NOTE: The syntax for version requirement is the same as in Cargo. See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
+
+## The following is an example of a dependency to a project in the local file system.
+# [[dependencies]]
+# name = "another-project"
+# version = "*"
+# path = "/path/to/project"
+
+## The following is an example of a dependency to a project in a remote git repository.
+## In this case, "fix" searches the tags (each name should be a semver, or semver with "v" prefix) of the repository to find the version that satisfies the requirement.
+## If the repository has no tags, "fix" will use the latest commit of the default branch.
+# [[dependencies]]
+# name = "your-project"
+# version = "1.2.0"
+# git = { url = "https://github.com/tttmmmyyyy/your-project.git" }

--- a/benchmark/speedtest/cases/startup/main.fix
+++ b/benchmark/speedtest/cases/startup/main.fix
@@ -1,0 +1,9 @@
+module Main;
+
+import Std::{IO, Monad::pure};
+
+// A program that does nothing, measured like every other case. Cachegrind counts the
+// dynamic loader and the runtime's own start-up along with the work, so this column is what
+// a case's figure holds before any of its work: the micro-benchmarks are mostly this, and a
+// change to the runtime moves every case together with it.
+main : IO () = pure();

--- a/benchmark/speedtest/cases/startup/test.fix
+++ b/benchmark/speedtest/cases/startup/test.fix
@@ -1,0 +1,9 @@
+module Test;
+
+import Std::{IO, Debug::assert_eq, Monad::pure};
+
+test : IO ();
+test = (
+    assert_eq(|_|"case 1", 42, 6*7);;
+    pure()
+);

--- a/benchmark/speedtest/history.md
+++ b/benchmark/speedtest/history.md
@@ -2,6 +2,14 @@
 
 Newer is above.
 
+**Rows measured before `cachegrind.py` fixed the environment are not comparable with rows after
+it.** Cachegrind counts the dynamic loader and libc start-up along with the program, and both walk
+the environment, so a row carried about 600 instructions per variable the shell that ran the
+harness happened to export — a background run and an interactive one differed by tens of thousands
+of instructions on every case. The measured command now runs with a fixed minimal environment, and
+the `startup` case records what a program that does nothing costs, so a row says how much of each
+figure was there before any of the work.
+
 ## fd0a7ee93588a9bd19e7ec67dcbd9b7ed26586c6
 
 Opens three kinds of column: the split accesses read from the hardware counters, the processor the
@@ -50,8 +58,10 @@ wide-return tail call reached main, so `mandelbrot` and `mandelbrot_fold` fall 5
 3.33% and `cp_lib_conv_zp` 1.99% — the same three cases and the same percentages `12165c4494bf`
 records for that work.
 
-Of what is left, every micro-benchmark moves by a constant 1,253 to 1,281 instructions, which is
-program startup rather than the measured loop. Four cases move by more: `fannkuch` +1.51%,
+Of what is left, every micro-benchmark moves by a constant 1,253 to 1,281 instructions. That is
+start-up, and the constant is the difference between the environments the two runs were measured
+from — about two variables' worth, at the 600 instructions each cost before `cachegrind.py` fixed
+the environment. Four cases move by more: `fannkuch` +1.51%,
 `cp_lib_bipartite` +1.10%, `cp_lib_lsegtree` +0.57% and `binary_trees` +0.40%, from the rest of the
 work merged between the two rows.
 


### PR DESCRIPTION
Reported from the work on #128: `log.csv`'s `-inst` and `-mem` columns depended on how many variables the shell that ran the harness had exported, so rows measured from different environments could not be subtracted from each other.

Confirmed here on `sum_by_fold`, same binary and same script:

| environment | inst |
|---|--:|
| 69 variables | 248,657 |
| 369 variables | 432,701 |
| fixed | 206,383 |

That is **613 instructions per variable**. Cachegrind counts the dynamic loader and libc start-up along with the program, and both walk the environment.

## The fix

`cachegrind.py` runs the measured command with a fixed minimal environment (`PATH`, `LC_ALL=C`). The count is now identical whether the caller exported 69 variables or 369.

**Rows before this are not comparable with rows after it**, and `history.md` says so. That property was already lost between any two rows measured from different shells; this makes it hold from here on.

## What start-up costs

The `startup` case is a program that does nothing, measured like any other, so every row carries its own baseline:

| case | inst | of which start-up |
|---|--:|--:|
| `startup` | 113,647 | 100% |
| `option_plumbing` | 202,323 | 56.2% |
| `sum_by_fold` | 206,383 | 55.1% |
| `array_mod` | 410,940 | 27.7% |
| `sum_by_loop` | 814,795 | 13.9% |
| `push_back` | 1,118,223 | 10.2% |
| `fill` | 7,547,799 | 1.5% |
| `mandelbrot` | 236,832,736 | 0.0% |

Half of several micro-benchmarks was never the loop. The column also moves every case together when the runtime's own start-up changes, which tells a reader which kind of change they are looking at.

The split counters are unaffected — a longer start-up crosses no more cache lines — which the report confirmed by measurement, and which is the reason that column was worth having.

https://claude.ai/code/session_01LAa4vvmJ8KWESYposht3vX