### PR TITLE
Document that consecutive let-expressions have no guaranteed evaluation order

### DIFF
--- a/Document.md
+++ b/Document.md
@@ -370,6 +370,8 @@ will be compiled, but the name `x` in the right hand side of `let x = x + 3` is 
 
 This means that you cannot define a local recursive function by let-expression naively. To do this, use `fix` built-in function.
 
+The order in which consecutive `let`-expressions evaluate their bound expressions is not guaranteed. A program that observes that order — two bindings that each abort, or that each print — can behave differently at different optimization levels. Sequence effects in `IO` to fix the order they happen in.
+
 ## If-expressions
 
 The syntax of `if` is the following: `if cond { expr_0 } (else|;) { expr_1 }` where curly braces around `expr_1` is optional.


### PR DESCRIPTION
A sequence of `let`s can be evaluated in an order other than the one it is written in, and the order a given program gets depends on the optimization level.

```fix
module Main;

first : I64 -> I64;
first = |_| undefined("A aborts");

second : I64 -> I64;
second = |_| undefined("B aborts");

g : I64 -> I64;
g = |_| (
    let x = first(0);
    let y = second(0);
    x * 10 + y
);

main : IO ();
main = println(g(0).to_string);
```

reports `A aborts` at `-O none`, `-O max` and `-O experimental`, and `B aborts` at `-O basic`. Both bindings are read by the expression that follows them, so neither evaluation is omitted; what differs is which one happens first.

Nothing in the documentation said which to expect. `eval` covers the neighbouring question — whether an expression is evaluated at all — and its notes already say that the order of its own two expressions is not guaranteed. This adds the same statement for `let`, and points at `IO` as the way to fix the order of effects.

The order stays unspecified: the mechanism is `let_elimination`'s condition 2-c, which moves a bound expression to where its name is read whenever that name is the first local name read, and which exists to keep the values the expression references from outliving their lifetime. Specifying the order would cost that.
