### PR TITLE
Inspect a binding's occurrences where its name is read

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -26,6 +26,9 @@ pub enum AppSourceCodeOrderType {
 #[derive(Serialize, Deserialize)]
 pub struct ExprNode {
     pub expr: Arc<Expr>,
+    // The free variables of `expr`, calculated when first asked for and kept for later requests.
+    // Building a node around a different `expr` goes through `clone_except_fvs`, which leaves the
+    // set to be calculated again.
     #[serde(skip)]
     free_vars: Arc<Mutex<Option<Set<FullName>>>>,
     pub source: Option<Span>,
@@ -1283,6 +1286,11 @@ impl ExprNode {
     // Does the given name occur free in this expression?
     pub fn has_free_var(&self, name: &FullName) -> bool {
         self.with_free_vars(|free_vars| free_vars.contains(name))
+    }
+
+    // Does any local name occur free in this expression?
+    pub fn has_free_local_var(&self) -> bool {
+        self.with_free_vars(|free_vars| free_vars.iter().any(|name| name.is_local()))
     }
 
     // Convert all global FullNames to absolute paths.

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1266,13 +1266,23 @@ impl ExprNode {
         }
     }
 
-    // Get the set of free vars.
-    pub fn free_vars(&self) -> Set<FullName> {
+    // Call `f` on the set of free vars, calculating it on the first call and reusing it afterwards.
+    fn with_free_vars<T>(&self, f: impl FnOnce(&Set<FullName>) -> T) -> T {
         let mut lock = self.free_vars.lock().unwrap();
         if lock.is_none() {
             *lock = Some(self.calc_free_vars());
         }
-        lock.as_ref().unwrap().clone()
+        f(lock.as_ref().unwrap())
+    }
+
+    // Get the set of free vars.
+    pub fn free_vars(&self) -> Set<FullName> {
+        self.with_free_vars(|free_vars| free_vars.clone())
+    }
+
+    // Does the given name occur free in this expression?
+    pub fn has_free_var(&self, name: &FullName) -> bool {
+        self.with_free_vars(|free_vars| free_vars.contains(name))
     }
 
     // Convert all global FullNames to absolute paths.

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1209,6 +1209,10 @@ impl ExprNode {
                 for arg in args {
                     free_vars.remove(&arg.name);
                 }
+                // A lambda expression binds `CAP_NAME` implicitly, so it goes here along with the
+                // parameters. `FreeOccurrenceProbe` of the let-elimination pass leans on this: it
+                // rejects `CAP_NAME` as a target name, since free variables locate every name but
+                // that one.
                 free_vars.remove(&FullName::local(CAP_NAME));
                 free_vars
             }
@@ -1377,14 +1381,13 @@ impl ExprNode {
     // Get the names which are captured by a lambda expressions.
     pub fn lambda_cap_names(&self) -> Vec<FullName> {
         assert!(self.is_lam());
-        let mut cap_names = self.free_vars().clone();
-        cap_names.remove(&FullName::local(CAP_NAME));
 
         // We need not and should not capture global variable:
         // If we capture global variable, then global recursive function such as
         // "main = |x| if x == 0 then 0 else x + main(x-1)" results in infinite recursion at its initialization.
         // So we remove global variable from the captured names.
-        let mut cap_names = cap_names
+        let mut cap_names = self
+            .free_vars()
             .into_iter()
             .filter(|name| name.is_local())
             .collect::<Vec<_>>();

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1210,9 +1210,8 @@ impl ExprNode {
                     free_vars.remove(&arg.name);
                 }
                 // A lambda expression binds `CAP_NAME` implicitly, so it goes here along with the
-                // parameters. `FreeOccurrenceProbe` of the let-elimination pass leans on this: it
-                // rejects `CAP_NAME` as a target name, since free variables locate every name but
-                // that one.
+                // parameters. `CAP_NAME` is therefore the one name the free variables of an
+                // expression do not locate.
                 free_vars.remove(&FullName::local(CAP_NAME));
                 free_vars
             }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1381,10 +1381,9 @@ impl ExprNode {
     pub fn lambda_cap_names(&self) -> Vec<FullName> {
         assert!(self.is_lam());
 
-        // We need not and should not capture global variable:
-        // If we capture global variable, then global recursive function such as
-        // "main = |x| if x == 0 then 0 else x + main(x-1)" results in infinite recursion at its initialization.
-        // So we remove global variable from the captured names.
+        // A lambda captures local names alone. Capturing a global would make a global recursive
+        // function such as "main = |x| if x == 0 then 0 else x + main(x-1)" recur forever at its
+        // initialization.
         let mut cap_names = self
             .free_vars()
             .into_iter()

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1112,8 +1112,8 @@ impl ExprNode {
                 t.walk_var_uses(f);
                 e.walk_var_uses(f);
             }
-            Expr::Match(scrut, arms) => {
-                scrut.walk_var_uses(f);
+            Expr::Match(cond, arms) => {
+                cond.walk_var_uses(f);
                 for (_pat, e) in arms {
                     e.walk_var_uses(f);
                 }
@@ -1163,8 +1163,8 @@ impl ExprNode {
                 t.walk_patterns(f);
                 e.walk_patterns(f);
             }
-            Expr::Match(scrut, arms) => {
-                scrut.walk_patterns(f);
+            Expr::Match(cond, arms) => {
+                cond.walk_patterns(f);
                 for (pat, e) in arms {
                     f(pat);
                     e.walk_patterns(f);
@@ -1236,10 +1236,10 @@ impl ExprNode {
             Expr::Match(cond, pat_vals) => {
                 let mut free_vars = cond.free_vars();
                 for (pat, val) in pat_vals {
-                    let mut fvs = val.free_vars();
+                    let mut val_free_vars = val.free_vars();
                     let pat_vars = pat.pattern.vars();
-                    fvs.retain(|v| !pat_vars.contains(v));
-                    free_vars.extend(fvs);
+                    val_free_vars.retain(|v| !pat_vars.contains(v));
+                    free_vars.extend(val_free_vars);
                 }
                 free_vars
             }

--- a/src/ast/traverse.rs
+++ b/src/ast/traverse.rs
@@ -177,6 +177,14 @@ pub trait ExprVisitor {
         self.visit_expr(expr, &mut state)
     }
 
+    // Whether to visit `expr`. An expression this answers `false` for is left as it is, together
+    // with everything under it: its `start_visit_*` and `end_visit_*` methods are skipped and its
+    // subexpressions are not reached. The default answer visits the whole expression, which is what
+    // a visitor with something to say about every node wants.
+    fn should_visit(&self, _expr: &Arc<ExprNode>) -> bool {
+        true
+    }
+
     fn revisit_if_changed(
         &mut self,
         end_res: EndVisitResult,
@@ -190,6 +198,9 @@ pub trait ExprVisitor {
     }
 
     fn visit_expr(&mut self, expr: &Arc<ExprNode>, state: &mut VisitState) -> EndVisitResult {
+        if !self.should_visit(expr) {
+            return EndVisitResult::unchanged(expr);
+        }
         match &*expr.expr {
             Expr::Var(_var) => {
                 let res = self.start_visit_var(&expr, state);

--- a/src/ast/traverse.rs
+++ b/src/ast/traverse.rs
@@ -12,16 +12,7 @@ pub enum StartVisitResult {
     Return,
     ReplaceAndRevisit(Arc<ExprNode>),
     ReplaceAndReturn(Arc<ExprNode>),
-    // Skip, // to be implemented
-    // ReplaceAndSkipChildren(Arc<ExprNode>), // to be implemented
-    // ReplaceAndVisitChildren(Arc<ExprNode>), // to be implemented
 }
-
-// pub enum EndVisitResult {
-//     NoReplace,
-//     Replace(Arc<ExprNode>),
-//     // ReplaceAndRevisit(Arc<ExprNode>), // to be implemented
-// }
 
 pub struct EndVisitResult {
     pub expr: Arc<ExprNode>,

--- a/src/optimization/decapturing.rs
+++ b/src/optimization/decapturing.rs
@@ -514,7 +514,7 @@ impl DecapturingVisitor {
         }
 
         let body = expr.get_lam_body();
-        if body.free_vars().contains(&FullName::local(CAP_NAME)) {
+        if body.has_free_var(&FullName::local(CAP_NAME)) {
             return false;
         }
 

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -53,6 +53,7 @@ use crate::{
         program::Program,
         traverse::{EndVisitResult, ExprVisitor, StartVisitResult, VisitState},
     },
+    constants::CAP_NAME,
     misc::Map,
     optimization::rename::{rename_free_name, substitute_free_name},
 };
@@ -357,6 +358,15 @@ struct FreeOccurrenceProbe {
 
 impl FreeOccurrenceProbe {
     fn new(target_name: FullName) -> Self {
+        // The traversal locates occurrences by the free variables of each subexpression, so it can
+        // only probe a name that free variables account for. `CAP_NAME` is the one name they do
+        // not: a lambda expression binds it implicitly, and it is absent from the free variables of
+        // every lambda expression whose body reads it.
+        assert!(
+            !(target_name.is_local() && target_name.name == CAP_NAME),
+            "occurrences of `{}` cannot be probed",
+            CAP_NAME
+        );
         Self {
             target_name,
             count: 0,
@@ -370,6 +380,29 @@ impl FreeOccurrenceProbe {
     // Does the target name occur free in `expr`? The traversal enters `expr` only if it does.
     fn target_occurs_in(&self, expr: &Arc<ExprNode>) -> bool {
         expr.has_free_var(&self.target_name)
+    }
+
+    // Does one of `exprs` the target name is absent from read a local name? Called on expressions
+    // evaluated as a group, such as the fields of a struct expression: any of them may be evaluated
+    // before the one holding the target name.
+    fn another_local_name_is_read_in<'a>(
+        &self,
+        exprs: impl IntoIterator<Item = &'a Arc<ExprNode>>,
+    ) -> bool {
+        exprs
+            .into_iter()
+            .any(|expr| !self.target_occurs_in(expr) && expr.has_free_local_var())
+    }
+
+    // Is the target name read in one of `later` while `earlier`, evaluated ahead of them, reads a
+    // local name? That is the shape in which the target name stops being the first local name the
+    // expression evaluates.
+    fn read_after_a_local_name<'a>(
+        &self,
+        earlier: &Arc<ExprNode>,
+        later: impl IntoIterator<Item = &'a Arc<ExprNode>>,
+    ) -> bool {
+        later.into_iter().any(|expr| self.target_occurs_in(expr)) && earlier.has_free_local_var()
     }
 }
 
@@ -388,6 +421,13 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn end_visit_var(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         // A variable expression is entered only when it is an occurrence of the target name.
+        let var = expr.get_var();
+        assert!(
+            var.name == self.target_name,
+            "entered a variable expression of `{}` while probing `{}`",
+            var.name.to_string(),
+            self.target_name.to_string()
+        );
         self.count += 1;
         EndVisitResult::unchanged(expr)
     }
@@ -403,12 +443,20 @@ impl ExprVisitor for FreeOccurrenceProbe {
     fn end_visit_llvm(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         // An LLVM expression is entered only when it takes the target name as an argument, which it
         // may do more than once.
+        let occurrences = expr
+            .get_llvm()
+            .generator
+            .free_vars()
+            .iter()
+            .filter(|fv| **fv == self.target_name)
+            .count();
+        assert!(
+            occurrences > 0,
+            "entered an LLVM expression taking no `{}` as an argument",
+            self.target_name.to_string()
+        );
         self.is_argument_to_llvm = true;
-        for fv in expr.get_llvm().generator.free_vars() {
-            if fv == self.target_name {
-                self.count += 1;
-            }
-        }
+        self.count += occurrences;
 
         EndVisitResult::unchanged(expr)
     }
@@ -421,12 +469,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // Function application expression {f}({x}).
 
         // If {x} contains the target name, and {f} contains local name, then set `used_before_any_other_local_names` to false.
-        if expr
-            .get_app_args()
-            .iter()
-            .any(|arg| self.target_occurs_in(arg))
-            && expr.get_app_func().has_free_local_var()
-        {
+        if self.read_after_a_local_name(&expr.get_app_func(), expr.get_app_args().iter()) {
             self.used_before_any_other_local_names = false;
         }
 
@@ -473,8 +516,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
         // If {value} contains the target name, and {bound} contains local name, then set `used_before_any_other_local_names` to false.
         if !target_rebound
-            && self.target_occurs_in(&expr.get_let_value())
-            && expr.get_let_bound().has_free_local_var()
+            && self.read_after_a_local_name(&expr.get_let_bound(), [&expr.get_let_value()])
         {
             self.used_before_any_other_local_names = false;
         }
@@ -502,10 +544,10 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // If expression `if {cond} { {then} } else { {else} }`.
 
         // if the target name appears in {then} or {else}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if (self.target_occurs_in(&expr.get_if_then())
-            || self.target_occurs_in(&expr.get_if_else()))
-            && expr.get_if_cond().has_free_local_var()
-        {
+        if self.read_after_a_local_name(
+            &expr.get_if_cond(),
+            [&expr.get_if_then(), &expr.get_if_else()],
+        ) {
             self.used_before_any_other_local_names = false;
         }
 
@@ -532,9 +574,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
             .collect::<Vec<_>>();
 
         // If the target name appears in any such {val}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if vals.iter().any(|val| self.target_occurs_in(val))
-            && expr.get_match_cond().has_free_local_var()
-        {
+        if self.read_after_a_local_name(&expr.get_match_cond(), vals.iter()) {
             self.used_before_any_other_local_names = false;
         }
 
@@ -577,12 +617,12 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // A struct expression is entered only when the target name appears in some field.
 
         // If any other field contains local name, then set `used_before_any_other_local_names` to false.
-        for (_, _, field) in &expr.get_make_struct_fields() {
-            if !self.target_occurs_in(field) && field.has_free_local_var() {
-                // A field contains local name other than the target name.
-                self.used_before_any_other_local_names = false;
-                break;
-            }
+        if self.another_local_name_is_read_in(
+            expr.get_make_struct_fields()
+                .iter()
+                .map(|(_name, _src, field)| field),
+        ) {
+            self.used_before_any_other_local_names = false;
         }
 
         StartVisitResult::VisitChildren
@@ -604,12 +644,8 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // An array literal is entered only when the target name appears in some element.
 
         // If any other element contains local name, then set `used_before_any_other_local_names` to false.
-        for element in expr.get_array_lit_elements() {
-            if !self.target_occurs_in(&element) && element.has_free_local_var() {
-                // An element contains local name other than the target name.
-                self.used_before_any_other_local_names = false;
-                break;
-            }
+        if self.another_local_name_is_read_in(expr.get_array_lit_elements().iter()) {
+            self.used_before_any_other_local_names = false;
         }
         StartVisitResult::VisitChildren
     }
@@ -630,12 +666,8 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // An FFI call is entered only when the target name appears in some argument.
 
         // If any other argument contains local name, then set `used_before_any_other_local_names` to false.
-        for arg in expr.get_ffi_call_args() {
-            if !self.target_occurs_in(&arg) && arg.has_free_local_var() {
-                // An argument contains local name other than the target name.
-                self.used_before_any_other_local_names = false;
-                break;
-            }
+        if self.another_local_name_is_read_in(expr.get_ffi_call_args().iter()) {
+            self.used_before_any_other_local_names = false;
         }
         StartVisitResult::VisitChildren
     }
@@ -654,8 +686,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // If the main expression contains the target name, and the sub-expression contains local name, then set `used_before_any_other_local_names` to false.
-        if self.target_occurs_in(&expr.get_eval_main()) && expr.get_eval_side().has_free_local_var()
-        {
+        if self.read_after_a_local_name(&expr.get_eval_side(), [&expr.get_eval_main()]) {
             self.used_before_any_other_local_names = false;
         }
         StartVisitResult::VisitChildren

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -371,26 +371,18 @@ impl FreeOccurrenceProbe {
     fn target_occurs_in(&self, expr: &Arc<ExprNode>) -> bool {
         expr.has_free_var(&self.target_name)
     }
-
-    fn contains_local_name(expr: &Arc<ExprNode>) -> bool {
-        for name in expr.free_vars() {
-            if name.is_local() {
-                return true;
-            }
-        }
-        false
-    }
 }
 
 impl ExprVisitor for FreeOccurrenceProbe {
+    fn should_visit(&self, expr: &Arc<ExprNode>) -> bool {
+        self.target_occurs_in(expr)
+    }
+
     fn start_visit_var(
         &mut self,
-        expr: &Arc<ExprNode>,
+        _expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
         StartVisitResult::VisitChildren
     }
 
@@ -402,12 +394,9 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn start_visit_llvm(
         &mut self,
-        expr: &Arc<ExprNode>,
+        _expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
         StartVisitResult::VisitChildren
     }
 
@@ -430,16 +419,13 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Function application expression {f}({x}).
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
 
         // If {x} contains the target name, and {f} contains local name, then set `used_before_any_other_local_names` to false.
         if expr
             .get_app_args()
             .iter()
             .any(|arg| self.target_occurs_in(arg))
-            && FreeOccurrenceProbe::contains_local_name(&expr.get_app_func())
+            && expr.get_app_func().has_free_local_var()
         {
             self.used_before_any_other_local_names = false;
         }
@@ -458,13 +444,9 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn start_visit_lam(
         &mut self,
-        expr: &Arc<ExprNode>,
+        _expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
-
         // A lambda expression is entered only when the target name is free in it, i.e., captured by
         // it. Its parameters are therefore names other than the target name, and the body is
         // visited with the target name still standing for the same binding.
@@ -483,9 +465,6 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Let expression `let {pat} = {bound} in {value}`.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
         let target_rebound = expr
             .get_let_pat()
             .pattern
@@ -495,7 +474,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // If {value} contains the target name, and {bound} contains local name, then set `used_before_any_other_local_names` to false.
         if !target_rebound
             && self.target_occurs_in(&expr.get_let_value())
-            && FreeOccurrenceProbe::contains_local_name(&expr.get_let_bound())
+            && expr.get_let_bound().has_free_local_var()
         {
             self.used_before_any_other_local_names = false;
         }
@@ -521,14 +500,11 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // If expression `if {cond} { {then} } else { {else} }`.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
 
         // if the target name appears in {then} or {else}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
         if (self.target_occurs_in(&expr.get_if_then())
             || self.target_occurs_in(&expr.get_if_else()))
-            && FreeOccurrenceProbe::contains_local_name(&expr.get_if_cond())
+            && expr.get_if_cond().has_free_local_var()
         {
             self.used_before_any_other_local_names = false;
         }
@@ -546,9 +522,6 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Match expression `match {cond} { pat1 => {val1}; pat2 => {val2}; ... }`.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
         // The value expressions of the arms whose {pat} leaves the target name standing for the
         // binding under inspection.
         let vals = expr
@@ -560,7 +533,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
         // If the target name appears in any such {val}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
         if vals.iter().any(|val| self.target_occurs_in(val))
-            && FreeOccurrenceProbe::contains_local_name(&expr.get_match_cond())
+            && expr.get_match_cond().has_free_local_var()
         {
             self.used_before_any_other_local_names = false;
         }
@@ -582,12 +555,9 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn start_visit_tyanno(
         &mut self,
-        expr: &Arc<ExprNode>,
+        _expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
         StartVisitResult::VisitChildren
     }
 
@@ -605,13 +575,10 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // A struct expression is entered only when the target name appears in some field.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
 
         // If any other field contains local name, then set `used_before_any_other_local_names` to false.
         for (_, _, field) in &expr.get_make_struct_fields() {
-            if !self.target_occurs_in(field) && FreeOccurrenceProbe::contains_local_name(field) {
+            if !self.target_occurs_in(field) && field.has_free_local_var() {
                 // A field contains local name other than the target name.
                 self.used_before_any_other_local_names = false;
                 break;
@@ -635,15 +602,10 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // An array literal is entered only when the target name appears in some element.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
 
         // If any other element contains local name, then set `used_before_any_other_local_names` to false.
         for element in expr.get_array_lit_elements() {
-            if !self.target_occurs_in(&element)
-                && FreeOccurrenceProbe::contains_local_name(&element)
-            {
+            if !self.target_occurs_in(&element) && element.has_free_local_var() {
                 // An element contains local name other than the target name.
                 self.used_before_any_other_local_names = false;
                 break;
@@ -666,13 +628,10 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // An FFI call is entered only when the target name appears in some argument.
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
 
         // If any other argument contains local name, then set `used_before_any_other_local_names` to false.
         for arg in expr.get_ffi_call_args() {
-            if !self.target_occurs_in(&arg) && FreeOccurrenceProbe::contains_local_name(&arg) {
+            if !self.target_occurs_in(&arg) && arg.has_free_local_var() {
                 // An argument contains local name other than the target name.
                 self.used_before_any_other_local_names = false;
                 break;
@@ -694,13 +653,8 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        if !self.target_occurs_in(expr) {
-            return StartVisitResult::Return;
-        }
-
         // If the main expression contains the target name, and the sub-expression contains local name, then set `used_before_any_other_local_names` to false.
-        if self.target_occurs_in(&expr.get_eval_main())
-            && FreeOccurrenceProbe::contains_local_name(&expr.get_eval_side())
+        if self.target_occurs_in(&expr.get_eval_main()) && expr.get_eval_side().has_free_local_var()
         {
             self.used_before_any_other_local_names = false;
         }

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -377,7 +377,7 @@ impl FreeOccurrenceProbe {
         }
     }
 
-    // Does the target name occur free in `expr`? The traversal enters `expr` only if it does.
+    // Does the target name occur free in `expr`? The traversal visits `expr` only if it does.
     fn target_occurs_in(&self, expr: &Arc<ExprNode>) -> bool {
         expr.has_free_var(&self.target_name)
     }
@@ -397,7 +397,7 @@ impl FreeOccurrenceProbe {
     // Is the target name read in one of `later` while `earlier`, evaluated ahead of them, reads a
     // local name? That is the shape in which the target name stops being the first local name the
     // expression evaluates.
-    fn read_after_a_local_name<'a>(
+    fn target_is_read_after_a_local_name<'a>(
         &self,
         earlier: &Arc<ExprNode>,
         later: impl IntoIterator<Item = &'a Arc<ExprNode>>,
@@ -420,11 +420,11 @@ impl ExprVisitor for FreeOccurrenceProbe {
     }
 
     fn end_visit_var(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        // A variable expression is entered only when it is an occurrence of the target name.
+        // A variable expression is visited only when it is an occurrence of the target name.
         let var = expr.get_var();
         assert!(
             var.name == self.target_name,
-            "entered a variable expression of `{}` while probing `{}`",
+            "visited a variable expression of `{}` while probing `{}`",
             var.name.to_string(),
             self.target_name.to_string()
         );
@@ -441,9 +441,9 @@ impl ExprVisitor for FreeOccurrenceProbe {
     }
 
     fn end_visit_llvm(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        // An LLVM expression is entered only when it takes the target name as an argument, which it
+        // An LLVM expression is visited only when it takes the target name as an argument, which it
         // may do more than once.
-        let occurrences = expr
+        let occurrence_count = expr
             .get_llvm()
             .generator
             .free_vars()
@@ -451,12 +451,12 @@ impl ExprVisitor for FreeOccurrenceProbe {
             .filter(|fv| **fv == self.target_name)
             .count();
         assert!(
-            occurrences > 0,
-            "entered an LLVM expression taking no `{}` as an argument",
+            occurrence_count > 0,
+            "visited an LLVM expression taking no `{}` as an argument",
             self.target_name.to_string()
         );
         self.is_argument_to_llvm = true;
-        self.count += occurrences;
+        self.count += occurrence_count;
 
         EndVisitResult::unchanged(expr)
     }
@@ -469,7 +469,8 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // Function application expression {f}({x}).
 
         // If {x} contains the target name, and {f} contains local name, then set `used_before_any_other_local_names` to false.
-        if self.read_after_a_local_name(&expr.get_app_func(), expr.get_app_args().iter()) {
+        if self.target_is_read_after_a_local_name(&expr.get_app_func(), expr.get_app_args().iter())
+        {
             self.used_before_any_other_local_names = false;
         }
 
@@ -490,7 +491,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // A lambda expression is entered only when the target name is free in it, i.e., captured by
+        // A lambda expression is visited only when the target name is free in it, i.e., captured by
         // it. Its parameters are therefore names other than the target name, and the body is
         // visited with the target name still standing for the same binding.
         self.is_captured_by_lambda = true;
@@ -516,7 +517,8 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
         // If {value} contains the target name, and {bound} contains local name, then set `used_before_any_other_local_names` to false.
         if !target_rebound
-            && self.read_after_a_local_name(&expr.get_let_bound(), [&expr.get_let_value()])
+            && self
+                .target_is_read_after_a_local_name(&expr.get_let_bound(), [&expr.get_let_value()])
         {
             self.used_before_any_other_local_names = false;
         }
@@ -544,7 +546,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // If expression `if {cond} { {then} } else { {else} }`.
 
         // if the target name appears in {then} or {else}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if self.read_after_a_local_name(
+        if self.target_is_read_after_a_local_name(
             &expr.get_if_cond(),
             [&expr.get_if_then(), &expr.get_if_else()],
         ) {
@@ -566,7 +568,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         // Match expression `match {cond} { pat1 => {val1}; pat2 => {val2}; ... }`.
         // The value expressions of the arms whose {pat} leaves the target name standing for the
         // binding under inspection.
-        let vals = expr
+        let vals_not_rebinding_target = expr
             .get_match_pat_vals()
             .into_iter()
             .filter(|(pat, _val)| !pat.pattern.vars().contains(&self.target_name))
@@ -574,15 +576,18 @@ impl ExprVisitor for FreeOccurrenceProbe {
             .collect::<Vec<_>>();
 
         // If the target name appears in any such {val}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if self.read_after_a_local_name(&expr.get_match_cond(), vals.iter()) {
+        if self.target_is_read_after_a_local_name(
+            &expr.get_match_cond(),
+            vals_not_rebinding_target.iter(),
+        ) {
             self.used_before_any_other_local_names = false;
         }
 
         // Visit the condition expression first
         self.traverse(&expr.get_match_cond());
 
-        // Visit the value expression of each arm
-        for val in vals {
+        // Visit the value expression of each such arm
+        for val in vals_not_rebinding_target {
             self.traverse(&val);
         }
 
@@ -614,7 +619,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // A struct expression is entered only when the target name appears in some field.
+        // A struct expression is visited only when the target name appears in some field.
 
         // If any other field contains local name, then set `used_before_any_other_local_names` to false.
         if self.another_local_name_is_read_in(
@@ -641,7 +646,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // An array literal is entered only when the target name appears in some element.
+        // An array literal is visited only when the target name appears in some element.
 
         // If any other element contains local name, then set `used_before_any_other_local_names` to false.
         if self.another_local_name_is_read_in(expr.get_array_lit_elements().iter()) {
@@ -663,7 +668,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // An FFI call is entered only when the target name appears in some argument.
+        // An FFI call is visited only when the target name appears in some argument.
 
         // If any other argument contains local name, then set `used_before_any_other_local_names` to false.
         if self.another_local_name_is_read_in(expr.get_ffi_call_args().iter()) {
@@ -686,7 +691,7 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // If the main expression contains the target name, and the sub-expression contains local name, then set `used_before_any_other_local_names` to false.
-        if self.read_after_a_local_name(&expr.get_eval_side(), [&expr.get_eval_main()]) {
+        if self.target_is_read_after_a_local_name(&expr.get_eval_side(), [&expr.get_eval_main()]) {
             self.used_before_any_other_local_names = false;
         }
         StartVisitResult::VisitChildren

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -76,7 +76,8 @@ pub fn create_global_lambda_to_arity_map(prg: &Program) -> Map<FullName, usize> 
 //
 // If any transformation is applied, returns true.
 //
-// - `global_lambda_to_arity`: a map from global lambda names to their arities. If given empty map, conditions 2-b will not be applied.
+// - `global_lambda_to_arity`: a map from global lambda names to their arities. An empty map
+//   leaves the transformation to conditions 1, 2-a, 2-c and 3.
 pub fn run_on_expr_once(
     expr: &mut Arc<ExprNode>,
     global_lambda_to_arity: &Map<FullName, usize>,

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -64,8 +64,8 @@ pub fn create_global_lambda_to_arity_map(prg: &Program) -> Map<FullName, usize> 
     for (name, sym) in &prg.symbols {
         let expr = sym.expr.as_ref().unwrap();
         if expr.is_lam() {
-            let args = expr.destructure_lam_sequence().0;
-            let arity = args.iter().map(|args| args.len()).sum();
+            let param_lists = expr.destructure_lam_sequence().0;
+            let arity = param_lists.iter().map(|params| params.len()).sum();
             global_lambda_to_arity.insert(name.clone(), arity);
         }
     }
@@ -81,10 +81,10 @@ pub fn run_on_expr_once(
     expr: &mut Arc<ExprNode>,
     global_lambda_to_arity: &Map<FullName, usize>,
 ) -> bool {
-    let mut remover = LetEliminator {
+    let mut eliminator = LetEliminator {
         global_lambda_to_arity,
     };
-    let res = remover.traverse(expr);
+    let res = eliminator.traverse(expr);
     *expr = res.expr;
     res.changed
 }
@@ -152,8 +152,8 @@ impl<'a> ExprVisitor for LetEliminator<'a> {
 
     fn end_visit_let(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         // Check if the expression is of the form `let x = {e0} in {e1}`.
-        let x = expr.get_let_pat();
-        if !x.is_var() {
+        let pat = expr.get_let_pat();
+        if !pat.is_var() {
             return EndVisitResult::unchanged(expr);
         }
         // The pattern is just a name.
@@ -163,14 +163,14 @@ impl<'a> ExprVisitor for LetEliminator<'a> {
             // Case 1 of the documentation at the top.
 
             // Replace all occurrences of `x` in `{e1}` with `{e0}`.
-            let x = &x.get_var().name;
+            let x = &pat.get_var().name;
             let e0 = &e0.get_var().name;
             let e1 = expr.get_let_value();
             let expr = rename_free_name(&e1, x, e0);
             return EndVisitResult::changed(expr);
         }
         // Inspect occurrences of `x` in `{e1}`.
-        let x = &x.get_var().name;
+        let x = &pat.get_var().name;
         let e1 = expr.get_let_value();
         let mut probe = FreeOccurrenceProbe::new(x.clone());
         probe.traverse(&e1);
@@ -250,10 +250,10 @@ impl<'a> ExprVisitor for LetEliminator<'a> {
             return EndVisitResult::unchanged(expr);
         }
 
-        // Replace all occurrences of `pat` in `expr` with `cond`.
-        let pat = &pat.get_var().name;
-        let cond = &cond.get_var().name;
-        let expr = rename_free_name(&val, pat, cond);
+        // Replace, in `{val}`, all occurrences of the name `{pat}` binds with the name `{cond}` reads.
+        let pat_name = &pat.get_var().name;
+        let cond_name = &cond.get_var().name;
+        let expr = rename_free_name(&val, pat_name, cond_name);
         EndVisitResult::changed(expr)
     }
 

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -53,7 +53,7 @@ use crate::{
         program::Program,
         traverse::{EndVisitResult, ExprVisitor, StartVisitResult, VisitState},
     },
-    misc::{Map, Set},
+    misc::Map,
     optimization::rename::{rename_free_name, substitute_free_name},
 };
 use std::sync::Arc;
@@ -333,8 +333,14 @@ impl<'a> ExprVisitor for LetEliminator<'a> {
     }
 }
 
-// An ExprVisitor that counts the number of free occurrences of a given name in an expression.
-pub struct FreeOccurrenceProbe {
+// An ExprVisitor that inspects the free occurrences of a given name in an expression.
+//
+// Everything it reports is a property of those occurrences, so a subexpression the name does not
+// occur free in leaves all of them as they stand. The traversal skips such subexpressions, which
+// keeps the cost of a probe proportional to the region where the name is used rather than to the
+// size of the expression it is run on. That region ends at a binder giving the name to another
+// binding, so no occurrence of another binding is ever reached.
+struct FreeOccurrenceProbe {
     // The name to count occurrences of.
     target_name: FullName,
     // Count of free occurrences found so far.
@@ -347,22 +353,23 @@ pub struct FreeOccurrenceProbe {
     is_captured_by_lambda: bool,
     // Is any occurrence of `target_name` appear as arguments to LLVM expression?
     is_argument_to_llvm: bool,
-
-    // Local names that are currently shadowed (i.e., not free).
-    shadowed: Set<FullName>,
 }
 
 impl FreeOccurrenceProbe {
     fn new(target_name: FullName) -> Self {
         Self {
             target_name,
-            shadowed: Set::default(),
             count: 0,
             is_applied: false,
             used_before_any_other_local_names: true,
             is_captured_by_lambda: false,
             is_argument_to_llvm: false,
         }
+    }
+
+    // Does the target name occur free in `expr`? The traversal enters `expr` only if it does.
+    fn target_occurs_in(&self, expr: &Arc<ExprNode>) -> bool {
+        expr.has_free_var(&self.target_name)
     }
 
     fn contains_local_name(expr: &Arc<ExprNode>) -> bool {
@@ -378,54 +385,37 @@ impl FreeOccurrenceProbe {
 impl ExprVisitor for FreeOccurrenceProbe {
     fn start_visit_var(
         &mut self,
-        _expr: &Arc<ExprNode>,
+        expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
         StartVisitResult::VisitChildren
     }
 
     fn end_visit_var(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        let var = expr.get_var();
-
-        // If the target name is shadowed, do nothing
-        if self.shadowed.contains(&self.target_name) {
-            return EndVisitResult::unchanged(expr);
-        }
-
-        // If the variable name matches the target name, increment count
-        if var.name == self.target_name {
-            self.count += 1;
-        }
-
+        // A variable expression is entered only when it is an occurrence of the target name.
+        self.count += 1;
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_llvm(
         &mut self,
-        _expr: &Arc<ExprNode>,
+        expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
         StartVisitResult::VisitChildren
     }
 
     fn end_visit_llvm(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        let llvm = expr.get_llvm();
-
-        if !self.shadowed.contains(&self.target_name) {
-            for fv in llvm.generator.free_vars() {
-                if fv == self.target_name {
-                    self.is_argument_to_llvm = true;
-                }
-            }
-        }
-
-        // If the target name is shadowed, do nothing
-        if self.shadowed.contains(&self.target_name) {
-            return EndVisitResult::unchanged(expr);
-        }
-
-        // Count occurrences in free_vars
-        for fv in llvm.generator.free_vars() {
+        // An LLVM expression is entered only when it takes the target name as an argument, which it
+        // may do more than once.
+        self.is_argument_to_llvm = true;
+        for fv in expr.get_llvm().generator.free_vars() {
             if fv == self.target_name {
                 self.count += 1;
             }
@@ -440,18 +430,18 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Function application expression {f}({x}).
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
 
         // If {x} contains the target name, and {f} contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            if expr
-                .get_app_args()
-                .iter()
-                .any(|arg| arg.free_vars().contains(&self.target_name))
-            {
-                if FreeOccurrenceProbe::contains_local_name(&expr.get_app_func()) {
-                    self.used_before_any_other_local_names = false;
-                }
-            }
+        if expr
+            .get_app_args()
+            .iter()
+            .any(|arg| self.target_occurs_in(arg))
+            && FreeOccurrenceProbe::contains_local_name(&expr.get_app_func())
+        {
+            self.used_before_any_other_local_names = false;
         }
 
         StartVisitResult::VisitChildren
@@ -459,14 +449,9 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn end_visit_app(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         // Check if the applied function is the target name
-        if !self.shadowed.contains(&self.target_name) {
-            let func = expr.get_app_func();
-            if func.is_var() {
-                let var = func.get_var();
-                if var.name == self.target_name {
-                    self.is_applied = true;
-                }
-            }
+        let func = expr.get_app_func();
+        if func.is_var() && func.get_var().name == self.target_name {
+            self.is_applied = true;
         }
         EndVisitResult::unchanged(expr)
     }
@@ -476,32 +461,16 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // Set is_captured_by_lambda if the target name is free in this lambda.
-        if !self.shadowed.contains(&self.target_name) {
-            let lam_names = expr.free_vars();
-            if lam_names.contains(&self.target_name) {
-                self.is_captured_by_lambda = true;
-            }
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
         }
 
-        let params = expr.get_lam_params();
+        // A lambda expression is entered only when the target name is free in it, i.e., captured by
+        // it. Its parameters are therefore names other than the target name, and the body is
+        // visited with the target name still standing for the same binding.
+        self.is_captured_by_lambda = true;
 
-        // Save the current shadowed state
-        let bak_shadowed = self.shadowed.clone();
-
-        // Add parameters to shadowed set
-        for param in &params {
-            self.shadowed.insert(param.name.clone());
-        }
-
-        // Visit the body
-        let body = expr.get_lam_body();
-        self.traverse(&body);
-
-        // Restore the shadowed state
-        self.shadowed = bak_shadowed;
-
-        StartVisitResult::Return
+        StartVisitResult::VisitChildren
     }
 
     fn end_visit_lam(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
@@ -514,39 +483,30 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Let expression `let {pat} = {bound} in {value}`.
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+        let target_rebound = expr
+            .get_let_pat()
+            .pattern
+            .vars()
+            .contains(&self.target_name);
 
         // If {value} contains the target name, and {bound} contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let pat_names = expr.get_let_pat().pattern.vars();
-            let val_names = expr.get_let_value().free_vars();
-            if !pat_names.contains(&self.target_name) && val_names.contains(&self.target_name) {
-                // Then the target name appears in {value}.
-                if FreeOccurrenceProbe::contains_local_name(&expr.get_let_bound()) {
-                    self.used_before_any_other_local_names = false;
-                }
-            }
+        if !target_rebound
+            && self.target_occurs_in(&expr.get_let_value())
+            && FreeOccurrenceProbe::contains_local_name(&expr.get_let_bound())
+        {
+            self.used_before_any_other_local_names = false;
         }
 
-        // Visit the bound expression first (where the target name is still free)
-        let bound = expr.get_let_bound();
-        self.traverse(&bound);
+        // Visit the bound expression, where the target name is still free.
+        self.traverse(&expr.get_let_bound());
 
-        // Save the current shadowed state
-        let bak_shadowed = self.shadowed.clone();
-
-        // Add pattern variables to shadowed set
-        let pattern = expr.get_let_pat();
-        let introduced_names = pattern.pattern.vars();
-        for name in introduced_names {
-            self.shadowed.insert(name);
+        // Visit the value expression, unless {pat} gives the target name to another binding.
+        if !target_rebound {
+            self.traverse(&expr.get_let_value());
         }
-
-        // Visit the value expression
-        let value = expr.get_let_value();
-        self.traverse(&value);
-
-        // Restore the shadowed state
-        self.shadowed = bak_shadowed;
 
         StartVisitResult::Return
     }
@@ -561,17 +521,16 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // If expression `if {cond} { {then} } else { {else} }`.
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
 
         // if the target name appears in {then} or {else}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let then_expr = expr.get_if_then();
-            let else_expr = expr.get_if_else();
-            if (then_expr.free_vars().contains(&self.target_name)
-                || else_expr.free_vars().contains(&self.target_name))
-                && FreeOccurrenceProbe::contains_local_name(&expr.get_if_cond())
-            {
-                self.used_before_any_other_local_names = false;
-            }
+        if (self.target_occurs_in(&expr.get_if_then())
+            || self.target_occurs_in(&expr.get_if_else()))
+            && FreeOccurrenceProbe::contains_local_name(&expr.get_if_cond())
+        {
+            self.used_before_any_other_local_names = false;
         }
 
         StartVisitResult::VisitChildren
@@ -587,45 +546,31 @@ impl ExprVisitor for FreeOccurrenceProbe {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Match expression `match {cond} { pat1 => {val1}; pat2 => {val2}; ... }`.
-        // If the target name appears in any {val} (not shadowed by {pat}), and {cond} contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let pat_vals = expr.get_match_pat_vals();
-            let mut appear_in_val = false;
-            for (pat, val) in &pat_vals {
-                let pat_names = pat.pattern.vars();
-                if !pat_names.contains(&self.target_name)
-                    && val.free_vars().contains(&self.target_name)
-                {
-                    appear_in_val = true;
-                    break;
-                }
-            }
-            if appear_in_val && FreeOccurrenceProbe::contains_local_name(&expr.get_match_cond()) {
-                self.used_before_any_other_local_names = false;
-            }
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+        // The value expressions of the arms whose {pat} leaves the target name standing for the
+        // binding under inspection.
+        let vals = expr
+            .get_match_pat_vals()
+            .into_iter()
+            .filter(|(pat, _val)| !pat.pattern.vars().contains(&self.target_name))
+            .map(|(_pat, val)| val)
+            .collect::<Vec<_>>();
+
+        // If the target name appears in any such {val}, and {cond} contains local name, then set `used_before_any_other_local_names` to false.
+        if vals.iter().any(|val| self.target_occurs_in(val))
+            && FreeOccurrenceProbe::contains_local_name(&expr.get_match_cond())
+        {
+            self.used_before_any_other_local_names = false;
         }
 
         // Visit the condition expression first
-        let cond = expr.get_match_cond();
-        self.traverse(&cond);
+        self.traverse(&expr.get_match_cond());
 
-        // Visit each match case
-        let pat_vals = expr.get_match_pat_vals();
-        for (pat, val) in &pat_vals {
-            // Save the current shadowed state
-            let bak_shadowed = self.shadowed.clone();
-
-            // Add pattern variables to shadowed set
-            let introduced_names = pat.pattern.vars();
-            for name in introduced_names {
-                self.shadowed.insert(name);
-            }
-
-            // Visit the value expression
+        // Visit the value expression of each arm
+        for val in vals {
             self.traverse(&val);
-
-            // Restore the shadowed state
-            self.shadowed = bak_shadowed;
         }
 
         StartVisitResult::Return
@@ -637,9 +582,12 @@ impl ExprVisitor for FreeOccurrenceProbe {
 
     fn start_visit_tyanno(
         &mut self,
-        _expr: &Arc<ExprNode>,
+        expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
         StartVisitResult::VisitChildren
     }
 
@@ -656,22 +604,17 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // If any field contains the target name, and any other field contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let expr_mames = expr.free_vars();
-            if expr_mames.contains(&self.target_name) {
-                // Then the target name appears in some field.
-                let struct_fields = expr.get_make_struct_fields();
-                for (_, _, field) in &struct_fields {
-                    let field_free_vars = field.free_vars();
-                    if !field_free_vars.contains(&self.target_name)
-                        && FreeOccurrenceProbe::contains_local_name(field)
-                    {
-                        // A field contains local name other than the target name.
-                        self.used_before_any_other_local_names = false;
-                        break;
-                    }
-                }
+        // A struct expression is entered only when the target name appears in some field.
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+
+        // If any other field contains local name, then set `used_before_any_other_local_names` to false.
+        for (_, _, field) in &expr.get_make_struct_fields() {
+            if !self.target_occurs_in(field) && FreeOccurrenceProbe::contains_local_name(field) {
+                // A field contains local name other than the target name.
+                self.used_before_any_other_local_names = false;
+                break;
             }
         }
 
@@ -691,22 +634,19 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // If any element contains the target name, and any other element contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let expr_mames = expr.free_vars();
-            if expr_mames.contains(&self.target_name) {
-                // Then the target name appears in some element.
-                let array_elements = expr.get_array_lit_elements();
-                for element in array_elements {
-                    let element_free_vars = element.free_vars();
-                    if !element_free_vars.contains(&self.target_name)
-                        && FreeOccurrenceProbe::contains_local_name(&element)
-                    {
-                        // An element contains local name other than the target name.
-                        self.used_before_any_other_local_names = false;
-                        break;
-                    }
-                }
+        // An array literal is entered only when the target name appears in some element.
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+
+        // If any other element contains local name, then set `used_before_any_other_local_names` to false.
+        for element in expr.get_array_lit_elements() {
+            if !self.target_occurs_in(&element)
+                && FreeOccurrenceProbe::contains_local_name(&element)
+            {
+                // An element contains local name other than the target name.
+                self.used_before_any_other_local_names = false;
+                break;
             }
         }
         StartVisitResult::VisitChildren
@@ -725,22 +665,17 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // If any argument contains the target name, and any other argument contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let expr_names = expr.free_vars();
-            if expr_names.contains(&self.target_name) {
-                // Then the target name appears in some argument.
-                let ffi_args = expr.get_ffi_call_args();
-                for arg in ffi_args {
-                    let arg_free_vars = arg.free_vars();
-                    if !arg_free_vars.contains(&self.target_name)
-                        && FreeOccurrenceProbe::contains_local_name(&arg)
-                    {
-                        // An argument contains local name other than the target name.
-                        self.used_before_any_other_local_names = false;
-                        break;
-                    }
-                }
+        // An FFI call is entered only when the target name appears in some argument.
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+
+        // If any other argument contains local name, then set `used_before_any_other_local_names` to false.
+        for arg in expr.get_ffi_call_args() {
+            if !self.target_occurs_in(&arg) && FreeOccurrenceProbe::contains_local_name(&arg) {
+                // An argument contains local name other than the target name.
+                self.used_before_any_other_local_names = false;
+                break;
             }
         }
         StartVisitResult::VisitChildren
@@ -759,15 +694,15 @@ impl ExprVisitor for FreeOccurrenceProbe {
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
+        if !self.target_occurs_in(expr) {
+            return StartVisitResult::Return;
+        }
+
         // If the main expression contains the target name, and the sub-expression contains local name, then set `used_before_any_other_local_names` to false.
-        if !self.shadowed.contains(&self.target_name) {
-            let side = expr.get_eval_side();
-            let main = expr.get_eval_main();
-            if main.free_vars().contains(&self.target_name)
-                && FreeOccurrenceProbe::contains_local_name(&side)
-            {
-                self.used_before_any_other_local_names = false;
-            }
+        if self.target_occurs_in(&expr.get_eval_main())
+            && FreeOccurrenceProbe::contains_local_name(&expr.get_eval_side())
+        {
+            self.used_before_any_other_local_names = false;
         }
         StartVisitResult::VisitChildren
     }

--- a/src/optimization/let_elimination.rs
+++ b/src/optimization/let_elimination.rs
@@ -338,9 +338,8 @@ impl<'a> ExprVisitor for LetEliminator<'a> {
 //
 // Everything it reports is a property of those occurrences, so a subexpression the name does not
 // occur free in leaves all of them as they stand. The traversal skips such subexpressions, which
-// keeps the cost of a probe proportional to the region where the name is used rather than to the
-// size of the expression it is run on. That region ends at a binder giving the name to another
-// binding, so no occurrence of another binding is ever reached.
+// keeps the cost of a probe proportional to the region where the name is used. That region ends at
+// a binder giving the name to another binding, so no occurrence of another binding is ever reached.
 struct FreeOccurrenceProbe {
     // The name to count occurrences of.
     target_name: FullName,

--- a/src/optimization/rename.rs
+++ b/src/optimization/rename.rs
@@ -780,7 +780,7 @@ mod tests {
         map.insert(local("x"), null_ptr());
         let res = Substitutor::new(map).traverse(&llvm_with_free_names(&["x", "#v0"]));
         assert!(
-            res.expr.free_vars().contains(&local("#v0")),
+            res.expr.has_free_var(&local("#v0")),
             "`#v0` of the enclosing scope was captured"
         );
     }
@@ -796,7 +796,7 @@ mod tests {
         map.insert(local("z"), null_ptr());
         let res = Substitutor::new(map).traverse(&llvm_with_free_names(&["x", "z"]));
         assert!(
-            res.expr.free_vars().contains(&local("z")),
+            res.expr.has_free_var(&local("z")),
             "`z` of the enclosing scope was captured"
         );
     }
@@ -812,7 +812,7 @@ mod tests {
         map.insert(local("z"), null_ptr());
         let res = Substitutor::new(map).traverse(&llvm_with_free_names(&["x", "z"]));
         assert!(
-            res.expr.free_vars().contains(&local("z")),
+            res.expr.has_free_var(&local("z")),
             "`z` of the enclosing scope was captured"
         );
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod test_hole_negative;
 mod test_hole_priority;
 mod test_import;
 mod test_index_syntax;
+mod test_let_elimination;
 mod test_llvm_passes;
 mod test_lsp;
 mod test_main_loop;

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -1,0 +1,126 @@
+// Let-elimination replaces `let x = {e0}; {e1}` with `{e1}[x := {e0}]` once it has inspected the
+// occurrences of `x` in `{e1}`. Which occurrences belong to that binding is what these tests pin:
+// an occurrence under a binder that gives the name to something else belongs to that binder, and an
+// occurrence the inspection reaches only through a lambda or a match arm still keeps the binding
+// alive.
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::Configuration;
+    use crate::tests::test_util::test_source;
+
+    /// The only occurrence of `x` is inside a lambda, which captures the binding.
+    #[test]
+    fn test_name_used_only_inside_a_lambda_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        used_in_lambda : I64 -> I64;
+        used_in_lambda = |a| (
+            let x = a + 1;
+            let f = |v : I64| v + x;
+            f(10)
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the lambda adds what `x` is bound to", used_in_lambda(5), 16);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The only occurrence of `x` is inside the value expression of a match arm.
+    #[test]
+    fn test_name_used_only_inside_a_match_arm_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        used_in_match_arm : I64 -> I64;
+        used_in_match_arm = |a| (
+            let x = a + 1;
+            match Option::some(3) {
+                some(v) => v + x,
+                none(_) => 0
+            }
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the arm adds what `x` is bound to", used_in_match_arm(5), 9);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A lambda parameter of the same name gives `x` inside the lambda to the parameter.
+    #[test]
+    fn test_name_rebound_by_a_lambda_parameter_denotes_the_parameter() {
+        let source = r#"
+        module Main;
+
+        rebound_by_lambda_param : I64 -> I64;
+        rebound_by_lambda_param = |a| (
+            let x = a + 1;
+            let g = |x : I64| x * 2;
+            g(10) + x
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"`x` in the lambda is its parameter", rebound_by_lambda_param(5), 26);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// An inner `let` of the same name gives `x` in its value expression to the inner binding.
+    #[test]
+    fn test_name_rebound_by_an_inner_let_denotes_the_inner_binding() {
+        let source = r#"
+        module Main;
+
+        rebound_by_inner_let : I64 -> I64;
+        rebound_by_inner_let = |a| (
+            let x = a + 1;
+            let y = (let x = 100; x * 2);
+            y + x
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"`x` in the inner `let` is what that `let` binds", rebound_by_inner_let(5), 206);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A match pattern of the same name gives `x` in that arm to the pattern, while the arm whose
+    /// pattern binds another name reaches the outer binding.
+    #[test]
+    fn test_name_rebound_by_a_match_pattern_denotes_the_pattern() {
+        let source = r#"
+        module Main;
+
+        rebound_by_match_pattern : I64 -> I64;
+        rebound_by_match_pattern = |a| (
+            let x = a + 1;
+            match Option::some(7) {
+                some(x) => x * 3,
+                none(_) => x
+            }
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"`x` in the arm is what the pattern binds", rebound_by_match_pattern(5), 21);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+}

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -2,7 +2,9 @@
 // occurrences of `x` in `{e1}`. Which occurrences belong to that binding is what these tests pin:
 // an occurrence under a binder that gives the name to something else belongs to that binder, and an
 // occurrence the inspection reaches only through a lambda or a match arm still keeps the binding
-// alive.
+// alive. The occurrences are placed in every kind of expression the inspection walks, and in each
+// position of a group evaluated together, so that the rewrite keeps the value whether or not
+// another local name is read ahead of the binding.
 
 #[cfg(test)]
 mod tests {
@@ -170,6 +172,368 @@ mod tests {
         main : IO ();
         main = (
             assert_eq(|_|"`x` in the arm is what the pattern binds", rebound_by_match_pattern(5), 21);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A destructuring `let` pattern gives `x` after it to what the pattern binds, while its bound
+    /// expression, evaluated in the enclosing scope, still reads the outer binding.
+    #[test]
+    fn test_name_rebound_by_a_destructuring_let_pattern_denotes_the_pattern() {
+        let source = r#"
+        module Main;
+
+        type Pair = unbox struct { fst : I64, snd : I64 };
+
+        rebound_by_destructuring_pattern : I64 -> I64;
+        rebound_by_destructuring_pattern = |a| (
+            let x = a + 1;
+            let Pair { fst : x, snd : y } = Pair { fst : x * 10, snd : 7 };
+            x + y
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"`x` after the pattern is what the pattern binds", rebound_by_destructuring_pattern(5), 67);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A name several levels down a nested pattern binds just as one at the top of it does.
+    #[test]
+    fn test_name_rebound_deep_inside_a_nested_pattern_denotes_the_pattern() {
+        let source = r#"
+        module Main;
+
+        type Pair = unbox struct { fst : I64, snd : I64 };
+        type Nest = unbox struct { inner : Pair, tag : I64 };
+
+        rebound_deep_in_pattern : I64 -> I64;
+        rebound_deep_in_pattern = |a| (
+            let x = a + 1;
+            let Nest { inner : Pair { fst : x, snd : y }, tag : t } =
+                Nest { inner : Pair { fst : x * 10, snd : 7 }, tag : x };
+            x + y + t
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"`x` after the pattern is what the pattern binds", rebound_deep_in_pattern(5), 73);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A union pattern of a match arm gives `x` in that arm to what it binds, while an arm whose
+    /// pattern binds another name reaches the outer binding.
+    #[test]
+    fn test_name_rebound_by_a_union_pattern_denotes_the_pattern() {
+        let source = r#"
+        module Main;
+
+        type Pair = unbox struct { fst : I64, snd : I64 };
+        type Choice = unbox union { one : I64, two : Pair };
+
+        rebound_by_union_pattern : I64 -> I64;
+        rebound_by_union_pattern = |a| (
+            let x = a + 1;
+            let inner = match Choice::two(Pair { fst : 3, snd : 4 }) {
+                one(v) => v + x,
+                two(Pair { fst : x, snd : s }) => x * 1000 + s
+            };
+            let outer = match Choice::one(5) {
+                one(v) => v + x,
+                two(p) => Pair::@fst(p)
+            };
+            inner + outer
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"each arm reads the binding its own pattern leaves standing", rebound_by_union_pattern(5), 3015);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// A chain of `let`s that each give the same name to a new binding, each bound expression
+    /// reading the binding before it.
+    #[test]
+    fn test_a_chain_of_rebindings_reads_the_binding_before_each() {
+        let source = r#"
+        module Main;
+
+        chain_of_rebindings : I64 -> I64;
+        chain_of_rebindings = |a| (
+            let x = a + 1;
+            let x = (
+                let x = (
+                    let x = x * 2;
+                    x + 1
+                );
+                x * 3
+            );
+            x + 1
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"each `let` reads the binding before it", chain_of_rebindings(5), 40);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The only occurrence of `x` is under a type annotation.
+    #[test]
+    fn test_name_used_only_under_a_type_annotation_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        used_under_type_annotation : I64 -> I64;
+        used_under_type_annotation = |a| (
+            let x = a + 1;
+            (x : I64) * 10
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the annotated expression is what `x` is bound to", used_under_type_annotation(5), 60);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The only occurrence of `x` is an argument to an inline-LLVM expression, which an array read
+    /// compiles to.
+    #[test]
+    fn test_name_used_only_as_an_llvm_argument_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        used_as_llvm_argument : I64 -> I64;
+        used_as_llvm_argument = |a| (
+            let x = [a, a + 1, a + 2];
+            x.@(2)
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the read answers the last element of what `x` is bound to", used_as_llvm_argument(5), 7);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The only occurrence of `x` is the function of an application, and `x` is bound to a strictly
+    /// partial application of names to a global lambda.
+    #[test]
+    fn test_name_bound_to_a_partial_application_and_applied_once() {
+        let source = r#"
+        module Main;
+
+        add3 : I64 -> I64 -> I64 -> I64;
+        add3 = |a, b, c| a + b + c;
+
+        applied_partial_application : I64 -> I64;
+        applied_partial_application = |a| (
+            let g = add3(a);
+            g(20, 300)
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the call sums the parameter and the two arguments", applied_partial_application(5), 325);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in a later field of a struct expression while an earlier field reads a
+    /// name of the enclosing scope.
+    #[test]
+    fn test_binding_read_in_a_later_struct_field_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        type Pair = struct { a : I64, b : I64 };
+
+        read_in_later_field : Array I64 -> I64;
+        read_in_later_field = |arr| (
+            let x = arr.get_size * 10;
+            let p = Pair { a : arr.@(0), b : x };
+            p.@a + p.@b
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the fields hold the first element and ten times the size", read_in_later_field([7, 8, 9]), 37);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in a middle element of an array literal whose other elements read a name
+    /// of the enclosing scope.
+    #[test]
+    fn test_binding_read_in_an_array_literal_element_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        read_in_element : Array I64 -> I64;
+        read_in_element = |arr| (
+            let x = arr.get_size * 10;
+            let lit = [arr.@(0), x, arr.@(1)];
+            lit.@(0) + lit.@(1) + lit.@(2)
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the literal holds two elements and ten times the size", read_in_element([7, 8, 9]), 45);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in a match arm whose condition reads a name of the enclosing scope.
+    #[test]
+    fn test_binding_read_in_an_arm_of_a_match_on_an_enclosing_name_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        read_in_arm : Array I64 -> I64;
+        read_in_arm = |arr| (
+            let x = arr.get_size * 10;
+            match Option::some(arr.@(0)) {
+                some(v) => v + x,
+                none(_) => x
+            }
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the arm adds the first element to ten times the size", read_in_arm([7, 8, 9]), 37);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in a branch of an `if` whose condition reads a name of the enclosing
+    /// scope.
+    #[test]
+    fn test_binding_read_in_a_branch_of_an_if_on_an_enclosing_name_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        read_in_branch : Array I64 -> I64;
+        read_in_branch = |arr| (
+            let x = arr.get_size * 10;
+            if arr.@(0) > 0 { x + arr.@(1) } else { 0 }
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the branch adds the second element to ten times the size", read_in_branch([7, 8, 9]), 38);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in the main expression of an `eval` whose side expression reads a name of
+    /// the enclosing scope, and in the body of a lambda that captures such a name too.
+    #[test]
+    fn test_binding_read_after_an_eval_and_inside_a_capturing_lambda_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        read_after_eval : Array I64 -> I64;
+        read_after_eval = |arr| (
+            let x = arr.get_size * 10;
+            eval arr.@(0);
+            x + 1
+        );
+
+        read_inside_lambda : Array I64 -> I64;
+        read_inside_lambda = |arr| (
+            let x = arr.get_size * 10;
+            let h = |k : I64| k + x + arr.@(0);
+            h(1) + h(2)
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the eval leaves ten times the size plus one", read_after_eval([7, 8, 9]), 31);;
+            assert_eq(|_|"the lambda adds what `x` is bound to on each call", read_inside_lambda([7, 8, 9]), 77);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in an argument of an FFI call whose other argument reads a name of the
+    /// enclosing scope.
+    #[test]
+    fn test_binding_read_in_an_ffi_call_argument_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        read_in_ffi_argument : Array U8 -> I64;
+        read_in_ffi_argument = |bytes| (
+            let n = bytes.get_size.to_I64;
+            let c = bytes.@(0).to_I64;
+            let a = FFI_CALL[CInt abs(CInt), (0 - c).to_CInt];
+            a.to_I64 + n
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the call returns the magnitude of the first byte plus the size", read_in_ffi_argument([65_U8, 66_U8, 67_U8]), 68);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The binding is read in the second argument of a dot-form call whose receiver is the array the
+    /// bound expression reads.
+    #[test]
+    fn test_binding_read_beside_its_own_array_keeps_its_value() {
+        let source = r#"
+        module Main;
+
+        set_from_size : Array I64 -> Array I64;
+        set_from_size = |arr| (
+            let x = arr.get_size + 100;
+            arr.set(0, x)
+        );
+
+        set_from_element : Array I64 -> Array I64;
+        set_from_element = |arr| (
+            let y = arr.@(1) * 1000;
+            arr.set(2, y)
+        );
+
+        digits : Array I64 -> I64;
+        digits = |arr| arr.to_iter.fold(0, |e, s| s * 10 + e);
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the first element becomes the size plus a hundred", set_from_size([1, 2, 3]).digits, 10323);;
+            assert_eq(|_|"the last element becomes a thousand times the second", set_from_element([1, 2, 3]).digits, 2120);;
             pure()
         );
         "#;

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -207,11 +207,11 @@ mod tests {
              succ : I64 -> I64;\n\
              succ = |x| x + 1;\n\
              \n\
-             seq : I64 -> I64;\n\
-             seq = |x| (\n{body});\n\
+             let_chain : I64 -> I64;\n\
+             let_chain = |x| (\n{body});\n\
              \n\
              main : IO ();\n\
-             main = println(seq(0).to_string);\n"
+             main = println(let_chain(0).to_string);\n"
         );
 
         let temp_dir = TempDir::new().expect("Failed to create temp directory");

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -181,9 +181,10 @@ mod tests {
     // binding.
     const CHAIN_LENGTH: usize = 2400;
 
-    // Generous next to the few seconds the build takes, and short enough to report a regression as
-    // a failure instead of occupying the machine.
-    const TIMEOUT: Duration = Duration::from_secs(60);
+    // Generous next to the few seconds the build takes, with room for a machine several times
+    // slower running the rest of the suite beside it, and well short of the minutes the build takes
+    // once the inspection walks whole bodies again.
+    const TIMEOUT: Duration = Duration::from_secs(120);
 
     /// Builds and runs a global whose body is a chain of `CHAIN_LENGTH` `let`s, failing if the
     /// build does not finish within `TIMEOUT`. `-O max` is the level that inspects the chain twice:

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -7,7 +7,11 @@
 #[cfg(test)]
 mod tests {
     use crate::configuration::Configuration;
-    use crate::tests::test_util::test_source;
+    use crate::tests::test_util::{fix_build_source_command, test_source, wait_within};
+    use std::fs::{self, File};
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+    use tempfile::TempDir;
 
     /// The only occurrence of `x` is inside a lambda, which captures the binding.
     #[test]
@@ -99,6 +103,54 @@ mod tests {
         test_source(source, Configuration::develop_mode());
     }
 
+    /// The bound expression of a `let` is evaluated in the enclosing scope, so it reaches the outer
+    /// binding even when the pattern gives the same name to what it binds.
+    #[test]
+    fn test_name_read_by_the_bound_expression_of_a_rebinding_let_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        rebinding_let_reads_the_outer_name : I64 -> I64;
+        rebinding_let_reads_the_outer_name = |a| (
+            let x = a + 1;
+            let x = x * 2;
+            x + x
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the bound expression doubles what the outer `x` is bound to", rebinding_let_reads_the_outer_name(5), 24);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
+    /// The expression a match inspects is evaluated in the enclosing scope, so it reaches the outer
+    /// binding even when every arm gives the same name to what its pattern binds.
+    #[test]
+    fn test_name_read_by_a_match_condition_keeps_its_binding() {
+        let source = r#"
+        module Main;
+
+        match_condition_reads_the_outer_name : I64 -> I64;
+        match_condition_reads_the_outer_name = |a| (
+            let x = a + 1;
+            match Option::some(x) {
+                some(x) => x * 3,
+                none(_) => 0
+            }
+        );
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"the match inspects what the outer `x` is bound to", match_condition_reads_the_outer_name(5), 18);;
+            pure()
+        );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+
     /// A match pattern of the same name gives `x` in that arm to the pattern, while the arm whose
     /// pattern binds another name reaches the outer binding.
     #[test]
@@ -122,5 +174,90 @@ mod tests {
         );
         "#;
         test_source(source, Configuration::develop_mode());
+    }
+
+    // A chain this long builds in a few seconds while the inspection of a binding is proportional
+    // to where its name is read, and in several minutes while it walks the whole body of every
+    // binding.
+    const CHAIN_LENGTH: usize = 2400;
+
+    // Generous next to the few seconds the build takes, and short enough to report a regression as
+    // a failure instead of occupying the machine.
+    const TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// Builds and runs a global whose body is a chain of `CHAIN_LENGTH` `let`s, failing if the
+    /// build does not finish within `TIMEOUT`. `-O max` is the level that inspects the chain twice:
+    /// once for the local inlining that eliminates `let`s, and again for the eta expansion that
+    /// uncurrying runs the same pass on.
+    ///
+    /// Each binding calls a global of one parameter rather than writing the arithmetic out, which
+    /// keeps type checking a small part of the budget: an operator resolved through a trait carries
+    /// a predicate per occurrence, and a chain of those spends most of the build before the
+    /// inspection under test even runs.
+    #[test]
+    fn test_long_let_chain_compiles_in_reasonable_time() {
+        let mut body = String::from("    let a0 = succ(x);\n");
+        for i in 1..CHAIN_LENGTH {
+            body.push_str(&format!("    let a{} = succ(a{});\n", i, i - 1));
+        }
+        body.push_str(&format!("    a{}\n", CHAIN_LENGTH - 1));
+        let source = format!(
+            "module Main;\n\
+             \n\
+             succ : I64 -> I64;\n\
+             succ = |x| x + 1;\n\
+             \n\
+             seq : I64 -> I64;\n\
+             seq = |x| (\n{body});\n\
+             \n\
+             main : IO ();\n\
+             main = println(seq(0).to_string);\n"
+        );
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let program_path = temp_dir.path().join("long_let_chain");
+
+        // The compiler's diagnostics go to a file, which the test reads once the child has exited.
+        // A pipe left unread that long fills its buffer and blocks the very build being timed.
+        let log_path = temp_dir.path().join("build.log");
+        let log = File::create(&log_path).expect("Failed to create the build log");
+        let log_for_stderr = log
+            .try_clone()
+            .expect("Failed to clone the build log handle");
+
+        let mut command = fix_build_source_command(temp_dir.path(), &source, "max");
+        command
+            .arg("-o")
+            .arg(&program_path)
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(log_for_stderr));
+        let mut child = command.spawn().expect("Failed to execute fix build");
+        let status = wait_within(
+            &mut child,
+            TIMEOUT,
+            &format!("compiling a chain of {} `let`s", CHAIN_LENGTH),
+        );
+        assert!(
+            status.success(),
+            "compiling a chain of {} `let`s failed: {}\n{}",
+            CHAIN_LENGTH,
+            status,
+            fs::read_to_string(&log_path).expect("Failed to read the build log")
+        );
+
+        let output = Command::new(&program_path)
+            .output()
+            .expect("Failed to run the compiled program");
+        assert!(
+            output.status.success(),
+            "the compiled program exited with {}",
+            output.status
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            CHAIN_LENGTH.to_string(),
+            "the chain of {} `let`s returned a wrong value",
+            CHAIN_LENGTH
+        );
     }
 }


### PR DESCRIPTION
Fixes #144.

A function whose body is a long straight-line chain of `let`s took time superlinear in its length to compile: at `-O max`, 1600 `let`s took 94 seconds, of which 81 were `optimization::run` — 54 in `inline_local` and 27 in `uncurry`.

## Where the time went

Both passes spend it in the same place. `let_elimination` decides whether `let x = {e0}; {e1}` may be rewritten into `{e1}[x := {e0}]` by running a `FreeOccurrenceProbe` over `{e1}`, and it does so for every `let` in the expression. In a chain of `N` bindings the k-th body is the remaining `N - k` bindings, so one traversal of a function ran `N` probes covering `N + (N-1) + ... + 1` nodes. `uncurry` inherits this through `eta_expansion::run_on_expr`, which calls the same pass.

On top of that, the probe carried a `Set` of the names shadowed above the node it was visiting, and saved and restored a copy of it at every lambda, `let` and match arm. Walking a chain of `N` bindings grew that set to `N` names and copied it `N` times, which is what made the growth steeper than quadratic — measured, `uncurry` rose 7.5x per doubling of `N`.

The clone in `ExprNode::free_vars` named in the issue is real, but it is the cost of one node visit rather than the reason there are so many node visits.

## The fix

Everything the probe reports is a property of the free occurrences of one name, so a subexpression that name does not occur free in leaves all of them as they stand. The traversal now visits a subexpression only when the name occurs free in it, which it asks of the free-variable set each expression node already memoizes. `ExprVisitor::should_visit` puts that question in `visit_expr`, ahead of the match on the kind of expression, so a kind added later is covered without being told; every other visitor keeps the default answer and is unchanged.

That also settles the shadowing: the traversal stops at a binder that gives the name to another binding, so it never reaches an occurrence of a different binding, and the set of shadowed names goes away together with the copying it required. Each remaining test of whether the name is shadowed, or whether it occurs in the subexpression about to be visited, is answered by the traversal having gone there at all.

`ExprNode::has_free_var` and `has_free_local_var` answer the membership questions without copying the memoized set.

One name needs saying: a lambda expression binds `#CAP` implicitly, so the free variables of an expression are the one place `#CAP` does not appear, and a probe of it would find no occurrence in any lambda that reads it — reporting an unused binding where the old counting reported a mislabelled one. No `let` binds that name; `FreeOccurrenceProbe::new` now asserts it.

## Measurements

`fix build -O max` on the issue's program, wall clock, including the ~2.5 seconds of standard library it compiles:

| N | before | after |
| --- | --- | --- |
| 200 | 2.86s | 2.71s |
| 400 | 4.84s | 3.53s |
| 800 | 16.62s | 6.09s |
| 1600 | 93.86s | 14.66s |

The passes themselves:

| N | `inline_local` | `uncurry` | `optimization::run` |
| --- | --- | --- | --- |
| 400 | 0.912s -> 0.006s | 0.448s -> 0.004s | 1.390s -> 0.040s |
| 800 | 7.185s -> 0.015s | 3.567s -> 0.008s | 10.800s -> 0.072s |
| 1600 | 53.816s -> 0.026s | 26.906s -> 0.015s | 80.821s -> 0.128s |

`optimization::run` now doubles as `N` doubles.

## Nothing that compiles today is affected

The traversal skips only what it could learn nothing from, so a probe returns what it returned before and the pass makes the same decisions.

Measured: every program in `examples/` compiled with the base compiler and this one at `-O basic`, `-O max` and `-O experimental`, comparing the emitted LLVM IR — 51 of 51 pairs identical. (The comparator was checked against pairs that must differ: the same program at two optimization levels, and two different programs.) The full test suite passes at `FIX_MAX_OPT_LEVEL` of `basic`, `max` and `experimental`, 1115 tests each.

Since the emitted code is unchanged, no speedtest row is recorded and no changelog entry is added.

## Tests

`src/tests/test_let_elimination.rs` pins which occurrences of a name belong to the binding under inspection: a name read only inside a lambda or a match arm keeps its binding alive; a lambda parameter, an inner `let` or a match pattern of the same name takes the occurrences under it; and the bound expression of a `let`, together with the expression a match inspects, reaches the outer binding across a pattern that rebinds the name. Each was checked to fail on a traversal that stops short — skipping a lambda body fails all of them, skipping the match arms or the match condition fails exactly the tests about match, and skipping the bound expression of a rebinding `let` fails exactly the test about that.

The last test bounds the build of a chain of 2400 `let`s at 60 seconds; it takes 5 seconds here and four and a half minutes with the compiler this branch starts from. Each binding calls a global of one parameter rather than writing the arithmetic out, so that type checking — which an operator resolved through a trait makes the larger part of the budget — leaves the bound measuring what it is about.

## What is left

The remaining cost of the issue's program is type checking: 14.3 of the 14.7 seconds at N=1600, and still superlinear (3.3s / 5.8s / 14.3s for N of 400 / 800 / 1600). That is a separate mechanism from the one this changes.

The probe is proportional to the region where a name is used, which for a body binding `N` names all read at the end is still `O(N^2)` — but of hash lookups rather than of node visits that copy sets. Such a body with 400 bindings builds in 5.1s where it took 9.4s.

The substitution that follows a probe walks the whole body as the probe used to, and could ask the same question of the same memoized sets. It is not what this program spends its time on, so it is left as it stands.
