### PR TITLE
Decide a binder's renaming without the set it needs only to pick new names

### DIFF
--- a/src/optimization/rename.rs
+++ b/src/optimization/rename.rs
@@ -592,6 +592,13 @@ fn calculate_renaming_bound_vars_avoiding(
         }
     }
 
+    // Everything below decides a new name for each name to rename, so a binder that keeps every
+    // name it binds needs none of it -- including the free variables of `value`, a set as large as
+    // the expression under the binder.
+    if names_to_rename.is_empty() {
+        return Map::default();
+    }
+
     // Calculate the set of names that should be avoided when we decide new names.
     let mut ng_list = ng_list.clone();
     for var in value.free_vars() {


### PR DESCRIPTION
Part of #159.

`Substitutor` walks the whole expression it substitutes into, and at every binder it passes, `calculate_renaming_bound_vars_avoiding` decides which of the names that binder introduces have to be renamed apart. That decision reads `ng_list`, the free names of the replacement expressions, and needs nothing else.

The function then builds a second, larger set out of `ng_list` plus the whole of `value.free_vars()`. It is used for one thing: choosing names that clash with nothing. When no name has to be renamed, `generate_new_names` is asked for zero names and that set is never read.

So a binder that keeps every name it binds now returns before building it. `value.free_vars()` is a set as large as the expression under the binder, and a copy of it is made at each binder the substitution passes, so what this removes grows with both the size of a body and the number of binders in it.

## What it buys

`fix build -O max` on a body of N bindings all read at the bottom -- the program in #159 -- wall clock, idle machine:

| N | main | this branch |
| --- | --- | --- |
| 300 | 5.3s | 4.7s |
| 600 | 25.3s | 19.6s |
| 1200 | 185.2s | 135.8s |

The larger part of that program's cost is the occurrence inspection #154 addresses, and it is paid at the same binders: with #154 also applied, the same program at N=1200 goes from 53.6s to **9.2s**. Neither cost is fully visible until the other is gone.

The walk itself remains. Giving `Substitutor` the entry decision the inspection now uses would remove it; #159 records that as a separate change, because `enter_scope` renames the binders it passes even where the substitution cannot reach and nothing establishes whether a later stage relies on those renames.

## Tests

Full suite at `FIX_MAX_OPT_LEVEL` of `basic`, `max` and `experimental`: 1111 passed, 0 failed at each.

The emitted code is unchanged, so no changelog entry and no speedtest row.
