### PR TITLE
サイクルでパスを探索し、O3 の後に効く 3 本を出荷する

### DIFF
--- a/benchmark/crosslang/.gitignore
+++ b/benchmark/crosslang/.gitignore
@@ -1,2 +1,3 @@
 bin/
 allocations.so
+bin_*/

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -37,6 +37,12 @@ METRICS = [
     ("mem", "Cachegrind memory",
      "Weighted memory-access estimate from cachegrind's cache model (l1 + 5*l3 + 35*ram).",
      "ratio", "cachegrind"),
+    ("cycles", "perf cycles",
+     "Core cycles the program spent in user mode, from the hardware counters, as the lowest of "
+     "several runs. This is the only column here that is not deterministic: it rises with whatever "
+     "else the machine is doing, so it is read only on runs taken while the machine is free and the "
+     "series is sparse. Two points are comparable only when both rows report a low load.",
+     "ratio", "perf"),
     ("splits", "perf splits",
      "Loads and stores that crossed a cache-line boundary, from the hardware counters. Cachegrind's "
      "model has no notion of these, and they cost real time; the count is deterministic and reaches "
@@ -97,6 +103,7 @@ def build_data(log_path, history_path, latest_n):
 
     index = {name.strip(): i for i, name in enumerate(header)}
     cpu_col = index.get("cpu")
+    load_col = index.get("load")
 
     commits = []
     for row in body:
@@ -110,7 +117,9 @@ def build_data(log_path, history_path, latest_n):
             matches = [k for k in history if h.startswith(k) or k.startswith(h)]
             entry = history[max(matches, key=len)] if matches else None
         cpu = row[cpu_col].strip() if cpu_col is not None and cpu_col < len(row) else ""
-        commits.append({"hash": h, "short": h[:8], "dirty": dirty, "history": entry, "cpu": cpu})
+        load = row[load_col].strip() if load_col is not None and load_col < len(row) else ""
+        commits.append({"hash": h, "short": h[:8], "dirty": dirty, "history": entry,
+                        "cpu": cpu, "load": load})
 
     # Split each "<case>-<metric>" column apart, and each "<case>-<metric>-<language>"
     # reference beside it. A reference does not move with a Fix commit, so the last value
@@ -149,9 +158,9 @@ def self_check():
     with tempfile.TemporaryDirectory() as tmp:
         log = Path(tmp) / "log.csv"
         log.write_text(
-            "commit,cpu,a-inst,a-mem,a-splits,b-inst,a-inst-c,a-inst-rust\n"
-            "1111111111111111111111111111111111111111,Zen,100,200,4,50,90,\n"
-            "2222222222222222222222222222222222222222(dirty),Zen,150,,0,,90,120\n",
+            "commit,cpu,load,a-inst,a-mem,a-splits,a-cycles,b-inst,a-inst-c,a-inst-rust\n"
+            "1111111111111111111111111111111111111111,Zen,0.10,100,200,4,7,50,90,\n"
+            "2222222222222222222222222222222222222222(dirty),Zen,,150,,0,,,90,120\n",
             encoding="utf-8",
         )
         history = Path(tmp) / "history.md"
@@ -159,13 +168,16 @@ def self_check():
         data = build_data(log, history, 40)
 
     first, second = data["commits"]
-    assert first["cpu"] == "Zen" and not first["dirty"], first
+    assert first["cpu"] == "Zen" and first["load"] == "0.10" and not first["dirty"], first
+    assert second["load"] == "", second
     assert second["dirty"] and "second commit" in second["history"], second
     assert first["history"] is None, first
     series = {k: v["series"] for k, v in data["metrics"].items()}
     assert series["inst"] == {"a": [100, 150], "b": [50, None]}, series["inst"]
     assert series["mem"] == {"a": [200, None]}, series["mem"]
     assert series["splits"] == {"a": [4, 0]}, series["splits"]
+    # Cycles are read only on the runs taken while the machine was free, so the series has gaps.
+    assert series["cycles"] == {"a": [7, None]}, series["cycles"]
     assert data["metrics"]["splits"]["kind"] == "absolute"
     assert data["metrics"]["inst"]["refs"] == {"a": {"c": 90, "rust": 120}}, data["metrics"]["inst"]["refs"]
     assert data["metrics"]["mem"]["refs"] == {}, data["metrics"]["mem"]["refs"]
@@ -371,6 +383,14 @@ function render() {
       }
     }
     el("path", { class: "series-line", stroke: s.color, d, "data-name": s.name }, lines);
+    // Mark where the series was actually measured. A metric read on only some of the commits
+    // draws a line across the gaps, which would otherwise read as a continuous measurement.
+    if (pts.length < s.values.length) {
+      s.values.forEach((v, i) => {
+        if (v !== null) el("circle", { class: "point", cx: xAt(i), cy: toY(v), r: 2.5,
+                                       fill: s.color }, lines);
+      });
+    }
     const hit = el("path", { class: "hit", d, "data-name": s.name }, lines);
     hit.addEventListener("mousemove", (ev) => hoverPoint(ev, s, xAt));
     hit.addEventListener("mouseleave", clearHover);
@@ -460,7 +480,8 @@ function clearHover() {
 function showHistory(i) {
   const c = DATA.commits[i];
   document.getElementById("history").innerHTML =
-    `<p class="commit">${c.hash}${c.dirty ? " (dirty)" : ""}${c.cpu ? "<br>" + c.cpu : ""}</p>`
+    `<p class="commit">${c.hash}${c.dirty ? " (dirty)" : ""}${c.cpu ? "<br>" + c.cpu : ""}`
+    + `${c.load ? ` at load ${c.load}` : ""}</p>`
     + (c.history || `<p class="placeholder">No note recorded for this commit.</p>`);
 }
 

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -163,7 +163,10 @@ main = (
         if line.get_bytes.@(0) == '_' { none() };
         some(line)
     );
-    let log = *dirs.fold_m(log, |dir, log|
+    // The highest load seen while the hardware counters were read, carried alongside the log
+    // so that the row can say what the machine was doing: the cycle columns mean nothing
+    // without it.
+    let (log, max_load) = *dirs.fold_m((log, 0.0), |dir, (log, max_load)|
         ez_cd(config, dir);;
         let command = ["cargo", "run", "--", "build", "-O", "experimental", "--emit-symbols", "--disable-cpu-feature", "avx512.*", "--allow-preliminary-commands"];
         let command = if args.@llvm_passes_file != "" {
@@ -189,18 +192,30 @@ main = (
         // Add to the log.
         let log = log.set(inst, log.@size - 1, bench.@(0));
         let log = log.set(mem, log.@size - 1, bench.@(1));
-        // Accesses split across a cache line, which cachegrind's cache model cannot express
-        // and which cost real time. Only this counter is recorded: it is deterministic, as
-        // every column of this log must be, while the cycle count the same tool reports
-        // rises with whatever else the machine is doing and a run takes an hour, over which
-        // that is not constant. Read cycles by hand on an idle machine instead.
-        // On a machine without the counter the column stays empty and the run carries on.
+        // Two things the instruction count cannot express. `-splits` counts loads and stores
+        // that crossed a cache-line boundary, which cost real time and which cachegrind's
+        // cache model has no notion of. `-cycles` counts what the machine actually took, so
+        // that a change to code layout or branch density -- where the instruction count and
+        // the time diverge -- shows up somewhere in this log.
+        //
+        // The split count is deterministic like every cachegrind column here. **The cycle
+        // count is not**: it is the lowest of several runs, and it rises with whatever else
+        // the machine is doing, so two rows are comparable on it only when both were taken on
+        // a quiet machine. The `load` column below is how a reader tells.
+        // On a machine without the counters both columns stay empty and the run carries on.
         let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "./a.out"].ez_run_oec(config);
-        let log = if perf_code != 0_U8 { log } else {
+        let (log, case_load) = if perf_code != 0_U8 { (log, 0.0) } else {
             let perf = perf.strip_spaces.split(",").to_array;
-            if perf.@(0) == "" { log };
-            log.set(case_name + "-splits", log.@size - 1, perf.@(0))
+            if perf.@(0) == "" { (log, 0.0) };
+            let log = log.set(case_name + "-splits", log.@size - 1, perf.@(0));
+            let log = log.set(case_name + "-cycles", log.@size - 1, perf.@(1));
+            // A load the harness cannot read leaves the row's `load` at whatever the other
+            // cases reported, which is the honest reading: this case contributed nothing.
+            let parsed : Result _ F64 = perf.@(2).from_string;
+            let case_load = if parsed.is_err { 0.0 } else { parsed.as_ok };
+            (log, case_load)
         };
+        let max_load = max(max_load, case_load);
         // A case may carry `ref.c` and `ref.rs`: the same program on the same input,
         // measured the same way, so the chart can show how far the Fix line is from C and
         // Rust. The column name keeps the language last, which is what holds these out of
@@ -216,10 +231,12 @@ main = (
         );
         // Change back to the parent directory.
         ez_cd(config, "..");;
-        log.pure
+        (log, max_load).pure
     );
 
     ez_cd(config, "..");;
+
+    let log = log.set("load", log.@size - 1, max_load.to_string_precision(2_U8));
 
     // Save the log to the log file.
     unless(args.@no_save,

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -85,6 +85,10 @@ namespace CSV {
 type Args = struct {
     no_save : Bool,
     llvm_passes_file: String,
+    // Whether to read the cycle counter as well. Off by default: a cycle count taken while the
+    // machine is busy is not comparable with one taken while it is idle, so the column is filled
+    // only on the runs whose operator knows the machine is free, and the series is sparse.
+    cycles : Bool,
 };
 
 namespace Args {
@@ -92,6 +96,7 @@ namespace Args {
     default = Args {
         no_save: false,
         llvm_passes_file: "",
+        cycles: false,
     };
 }
 
@@ -104,6 +109,8 @@ main = (
         if i >= raw_args.@size { break $ args };
         if raw_args.@(i) == "--no-save" {
             continue $ (i + 1, args.set_no_save(true))
+        } else if raw_args.@(i) == "--cycles" {
+            continue $ (i + 1, args.set_cycles(true))
         } else if raw_args.@(i) == "--llvm-passes-file" {
             if i + 1 >= raw_args.@size {
                 undefined("error: --llvm-passes-file requires a file path argument")
@@ -198,17 +205,20 @@ main = (
         // that a change to code layout or branch density -- where the instruction count and
         // the time diverge -- shows up somewhere in this log.
         //
-        // The split count is deterministic like every cachegrind column here. **The cycle
-        // count is not**: it is the lowest of several runs, and it rises with whatever else
-        // the machine is doing, so two rows are comparable on it only when both were taken on
-        // a quiet machine. The `load` column below is how a reader tells.
+        // The split count is deterministic like every cachegrind column here, so it is read on
+        // every run. **The cycle count is not**, so it is read only under `--cycles`, and the
+        // `load` column records what the machine was doing while it was: two rows are
+        // comparable on cycles only when both were taken on a quiet machine.
         // On a machine without the counters both columns stay empty and the run carries on.
-        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "./a.out"].ez_run_oec(config);
+        let repeat = if args.@cycles { "5" } else { "1" };
+        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--repeat", repeat, "./a.out"].ez_run_oec(config);
         let (log, case_load) = if perf_code != 0_U8 { (log, 0.0) } else {
             let perf = perf.strip_spaces.split(",").to_array;
             if perf.@(0) == "" { (log, 0.0) };
             let log = log.set(case_name + "-splits", log.@size - 1, perf.@(0));
-            let log = log.set(case_name + "-cycles", log.@size - 1, perf.@(1));
+            let log = if args.@cycles {
+                log.set(case_name + "-cycles", log.@size - 1, perf.@(1))
+            } else { log };
             // A load the harness cannot read leaves the row's `load` at whatever the other
             // cases reported, which is the honest reading: this case contributed nothing.
             let parsed : Result _ F64 = perf.@(2).from_string;

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -1,24 +1,31 @@
 """Run a program under `perf stat` and print the counters cachegrind cannot express.
 
-Prints one line, `<splits>,<cycles>`: loads and stores that crossed a cache-line
-boundary, and user-space cycles. Cachegrind's cache model counts references and
-misses and has no notion of a line-crossing access, yet those cost real time -- an
-array whose elements start 8 bytes into a 16-byte-aligned allocation splits half of
-its 32-byte accesses.
+Prints one line, `<splits>,<cycles>,<load>`: loads and stores that crossed a cache-line
+boundary, user-space core cycles, and the highest one-minute load average seen while
+measuring. Cachegrind's cache model counts references and misses and has no notion of a
+line-crossing access, yet those cost real time -- an array whose elements start 8 bytes
+into a 16-byte-aligned allocation splits half of its 32-byte accesses. And an instruction
+count says nothing about how fast the machine gets through those instructions, which is
+where a change to code layout or branch density shows up.
+
+The split count is deterministic; the cycle count is not, so it is the minimum over
+`--repeat` runs and the load is reported beside it. **Two cycle figures are comparable only
+when both were taken on a quiet machine**, which the load column is there to show.
 
 Exits non-zero when the counters are unavailable (no hardware PMU, or
-`kernel.perf_event_paranoid` above 2), so a caller can leave the columns empty
-instead of failing.
+`kernel.perf_event_paranoid` above 2) or when the PMU had to time-slice them, so a caller
+can leave the columns empty instead of logging an estimate.
 
-    python3 perf_counters.py ./a.out [args...]
+    python3 perf_counters.py [--repeat N] ./a.out [args...]
+    python3 perf_counters.py --cpu
 """
 
+import os
 import subprocess
 import sys
 
-# Two counters per run: the split accesses, and cycles as a diagnostic. Keeping the
-# list short matters -- asking for more events than the PMU has counters makes perf
-# time-slice them and report scaled estimates.
+# Three counters per run. Keeping the list short matters -- asking for more events than the
+# PMU has counters makes perf time-slice them and report scaled estimates.
 SPLIT_EVENTS = ["mem_inst_retired.split_loads", "mem_inst_retired.split_stores"]
 CYCLE_EVENT = "cycles:u"
 
@@ -46,8 +53,49 @@ def read_counters(argv):
             continue
         # perf appends `:u` to the event name when it may only count user space.
         name = fields[2].strip().removesuffix(":u")
+        # Field 5 is the percentage of the run the event was actually on a counter. Below
+        # 100 the PMU time-sliced the events and perf scaled the count up to compensate, so
+        # what it prints is an estimate that looks like any other measurement.
+        if len(fields) >= 5 and fields[4].strip():
+            try:
+                if float(fields[4]) < 100.0:
+                    sys.exit(f"perf could keep {name} on a counter for only "
+                             f"{fields[4].strip()}% of the run, so its count is an estimate")
+            except ValueError:
+                pass
         found[name] = int(fields[0])
     return found, proc.stderr
+
+
+def measure(argv, repeat):
+    """The split count, the lowest cycle count over `repeat` runs, and the highest load seen.
+
+    The run with the fewest cycles is the one the rest of the machine disturbed least. The
+    split count comes from the same runs and has to agree across them, since it counts
+    retired instructions of a kind and nothing about the machine's state can change it.
+    """
+    splits = None
+    cycles = None
+    load = 0.0
+    for _ in range(repeat):
+        load = max(load, os.getloadavg()[0])
+        found, report = read_counters(argv)
+        missing = [e for e in SPLIT_EVENTS + [CYCLE_EVENT.removesuffix(":u")]
+                   if e not in found]
+        if missing:
+            # Say which of the two it was: the program never ran, or the counters are out
+            # of reach.
+            sys.exit(f"perf reported none of {', '.join(missing)}. perf said:\n"
+                     + report.strip())
+        run_splits = sum(found[e] for e in SPLIT_EVENTS)
+        if splits is None:
+            splits = run_splits
+        elif run_splits != splits:
+            sys.exit(f"the split count changed between runs of the same program "
+                     f"({splits} then {run_splits}), so one of them is not a measurement")
+        run_cycles = found[CYCLE_EVENT.removesuffix(":u")]
+        cycles = run_cycles if cycles is None else min(cycles, run_cycles)
+    return splits, cycles, load
 
 
 def cpu_model():
@@ -63,19 +111,19 @@ def cpu_model():
 
 
 def main():
-    if len(sys.argv) == 2 and sys.argv[1] == "--cpu":
+    argv = sys.argv[1:]
+    if argv == ["--cpu"]:
         print(cpu_model())
         return
-    if len(sys.argv) < 2:
-        sys.exit("usage: perf_counters.py <program> [args...]\n"
+    repeat = 5
+    if len(argv) >= 2 and argv[0] == "--repeat":
+        repeat = int(argv[1])
+        argv = argv[2:]
+    if not argv:
+        sys.exit("usage: perf_counters.py [--repeat N] <program> [args...]\n"
                  "       perf_counters.py --cpu")
-    found, report = read_counters(sys.argv[1:])
-    missing = [e for e in SPLIT_EVENTS + [CYCLE_EVENT.removesuffix(":u")] if e not in found]
-    if missing:
-        # Say which of the two it was: the program never ran, or the counters are out of reach.
-        sys.exit(f"perf reported none of {', '.join(missing)}. perf said:\n" + report.strip())
-    splits = sum(found[e] for e in SPLIT_EVENTS)
-    print(f"{splits},{found[CYCLE_EVENT.removesuffix(':u')]}")
+    splits, cycles, load = measure(argv, repeat)
+    print(f"{splits},{cycles},{load:.2f}")
 
 
 main()

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -1,37 +1,92 @@
-from math import ceil
-import select
-import subprocess
-import re
-import itertools
-import sys
-import random
-from statsmodels.stats.weightstats import ttest_ind
-import numpy as np
+"""Searches for an LLVM pass pipeline that runs the benchmark cases in fewer cycles.
+
+The objective is `cycles:u`, the core cycles a program spends in user mode, rather than the
+instruction count `benchmark/speedtest` tracks. The two disagree often enough to send a search the
+wrong way: appending the twelve passes the compiler used to ship costs `levenshtein` 2.4% of its
+instructions while saving 0.4% of its cycles, and saves `fannkuch_scratch` 2.2% of its cycles while
+leaving its instruction count where it was. What a pass changes is usually the shape of the code —
+where the branches fall, how the front end fetches it — which the instruction count cannot see.
+
+Cycles are not deterministic, so the measurement is built to survive that:
+
+- A candidate is always measured **against the incumbent in the same run**, alternating between the
+  two binaries, so that whatever else the machine is doing lands on both.
+- Each figure is the **minimum** over several rounds — the round least disturbed by the rest of the
+  machine.
+- A candidate has to beat the incumbent by more than `IMPROVEMENT`, which sits above the noise the
+  `--noise` mode measures, so that noise alone cannot promote a pipeline.
+
+Perf costs about as much as running the program, where cachegrind costs fifty times that, so the
+search covers far more candidates per hour than the instruction-count version did.
+
+    python3 passes_optimizer.py            # search until a line is typed on stdin
+    python3 passes_optimizer.py --noise    # measure the noise floor and exit
+
+The pipeline the compiler ships lives in `Configuration::llvm_passes`; adopting a result means
+editing that. The file this hands to `--llvm-passes-file` is the complete pipeline — it replaces the
+passes the optimization level implies, so a candidate lists every pass it wants run.
+"""
+
 import math
-import datetime
+import os
+import random
+import re
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
 
-# The file handed to `--llvm-passes-file` is the complete pipeline: it replaces the passes the
-# optimization level implies, so a candidate has to list every pass it wants run.
-LLVM_PASSES_TMP_FILE = 'llvm_passes_tmp.txt'
+REPO = Path(__file__).resolve().parent
+CASES_DIR = REPO / "benchmark/speedtest/cases"
+FIX = REPO / "target/release/fix"
+LOG_FILE = REPO / "passes_optimizer.log"
 
-# Where the best sequence found so far is recorded. The compiler's own pipeline lives in
-# `Configuration::llvm_passes`, so adopting a result means editing that.
-LLVM_PASSES_BEST_FILE = 'llvm_passes_best.txt'
+# Where the best sequence found so far is recorded.
+LLVM_PASSES_BEST_FILE = REPO / "llvm_passes_best.txt"
 
 # The pipeline the compiler ships, which the search starts from. Must stay in sync with
-# `LLVM_O3_PIPELINE` and `LLVM_O3_RUNS_FOR_SPEED` in `src/configuration.rs`.
-INITIAL_PASSES = ['default<O3>'] * 3
+# `LLVM_O3_PIPELINE` x `LLVM_O3_RUNS_FOR_SPEED` in `src/configuration.rs`.
+INITIAL_PASSES = ["default<O3>"] * 3
 
-LOG_FILE = 'passes_optimizer.log'
+# The cases the search optimizes. Each runs long enough that process start-up is lost in it, and
+# together they cover array loops, allocation, recursion, floating point and string work.
+SEARCH_CASES = [
+    "arrayrw", "binary_trees", "fannkuch", "fannkuch_scratch", "fib", "levenshtein",
+    "mandelbrot", "nbody", "sort", "cp_lib_lsegtree",
+]
 
+# Measured only when a candidate becomes the new optimum, and never used to choose one. A pipeline
+# that wins on the search cases and loses on these was fitted to the search cases.
+HOLDOUT_CASES = ["cp_lib_scc", "cp_lib_dijkstra", "cp_lib_segtree", "nbody_fold", "get_sub"]
+
+# Rounds of the alternating measurement. The minimum over this many is what a figure reports.
+ROUNDS = 12
+
+# How much a candidate has to win by, as a ratio of the geometric mean of its per-case cycle counts
+# to the incumbent's, and it has to win by that twice over independent rounds before it is promoted.
+# Three runs of `--noise` — two builds of one pipeline, so every difference is noise — put the
+# geometric mean within 0.07% of 1, with single cases reaching 0.6%. One confirmation at 0.3% is
+# already four times that spread, and requiring a second is what keeps a long search from promoting
+# the one candidate in a hundred that drew a good pair of rounds.
+IMPROVEMENT = 0.997
+
+# Up to this many passes are appended in one add phase.
 ADDED_PASSES_NUM = 10
 
-# All passes
-# Can be found in: "opt --print-passes"
-# See also: https://gist.github.com/gingerBill/d889ae03d429653a4a9081ad6dc2a6c3
-# Exclude:
-# attributor, attributor-cgscc, unify-loop-exits: may breaks the program
+# The measured command gets a fixed environment, so that start-up costs the same whatever shell the
+# search was launched from.
+MEASURE_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C"}
+
+# Candidate passes, from `opt --print-passes`. See also:
+# https://gist.github.com/gingerBill/d889ae03d429653a4a9081ad6dc2a6c3
+# Excluded because they may break the program: attributor, attributor-cgscc, unify-loop-exits.
+# `reg2mem` is excluded as well: the allocas it introduces escape into indirect tail calls, which
+# costs the program its guaranteed tail calls and overflows the stack.
 PASSES = '''
+default<O3>
 aa-eval
 adce
 add-discriminators
@@ -44,35 +99,23 @@ argpromotion
 assume-builder
 assume-simplify
 bdce
-bounds-checking
 break-crit-edges
 called-value-propagation
 callsite-splitting
 canon-freeze
 canonicalize-aliases
-check-debugify
 chr
 consthoist
 constmerge
 constraint-elimination
-coro-cleanup
-coro-early
-coro-elide
-coro-split
 correlated-propagation
-count-visits
-cross-dso-cfi
 dce
 deadargelim
-declare-to-assign
 dfa-jump-threading
 div-rem-pairs
 dse
 early-cse
-ee-instrument
 elim-avail-extern
-extract-blocks
-fix-irreducible
 flattencfg
 float2int
 forceattrs
@@ -84,7 +127,6 @@ guard-widening
 gvn
 gvn-hoist
 gvn-sink
-hardware-loops
 hotcoldsplit
 indvars
 infer-address-spaces
@@ -94,27 +136,20 @@ inline
 inliner-wrapper
 inliner-wrapper-no-mandatory-first
 instcombine
-instcount
-instnamer
-instrorderfile
-instrprof
 instsimplify
 internalize
 irce
 iroutliner
 jump-threading
-kcfi
 lcssa
 libcalls-shrinkwrap
 licm
-lint
 lnicm
 load-store-vectorizer
 loop-bound-split
 loop-data-prefetch
 loop-deletion
 loop-distribute
-loop-extract
 loop-flatten
 loop-fusion
 loop-idiom
@@ -136,50 +171,25 @@ loop-versioning
 loop-versioning-licm
 lower-constant-intrinsics
 lower-expect
-lower-global-dtors
 lower-guard-intrinsic
-lower-ifunc
 lower-matrix-intrinsics
 lower-widenable-condition
-loweratomic
-lowerinvoke
-lowerswitch
-lowertypetests
-make-guards-explicit
 mem2reg
 memcpyopt
 mergefunc
 mergeicmps
 mergereturn
-metarenamer
 mldst-motion
-module-inline
 move-auto-init
-name-anon-globals
 nary-reassociate
 newgvn
-no-op-cgscc
-no-op-function
-no-op-loop
-no-op-loopnest
-no-op-module
-pa-eval
 partial-inliner
 partially-inline-libcalls
-place-safepoints
-poison-checking
-pseudo-probe
-pseudo-probe-update
 reassociate
 recompute-globalsaa
 redundant-dbg-inst-elim
-reg2mem
 rel-lookup-table-converter
-rewrite-statepoints-for-gc
-rewrite-symbols
 rpo-function-attrs
-sancov-module
-sanmd-module
 scalarize-masked-mem-intrin
 scalarizer
 scc-oz-module-inliner
@@ -193,198 +203,183 @@ slsr
 speculative-execution
 sroa
 strip-dead-prototypes
-structurizecfg
-synthetic-counts-propagation
 tailcallelim
 tlshoist
-transform-warning
 typepromotion
 vector-combine
-wholeprogramdevirt
 '''
 
 
-class BenchmarkResult:
-    def __init__(self, scores):
-        self.scores = scores
-
-    def __str__(self):
-        sum_scores = sum(self.scores)
-        return f'BenchmarkResult(sum_scores={sum_scores})'
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __lt__(self, other):
-        """
-        True iff prod(self.scores / other.scores) < 0.999
-        """
-        if len(self.scores) != len(other.scores):
-            raise ValueError(
-                "self.scores and other.scores must have the same length.")
-
-        ratios = [s / o for s, o in zip(self.scores, other.scores)]
-
-        product_of_ratios = math.prod(ratios)
-
-        return product_of_ratios < 0.999
+def all_passes():
+    """Every pass the search may add, one per line of `PASSES`."""
+    return [p for p in (line.strip() for line in PASSES.split("\n")) if p]
 
 
-def get_all_passes():
-    # The whole O3 pipeline is a candidate alongside the individual passes: the minimize phase can
-    # drop one of the runs the search starts from, so the add phase has to be able to put one back.
-    passes = list(INITIAL_PASSES[:1])
-    for p in PASSES.split('\n'):
-        if len(p.strip()) > 0:
-            passes.append(p)
-    return passes
+def build(passes, cases, out_dir):
+    """Builds each case with `passes` as its whole pipeline, into `out_dir`.
 
-
-def write_llvm_passes_file(passes, file_type):
-    if file_type == 'best':
-        path = LLVM_PASSES_BEST_FILE
-    elif file_type == 'tmp':
-        path = LLVM_PASSES_TMP_FILE
-    else:
-        # Print error message
-        print('Invalid file type: {}'.format(file_type))
-        exit(1)
-
-    print('Writing passes to {}'.format(path))
-    with open(path, 'w') as f:
-        for p in passes:
-            f.write(p)
-            f.write('\n')
-
-
-def install_fix():
-    subprocess.run(['cargo', 'install', '--locked',
-                   '--path', '.'], capture_output=True)
-
-
-def run_benchmark(timeout=240):
-    work_dir = "./benchmark/speedtest"
-    llvm_passes_file_path = '../../' + LLVM_PASSES_TMP_FILE
-
-    try:
-        proc = subprocess.run(['./a.out', '--no-save', '--llvm-passes-file', llvm_passes_file_path],
-                            capture_output=True, text=True, timeout=timeout, cwd=work_dir)
-        if proc.returncode != 0:
-            print('run failed.')
-            print('stdout:')
-            print(proc.stdout)
-            print('stderr:')
-            print(proc.stderr)
+    Returns the case-to-binary map, or `None` when any case fails to build — a pipeline that cannot
+    compile the suite is out of the running, and reporting which case broke is what tells the
+    searcher whether the pass or the program is at fault.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    passes_file = out_dir / "passes.txt"
+    passes_file.write_text("\n".join(passes) + "\n")
+    binaries = {}
+    for case in cases:
+        binary = out_dir / case
+        result = subprocess.run(
+            [str(FIX), "build", "-f", "main.fix", "-O", "experimental",
+             "--allow-preliminary-commands", "--llvm-passes-file", str(passes_file),
+             "-o", str(binary)],
+            cwd=CASES_DIR / case, capture_output=True)
+        if result.returncode != 0 or not binary.exists():
+            print(f"  {case} failed to build: "
+                  f"{result.stderr.decode()[-200:].strip()}", flush=True)
             return None
-        else:
-            # The commit hash, then one number per cachegrind column.
-            # (must stay in sync with the line `benchmark/speedtest/main.fix` prints)
-            costs = proc.stdout.strip().split(',')
-            print('Benchmark result:', costs)
-            return BenchmarkResult([float(x) for x in costs[1:]])
-
-    except subprocess.TimeoutExpired:
-        print('run timed out.')
-        return None
+        binaries[case] = binary
+    return binaries
 
 
-def print_passes(passes):
-    print('  ' + ', '.join(passes), flush=True)
+def cycles(binary):
+    """User-mode core cycles for one run of `binary`, with ASLR off."""
+    arch = subprocess.check_output(["uname", "-m"]).decode().strip()
+    result = subprocess.run(
+        ["setarch", arch, "-R", "perf", "stat", "-x,", "-e", "cycles:u", "--", str(binary)],
+        env=MEASURE_ENV, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+    for line in result.stderr.decode().splitlines():
+        field = line.split(",")[0]
+        if re.fullmatch(r"\d+", field):
+            return int(field)
+    raise RuntimeError(f"no cycle count for {binary}: {result.stderr.decode()!r}")
 
 
-def add_log(phase, time, passes):
-    with open(LOG_FILE, 'a') as f:
-        f.write(f'{phase},{time},"{",".join(passes)}"\n')
+def compare(candidate, incumbent, rounds=ROUNDS):
+    """Cycles of `candidate` against `incumbent`, per case and as a geometric mean.
+
+    The two are run alternately within each round, so a change in what else the machine is doing
+    reaches both; each case's figure is its minimum over the rounds.
+    """
+    cases = sorted(candidate)
+    best = {case: {"candidate": math.inf, "incumbent": math.inf} for case in cases}
+    for _ in range(rounds):
+        for case in cases:
+            for label, binaries in (("candidate", candidate), ("incumbent", incumbent)):
+                best[case][label] = min(best[case][label], cycles(binaries[case]))
+    ratios = {case: best[case]["candidate"] / best[case]["incumbent"] for case in cases}
+    geomean = math.exp(sum(math.log(r) for r in ratios.values()) / len(ratios))
+    return geomean, ratios
 
 
-def optimize():
-    install_fix()
+def report(geomean, ratios, threshold=0.005):
+    """Prints the per-case ratios that moved, then the geometric mean."""
+    for case, ratio in sorted(ratios.items(), key=lambda kv: kv[1]):
+        if abs(ratio - 1) >= threshold:
+            print(f"    {case:<20}{(ratio - 1) * 100:+7.2f}%")
+    print(f"    {'geometric mean':<20}{(geomean - 1) * 100:+7.2f}%", flush=True)
 
-    all_passes = get_all_passes()
 
-    optimum_passes = list(INITIAL_PASSES)
+def measure_noise(work_dir):
+    """Builds the shipped pipeline twice and compares the two, which have identical code.
 
-    # Add the date and time to the log file
-    with open(LOG_FILE, 'a') as f:
-        f.write(f'Start optimization: {datetime.datetime.now()}\n')
+    Whatever this reports is measurement noise, so `IMPROVEMENT` has to sit outside it.
+    """
+    print("Building the shipped pipeline twice to measure the noise floor.")
+    first = build(INITIAL_PASSES, SEARCH_CASES, work_dir / "noise_a")
+    second = build(INITIAL_PASSES, SEARCH_CASES, work_dir / "noise_b")
+    if first is None or second is None:
+        sys.exit("the shipped pipeline failed to build")
+    geomean, ratios = compare(first, second)
+    print(f"  noise floor over {ROUNDS} rounds (two builds of one pipeline):")
+    report(geomean, ratios, threshold=0.0)
+    print(f"  IMPROVEMENT is {IMPROVEMENT}, i.e. {(IMPROVEMENT - 1) * 100:+.2f}%")
 
-    print('Initial passes:')
-    print_passes(optimum_passes)
 
-    write_llvm_passes_file(optimum_passes, 'tmp')
-    optimum_time = run_benchmark()
-    if optimum_time is None:
-        print('Initial benchmark failed.')
-        sys.exit(1)
+def log(phase, geomean, passes):
+    with open(LOG_FILE, "a") as f:
+        f.write(f'{phase},{geomean:.5f},"{",".join(passes)}"\n')
+
+
+def interrupted():
+    """True once a line has been typed on stdin, which is how the search is stopped."""
+    readable, _, _ = select.select([sys.stdin], [], [], 0)
+    return bool(readable and sys.stdin.readline().strip())
+
+
+def optimize(work_dir):
+    pool = all_passes()
+    optimum = list(INITIAL_PASSES)
+    optimum_dir = work_dir / "optimum"
+    optimum_binaries = build(optimum, SEARCH_CASES, optimum_dir)
+    if optimum_binaries is None:
+        sys.exit("the starting pipeline failed to build")
+
+    with open(LOG_FILE, "a") as f:
+        f.write(f"Start optimization at {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+    print("Starting from:", ", ".join(optimum))
 
     phase = 0
-
-    while True:
-        # If any character with newline is pressed, break the loop
-        readable, _, _ = select.select([sys.stdin], [], [], 0.1)
-        if readable:
-            user_input = sys.stdin.readline().strip()
-            if len(user_input) > 0:
-                break
-
-        # add passes
-        print(f'\nPhase {phase}:')
+    while not interrupted():
         phase += 1
-        added_passes_count = random.randint(1, ADDED_PASSES_NUM)
-        added_passes = []
-        for _ in range(added_passes_count):
-            idx = random.randint(0, len(all_passes)-1)
-            added_passes.append(all_passes[idx])
-        print('Try adding passes:')
-        print_passes(added_passes)
-        passes = optimum_passes.copy()
-        for p in added_passes:
-            passes.append(p)
-        write_llvm_passes_file(passes, 'tmp')
-        time = run_benchmark()
-        if time is not None and time < optimum_time:
-            optimum_passes = passes
-            optimum_time = time
-            print('New optimum passes found!')
-            add_log(phase, time, passes)
-            # Record the best sequence found so far
-            write_llvm_passes_file(passes, 'best')
+        # Alternate between adding passes and dropping one, so that the pipeline can grow toward a
+        # win and then shed whatever turned out not to be carrying it.
+        if phase % 2 == 1:
+            added = [random.choice(pool) for _ in range(random.randint(1, ADDED_PASSES_NUM))]
+            candidate = optimum + added
+            print(f"\nPhase {phase}: adding {', '.join(added)}")
         else:
-            print('No improvement found.')
+            if len(optimum) <= 1:
+                continue
+            dropped = random.randrange(len(optimum))
+            candidate = optimum[:dropped] + optimum[dropped + 1:]
+            print(f"\nPhase {phase}: dropping {optimum[dropped]}")
 
-        # minimize passes
-
-        # Remove one pass randomly
-        remove_idx = random.randint(0, len(optimum_passes) - 1)
-        removed_passes = [optimum_passes[remove_idx]]
-        passes = [optimum_passes[i]
-                  for i in range(len(optimum_passes)) if i != remove_idx]
-
-        # If no passes are removed, skip the minimize phase.
-        if removed_passes == []:
+        candidate_dir = work_dir / f"candidate{phase}"
+        candidate_binaries = build(candidate, SEARCH_CASES, candidate_dir)
+        if candidate_binaries is None:
+            shutil.rmtree(candidate_dir, ignore_errors=True)
             continue
 
-        print(f'\nPhase {phase}:')
-        phase += 1
-        print('Try removing passes:')
-        print_passes(removed_passes)
-        write_llvm_passes_file(passes, 'tmp')
-        time = run_benchmark()
-        if time is not None and not (time > optimum_time):
-            optimum_passes = passes
-            optimum_time = time
-            print('Minimize success!')
-            add_log(phase, time, passes)
-            # Record the best sequence found so far
-            write_llvm_passes_file(passes, 'best')
-        else:
-            print('Minimize failed.')
+        geomean, ratios = compare(candidate_binaries, optimum_binaries)
+        report(geomean, ratios)
+        # A dropped pass is kept out on a tie: a shorter pipeline that measures the same is the
+        # better one, and it gives the next add phase room.
+        accepted = geomean < IMPROVEMENT if phase % 2 == 1 else geomean <= 1.0
+        if accepted and phase % 2 == 1:
+            confirm_geomean, confirm_ratios = compare(candidate_binaries, optimum_binaries)
+            print("  confirming:")
+            report(confirm_geomean, confirm_ratios)
+            accepted = confirm_geomean < IMPROVEMENT
+        if not accepted:
+            shutil.rmtree(candidate_dir, ignore_errors=True)
+            continue
 
-        # print current optimum
-        print('Current optimum passes:')
-        print_passes(optimum_passes)
-        print('Current optimum cost: {}'.format(optimum_time))
+        print("  accepted", flush=True)
+        holdout = build(candidate, HOLDOUT_CASES, candidate_dir / "holdout")
+        holdout_incumbent = build(optimum, HOLDOUT_CASES, optimum_dir / "holdout")
+        if holdout is not None and holdout_incumbent is not None:
+            holdout_geomean, holdout_ratios = compare(holdout, holdout_incumbent)
+            print("  held-out cases (not used to choose):")
+            report(holdout_geomean, holdout_ratios)
+
+        shutil.rmtree(optimum_dir, ignore_errors=True)
+        optimum, optimum_dir, optimum_binaries = candidate, candidate_dir, candidate_binaries
+        log(phase, geomean, optimum)
+        LLVM_PASSES_BEST_FILE.write_text("\n".join(optimum) + "\n")
+        print("  current optimum:", ", ".join(optimum), flush=True)
 
 
-if __name__ == '__main__':
-    optimize()
+def main():
+    if not FIX.exists():
+        sys.exit(f"no fix binary at {FIX} -- build one with `cargo build --release`")
+    with tempfile.TemporaryDirectory(prefix="passes_optimizer_") as tmp:
+        work_dir = Path(tmp)
+        if "--noise" in sys.argv:
+            measure_noise(work_dir)
+            return
+        print(f"Type a line and press enter to stop. Load is {os.getloadavg()[0]:.2f}; "
+              f"cycles are worth measuring on a quiet machine.")
+        optimize(work_dir)
+
+
+main()

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -19,8 +19,13 @@ Cycles are not deterministic, so the measurement is built to survive that:
 Perf costs about as much as running the program, where cachegrind costs fifty times that, so the
 search covers far more candidates per hour than the instruction-count version did.
 
-    python3 passes_optimizer.py            # search until a line is typed on stdin
-    python3 passes_optimizer.py --noise    # measure the noise floor and exit
+    python3 passes_optimizer.py                 # search until a line is typed on stdin
+    python3 passes_optimizer.py --noise         # measure the noise floor and exit
+    python3 passes_optimizer.py --start <file>  # search from the pipeline in <file>
+
+Starting from a pipeline that is already known to win lets the drop phases say which of its
+passes carry that win, which is what a search from the shipped pipeline cannot reach: adding
+passes at random on top of a full `default<O3>` almost never moves anything.
 
 The pipeline the compiler ships lives in `Configuration::llvm_passes`; adopting a result means
 editing that. The file this hands to `--llvm-passes-file` is the complete pipeline — it replaces the
@@ -306,9 +311,9 @@ def interrupted():
     return bool(readable and sys.stdin.readline().strip())
 
 
-def optimize(work_dir):
+def optimize(work_dir, start):
     pool = all_passes()
-    optimum = list(INITIAL_PASSES)
+    optimum = list(start)
     optimum_dir = work_dir / "optimum"
     optimum_binaries = build(optimum, SEARCH_CASES, optimum_dir)
     if optimum_binaries is None:
@@ -377,9 +382,14 @@ def main():
         if "--noise" in sys.argv:
             measure_noise(work_dir)
             return
+        start = list(INITIAL_PASSES)
+        if "--start" in sys.argv:
+            start_file = Path(sys.argv[sys.argv.index("--start") + 1])
+            start = [line.strip() for line in start_file.read_text().splitlines()
+                     if line.strip()]
         print(f"Type a line and press enter to stop. Load is {os.getloadavg()[0]:.2f}; "
               f"cycles are worth measuring on a quiet machine.")
-        optimize(work_dir)
+        optimize(work_dir, start)
 
 
 main()

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -321,7 +321,7 @@ def optimize(work_dir, start):
 
     with open(LOG_FILE, "a") as f:
         f.write(f"Start optimization at {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-    print("Starting from:", ", ".join(optimum))
+    print("Starting from:", ", ".join(optimum), flush=True)
 
     phase = 0
     while not interrupted():
@@ -331,13 +331,13 @@ def optimize(work_dir, start):
         if phase % 2 == 1:
             added = [random.choice(pool) for _ in range(random.randint(1, ADDED_PASSES_NUM))]
             candidate = optimum + added
-            print(f"\nPhase {phase}: adding {', '.join(added)}")
+            print(f"\nPhase {phase}: adding {', '.join(added)}", flush=True)
         else:
             if len(optimum) <= 1:
                 continue
             dropped = random.randrange(len(optimum))
             candidate = optimum[:dropped] + optimum[dropped + 1:]
-            print(f"\nPhase {phase}: dropping {optimum[dropped]}")
+            print(f"\nPhase {phase}: dropping {optimum[dropped]}", flush=True)
 
         candidate_dir = work_dir / f"candidate{phase}"
         candidate_binaries = build(candidate, SEARCH_CASES, candidate_dir)
@@ -388,7 +388,7 @@ def main():
             start = [line.strip() for line in start_file.read_text().splitlines()
                      if line.strip()]
         print(f"Type a line and press enter to stop. Load is {os.getloadavg()[0]:.2f}; "
-              f"cycles are worth measuring on a quiet machine.")
+              f"cycles are worth measuring on a quiet machine.", flush=True)
         optimize(work_dir, start)
 
 

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -53,8 +53,10 @@ LOG_FILE = REPO / "passes_optimizer.log"
 LLVM_PASSES_BEST_FILE = REPO / "llvm_passes_best.txt"
 
 # The pipeline the compiler ships, which the search starts from. Must stay in sync with
-# `LLVM_O3_PIPELINE` x `LLVM_O3_RUNS_FOR_SPEED` in `src/configuration.rs`.
-INITIAL_PASSES = ["default<O3>"] * 3
+# `LLVM_O3_PIPELINE`, `LLVM_O3_RUNS_FOR_SPEED` and `LLVM_TAIL_PASSES` in `src/configuration.rs`.
+INITIAL_PASSES = ["default<O3>"] * 3 + [
+    "speculative-execution", "loop-vectorize", "pseudo-probe",
+]
 
 # The cases the search optimizes. Each runs long enough that process start-up is lost in it, and
 # together they cover array loops, allocation, recursion, floating point and string work.

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -30,10 +30,19 @@ const LLVM_O3_PIPELINE: &str = "default<O3>";
 /// One run leaves work that a second and a third still find: over `benchmark/speedtest`, the
 /// second run takes 2.2% of the instructions off and the third another 0.8%, reaching 21% on
 /// `nbody`. A fourth run changes no case by a single instruction.
-///
-/// `INITIAL_PASSES` in `passes_optimizer.py` starts its search from this pipeline, and must stay in
-/// sync with it.
 const LLVM_O3_RUNS_FOR_SPEED: usize = 3;
+
+/// Passes run after the `default<O3>` rounds at the optimization levels built for speed.
+///
+/// The three together take 0.80% off the cycle counts of the fifteen benchmark cases —
+/// `get_sub` 4.4%, `fib` 4.4%, `cp_lib_dijkstra` 2.8%, `levenshtein` 2.2% — against 2.0% back on
+/// `cp_lib_lsegtree` and 1.5% on `cp_lib_segtree`. **The three are one unit**: none of them earns
+/// that alone, and `pseudo-probe` on its own costs 0.48%. What they change is the shape of the
+/// code rather than the work it does, which is why the instruction count barely moves.
+///
+/// `passes_optimizer.py` searches for this list and starts from it, so `INITIAL_PASSES` there
+/// must stay in sync with this and `LLVM_O3_RUNS_FOR_SPEED`.
+const LLVM_TAIL_PASSES: [&str; 3] = ["speculative-execution", "loop-vectorize", "pseudo-probe"];
 
 /// Appends a hash of `items` to `data`, for a hash source that concatenates several lists.
 ///
@@ -683,14 +692,15 @@ impl Configuration {
         if let Some(passes) = &self.llvm_passes_override {
             return passes.clone();
         }
-        let runs = match self.fix_opt_level {
-            FixOptimizationLevel::None => 0,
-            FixOptimizationLevel::Basic => 1,
+        match self.fix_opt_level {
+            FixOptimizationLevel::None => vec![],
+            FixOptimizationLevel::Basic => vec![LLVM_O3_PIPELINE.to_string()],
             FixOptimizationLevel::Max | FixOptimizationLevel::Experimental => {
-                LLVM_O3_RUNS_FOR_SPEED
+                let mut passes = vec![LLVM_O3_PIPELINE.to_string(); LLVM_O3_RUNS_FOR_SPEED];
+                passes.extend(LLVM_TAIL_PASSES.iter().map(|pass| pass.to_string()));
+                passes
             }
-        };
-        vec![LLVM_O3_PIPELINE.to_string(); runs]
+        }
     }
 
     // Get hash value of the configurations that affect the object file generation.

--- a/src/tests/test_llvm_passes.rs
+++ b/src/tests/test_llvm_passes.rs
@@ -189,16 +189,28 @@ fn test_passes_file_replaces_the_level_pipeline() {
     );
 }
 
-/// The optimization levels built for speed run LLVM's pipeline more than once, and `-O none` runs
-/// nothing, so that a level change is visible in the pipeline rather than only in the timings.
+/// The optimization levels built for speed run LLVM's pipeline three times and follow it with the
+/// passes measured to earn their place, `-O basic` runs it once, and `-O none` runs nothing, so
+/// that a level change is visible in the pipeline rather than only in the timings.
 #[test]
-fn test_pass_pipeline_runs_per_optimization_level() {
+fn test_pass_pipeline_per_optimization_level() {
     // `set_fix_opt_level` clamps to `FIX_MAX_OPT_LEVEL`, which the test suite's matrix varies, so
     // the expectation is read off the level the configuration ended up at.
-    let expected_runs = |level: FixOptimizationLevel| match level {
-        FixOptimizationLevel::None => 0,
-        FixOptimizationLevel::Basic => 1,
-        FixOptimizationLevel::Max | FixOptimizationLevel::Experimental => 3,
+    let expected = |level: FixOptimizationLevel| -> Vec<String> {
+        let full_pipeline = "default<O3>".to_string();
+        match level {
+            FixOptimizationLevel::None => vec![],
+            FixOptimizationLevel::Basic => vec![full_pipeline],
+            FixOptimizationLevel::Max | FixOptimizationLevel::Experimental => {
+                let mut passes = vec![full_pipeline; 3];
+                passes.extend(
+                    ["speculative-execution", "loop-vectorize", "pseudo-probe"]
+                        .iter()
+                        .map(|pass| pass.to_string()),
+                );
+                passes
+            }
+        }
     };
     for level in [
         FixOptimizationLevel::None,
@@ -208,18 +220,11 @@ fn test_pass_pipeline_runs_per_optimization_level() {
     ] {
         let mut config = Configuration::develop_mode();
         config.set_fix_opt_level(level);
-        let passes = config.llvm_passes();
         assert_eq!(
-            passes.len(),
-            expected_runs(config.fix_opt_level()),
-            "unexpected number of pipeline runs at -O {}",
+            config.llvm_passes(),
+            expected(config.fix_opt_level()),
+            "unexpected pipeline at -O {}",
             config.fix_opt_level()
-        );
-        assert!(
-            passes.iter().all(|pass| pass == "default<O3>"),
-            "the pipeline at -O {} should be LLVM's full pipeline, but it is {:?}",
-            config.fix_opt_level(),
-            passes
         );
     }
 }


### PR DESCRIPTION
## 指標をサイクルに変える

`passes_optimizer.py` の目的関数を命令数から `cycles:u` に変えた。両者は探索を逆方向に導くほど食い違う。

| 変更 | 命令数 | サイクル |
|---|--:|--:|
| 12 本を足す（`levenshtein`） | +2.4% | **-0.4%** |
| 12 本を足す（`fannkuch_scratch`） | -0.2% | **-2.2%** |
| O3 を不動点まで（`nbody`） | -21% | **0%** |
| 配列アラインメント #128（`arrayrw`） | ±0% | **-40%** |

パスが変えるのは多くの場合コードの形（分岐の落ち方、フロントエンドの取り直し）であって、実行する仕事の量ではない。命令数を目的関数にすると `levenshtein` で符号を間違え、`nbody` で効かない改善を追い、`arrayrw` で効く改善を見落とす。

perf は実行と同程度、cachegrind は 50-100 倍なので、指標を変えると探索は速くもなる。

**測定の設計**: 候補は現行と同一実行内で交互に測る。各ケースは 12 ラウンドの最小値。採用には 0.3% の勝ちを独立した 2 回要求する。`--noise` は同じパイプラインを 2 回ビルドして比べるので、出る差は全部ノイズ — 3 回走らせて幾何平均は ±0.07%、しきい値はその 4 倍以上に置いた。5 ケースを探索から外し、採用時にだけ測る。

## 出荷するパイプライン

140 フェーズで、#147 まで出荷していた 12 本が 3 本まで剥がれた。

```
-O max / experimental:  default<O3> x3, speculative-execution, loop-vectorize, pseudo-probe
-O basic:               default<O3> x1        (変更なし)
-O none:                なし                  (変更なし)
```

3 本を足さないパイプラインとの比較（15 ケース、同一実行内で交互に 15 ラウンド）:

| | |
|---|--:|
| 幾何平均 | **-0.80%** |
| **ホールドアウト 5 ケースのみ** | **-1.22%** |

`get_sub` -4.4%、`fib` -4.4%、`cp_lib_dijkstra` -2.8%、`levenshtein` -2.2%、`fannkuch_scratch` -1.9%。戻すのは `cp_lib_lsegtree` +2.0% と `cp_lib_segtree` +1.5%。探索に使っていないケースのほうが良いので、過学習ではない。

**3 本は 1 つの単位である。** 単独では誰も稼がない。`pseudo-probe` だけを足すと逆に +0.48% で、ホールドアウトでは +1.21% 悪化する。#147 がこのリストを無価値と測って捨てたのは、測ったのが命令数だったからで、これらが変えるのは仕事の量ではなくコードの形である。

## log に cycles を足す

各ケースに `-cycles` 列（5 回の最小値）と、行に 1 つ `load` 列（カウンタを読んだ間の最大ロード）。**この log で唯一の非決定的な列**なので、`--cycles` を付けた実行でだけ埋まる。機械が空いているときに取る運用で、系列はまばらになる。グラフは実際に測った commit に点を打つ（隙間をまたぐ線が連続した測定に見えるため）。`load` は commit ペインに processor と並べて出る。

`perf_counters.py` は PMU の多重化を検出して拒否するようにした。イベント数がカウンタ数を超えると perf は時分割してスケーリングした推定値を普通の測定値と同じ顔で出す。split 列が一度 10 倍になった原因がこれである。

https://claude.ai/code/session_01LAa4vvmJ8KWESYposht3vX