### PR TITLE
Cut what type checking copies when it tries something it may abandon

### DIFF
--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -24,7 +24,7 @@ use crate::elaboration::desugar_opaque::{
     remove_opaque_wrapper_func, resolve_opaque_tycon_in_expr, resolve_opaque_type_in_type,
 };
 use crate::elaboration::name_resolution::{NameResolutionContext, NameResolutionEnv};
-use crate::elaboration::typecheck::{TypeCheckContext, UnifOrOtherErr};
+use crate::elaboration::typecheck::TypeCheckContext;
 use crate::error::{panic_if_err, Error, Errors, WARN_DEPRECATED};
 use crate::fixstd::builtin::{
     boxed_trait_instance, bulitin_tycons, make_io_unit_ty, make_unit_ty, struct_act,
@@ -1434,9 +1434,8 @@ impl Program {
         // Also resolve opaque types in method_ty so both sides use concrete types.
         let opaque_types = &self.opaque_types;
         let method_selector = |method: &TraitMemberImpl| -> Result<bool, Errors> {
-            let mut tc0 = tc.clone();
             let method_ty = resolve_opaque_type_in_type(&method.scm_via_defn.ty, opaque_types);
-            Ok(UnifOrOtherErr::extract_others(tc0.unify(&method_ty, &sym.ty))?.is_ok())
+            tc.are_unifiable(&method_ty, &sym.ty)
         };
 
         // Select the typed expression to specialize.

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1433,7 +1433,7 @@ impl Program {
         // Select method implementation whose type unifies with the required type `sym.ty`.
         // Also resolve opaque types in method_ty so both sides use concrete types.
         let opaque_types = &self.opaque_types;
-        let method_selector = |method: &TraitMemberImpl| -> Result<bool, Errors> {
+        let method_type_matches = |method: &TraitMemberImpl| -> Result<bool, Errors> {
             let method_ty = resolve_opaque_type_in_type(&method.scm_via_defn.ty, opaque_types);
             tc.are_unifiable(&method_ty, &sym.ty)
         };
@@ -1445,7 +1445,7 @@ impl Program {
             SymbolExpr::Method(impls) => {
                 let method = impls
                     .iter()
-                    .find(|method| method_selector(method).unwrap_or(false))
+                    .find(|method| method_type_matches(method).unwrap_or(false))
                     .unwrap();
                 &method.expr
             }

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1418,9 +1418,12 @@ impl Program {
         errors.to_result()
     }
 
-    // Instantiate symbol.
-    // Assumes that namespace resolution and type-checking have already been performed
-    // for all global values (via `resolve_namespace_and_check_type_in_modules`).
+    /// Fills `sym.expr` with the typed expression of `sym.generic_name`
+    /// specialized to `sym.ty`, picking the matching implementation when the
+    /// symbol is a trait method.
+    ///
+    /// Assumes that `resolve_namespace_and_check_type_in_modules` has already
+    /// run over all global values.
     fn instantiate_symbol(
         &mut self,
         sym: &mut Symbol,
@@ -1476,7 +1479,9 @@ impl Program {
         Ok(())
     }
 
-    // Instantiate all symbols.
+    /// Instantiates every symbol queued in `deferred_instantiation`, moving each
+    /// into `symbols`. Instantiation queues further symbols, so this runs until
+    /// the queue drains.
     pub fn instantiate_symbols(&mut self, tc: &TypeCheckContext) -> Result<(), Errors> {
         let mut errors = Errors::empty();
         while !self.deferred_instantiation.is_empty() {
@@ -1489,7 +1494,12 @@ impl Program {
         errors.to_result()
     }
 
-    // Instantiate `Main::main` (or `Test::test` if `fix test` is running).
+    /// Instantiates the program's entry point at type `IO ()` and stores it in
+    /// `entry_io_value`.
+    ///
+    /// # Arguments
+    /// * `test_mode` — when true the entry point is `Test::test`, as `fix test`
+    ///   runs it; otherwise it is `Main::main`.
     pub fn instantiate_entry_io_value(
         &mut self,
         tc: &TypeCheckContext,
@@ -1507,8 +1517,9 @@ impl Program {
         Ok(())
     }
 
-    // Instantiate exported values.
-    // In this function, `ExportStatement`s are updated.
+    /// Instantiates the value named by each export statement, recording the
+    /// instantiated expression and its exported function type back into the
+    /// statement.
     pub fn instantiate_exported_values(&mut self, tc: &TypeCheckContext) -> Result<(), Errors> {
         let mut errors = Errors::empty();
         let mut export_stmts = replace(&mut self.export_statements, vec![]);
@@ -1526,9 +1537,14 @@ impl Program {
         Ok(())
     }
 
-    // Instantiate a global value.
-    // - required_ty: for `Main::main`, pass `IO ()` to check that the specified type is correct. If None, then use the type specified by user.
-    // - required_src: source place where the value is exported. Used to show error message.
+    /// Instantiates the global value `value_name` for export, returning the
+    /// instantiated expression together with the function type it is exported at.
+    ///
+    /// # Arguments
+    /// * `required_ty` — the type the value is required to have, e.g. `IO ()`
+    ///   for `Main::main`; `None` accepts the type the user declared.
+    /// * `required_src` — the source location of the export, used to place the
+    ///   error message.
     pub fn instantiate_exported_value(
         &mut self,
         value_name: &FullName,

--- a/src/commands/lsp/completion/score.rs
+++ b/src/commands/lsp/completion/score.rs
@@ -68,14 +68,14 @@ pub(super) enum NamespaceMatch {
     /// e.g., `Std::push_back` for a `Std::Array` receiver. Useful for
     /// helpers grouped alongside the type at the parent level.
     InParent,
-    /// Neither — a function from an unrelated namespace that happens
-    /// to take this type as its receiver position.
+    /// Candidate lives in a namespace unrelated to the receiver TyCon,
+    /// and happens to take this type as its receiver position.
     Unrelated,
 }
 
 impl NamespaceMatch {
     /// Single-letter encoding for `sort_text`. Order: `'a' < 'b' < 'c'`
-    /// matches the variant ordering above.
+    /// matches the declaration order of `NamespaceMatch`.
     fn as_letter(self) -> char {
         match self {
             NamespaceMatch::InsideTyCon => 'a',
@@ -133,7 +133,7 @@ pub(super) fn sort_text_for(
 /// `sort_text` for completion items that can never satisfy a dot
 /// expression (types / traits / assoc types). They land at the bottom
 /// of the dot-context list — `Tier::Three` + `NamespaceMatch::Unrelated`
-/// — so they don't outrank function candidates but are still present
+/// — so function candidates rank above them while they stay reachable
 /// when the user is working in a misclassified context.
 pub(super) fn dot_context_low_priority_sort_text(name: &FullName) -> String {
     sort_text_for(Tier::Three, NamespaceMatch::Unrelated, false, name)
@@ -176,10 +176,8 @@ pub(super) fn assign_tier(
     }
 }
 
-/// Bucket-only tier assignment: the cheap Tier 1/2/3 classification
-/// without the unify-based Tier 0 promotion. Used as a fallback when
-/// the unify step's prerequisites (a scratch `Configuration` for
-/// building a `TypeCheckContext`) couldn't be set up.
+/// Bucket-only tier assignment: classifies `name` as Tier 1, 2 or 3 from
+/// `index` alone, so it costs a pair of lookups.
 pub(super) fn assign_tier_no_unify(
     name: &FullName,
     index: &CompletionIndex,
@@ -234,10 +232,10 @@ fn try_unify_receiver(
         .map_err(|_| ())?;
     let (srcs, _) = inst_ty.collect_app_src(usize::MAX);
     let cand_recv_ty = srcs.last().ok_or(())?;
-    /// Collapses the two-level `Result<Result<T, UnificationErr>, Errors>`
-    /// returned by `extract_others` down to `Result<(), ()>`: any failure
-    /// (unification mismatch or unsatisfiable predicate) means the
-    /// candidate doesn't fit the receiver.
+    /// Collapses the outcome of a type-check step down to `Result<(), ()>`:
+    /// any failure — a unification mismatch, an unsatisfiable predicate, or
+    /// an error raised along the way — means the candidate doesn't fit the
+    /// receiver.
     fn flatten<T>(r: Result<T, UnifOrOtherErr>) -> Result<(), ()> {
         UnifOrOtherErr::extract_others(r)
             .map_err(|_| ())?

--- a/src/commands/lsp/completion/score.rs
+++ b/src/commands/lsp/completion/score.rs
@@ -248,8 +248,8 @@ fn try_unify_receiver(
 
     // The remaining `reduce_predicates` call — checking that the
     // candidate's trait constraints hold for the bound receiver — is the
-    // dominant cost (it searches trait instances, cloning the context per
-    // non-matching instance). Its verdict depends only on the substituted
+    // dominant cost (it matches the predicate against every instance of its
+    // trait until one fits). Its verdict depends only on the substituted
     // predicates plus the instance environment, which is identical across
     // candidates within this request. So memoize the verdict keyed by the
     // substituted predicate set and reuse it for sibling candidates that

--- a/src/commands/lsp/completion/score.rs
+++ b/src/commands/lsp/completion/score.rs
@@ -233,7 +233,7 @@ fn try_unify_receiver(
         .instantiate_scheme(&gv.scm, ConstraintInstantiationMode::Require)
         .map_err(|_| ())?;
     let (srcs, _) = inst_ty.collect_app_src(usize::MAX);
-    let recv_pos = srcs.last().ok_or(())?;
+    let cand_recv_ty = srcs.last().ok_or(())?;
     /// Collapses the two-level `Result<Result<T, UnificationErr>, Errors>`
     /// returned by `extract_others` down to `Result<(), ()>`: any failure
     /// (unification mismatch or unsatisfiable predicate) means the
@@ -244,7 +244,7 @@ fn try_unify_receiver(
             .map(|_| ())
             .map_err(|_| ())
     }
-    flatten(tc.unify(recv_pos, receiver_type))?;
+    flatten(tc.unify(cand_recv_ty, receiver_type))?;
 
     // The remaining `reduce_predicates` call — checking that the
     // candidate's trait constraints hold for the bound receiver — is the

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -901,13 +901,19 @@ impl TypeCheckContext {
         }
     }
 
-    pub fn instantiate_type(&mut self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
+    // The substitution that sends each of `tyvars` to a fresh type variable of the same kind.
+    fn instantiate_tyvars(&mut self, tyvars: &[Arc<TyVar>]) -> Substitution {
         let mut sub = Substitution::default();
-        for tv in ty.free_vars_vec() {
-            let new_tv = self.new_tyvar_by(&tv);
-            let merge_ok = sub.merge(&Substitution::single(&tv.name, type_from_tyvar(new_tv)));
+        for tv in tyvars {
+            let new_tv = type_from_tyvar(self.new_tyvar_by(tv));
+            let merge_ok = sub.merge(&Substitution::single(&tv.name, new_tv));
             assert!(merge_ok);
         }
+        sub
+    }
+
+    pub fn instantiate_type(&mut self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
+        let sub = self.instantiate_tyvars(&ty.free_vars_vec());
         sub.substitute_type(ty)
     }
 
@@ -1899,12 +1905,7 @@ impl TypeCheckContext {
                 let assumed_eqs = self.assumed_eqs.clone();
                 for assumed_eq in assumed_eqs.get(assoc_ty).map_or(&[][..], Vec::as_slice) {
                     // Instantiate `assumed_eq`.
-                    let mut subst = Substitution::default();
-                    for tv in &assumed_eq.gen_vars {
-                        let new_tv = type_from_tyvar(self.new_tyvar_by(tv));
-                        let merge_ok = subst.merge(&Substitution::single(&tv.name, new_tv));
-                        assert!(merge_ok);
-                    }
+                    let subst = self.instantiate_tyvars(&assumed_eq.gen_vars);
                     let mut equality = assumed_eq.equality.clone();
                     subst.substitute_equality(&mut equality);
 
@@ -2135,12 +2136,7 @@ impl TypeCheckContext {
             .map_or(&[][..], Vec::as_slice)
         {
             // Instantiate qualified predicate.
-            let mut subst = Substitution::default();
-            for tv in &qual_pred_scm.gen_vars {
-                let new_tv = type_from_tyvar(self.new_tyvar_by(tv));
-                let merge_ok = subst.merge(&Substitution::single(&tv.name, new_tv));
-                assert!(merge_ok);
-            }
+            let subst = self.instantiate_tyvars(&qual_pred_scm.gen_vars);
             let mut qual_pred = qual_pred_scm.qual_pred.clone();
             subst.substitute_qualpred(&mut qual_pred);
 

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1188,11 +1188,11 @@ impl TypeCheckContext {
                 } else {
                     // candidates.len() == 1
                     let (tc, ns) = candidates_check_res
-                        .iter()
-                        .find_map(|cand| cand.as_ref().ok())
+                        .into_iter()
+                        .find_map(|cand| cand.ok())
                         .unwrap();
-                    *self = tc.clone();
-                    let ei = ei.set_var_namespace(ns.clone());
+                    *self = tc;
+                    let ei = ei.set_var_namespace(ns);
                     let name = &ei.get_var().name;
                     if name.is_global() && !name.is_absolute() {
                         self.import_required.push(name.clone());

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2009,41 +2009,44 @@ impl TypeCheckContext {
         }
     }
 
-    /// Whether `ty1` and `ty2` can be unified, when the unifier itself is
-    /// not wanted.
+    /// Whether `ty1` and `ty2` can be unified, when the unifier itself is not
+    /// wanted.
     ///
-    /// Both types must already be substituted under `self`. The query then
-    /// runs on an empty substitution -- a substitution maps each of its
-    /// variables to a type free of them all, so applying it to its own image
-    /// changes nothing -- and so costs the size of the two types rather than
-    /// the size of the inference state, which a copy of `self` would.
-    fn are_unifiable(&self, ty1: &Arc<TypeNode>, ty2: &Arc<TypeNode>) -> Result<bool, Errors> {
+    /// The query costs the size of the two types rather than the size of the
+    /// inference state, which a copy of `self` would. It substitutes both types
+    /// here and runs on an empty substitution of its own: a substitution maps
+    /// each of its variables to a type free of them all, so it has nothing left
+    /// to say about its own image.
+    pub fn are_unifiable(&self, ty1: &Arc<TypeNode>, ty2: &Arc<TypeNode>) -> Result<bool, Errors> {
+        let ty1 = self.substitute_type(ty1);
+        let ty2 = self.substitute_type(ty2);
         let mut tc = Self {
             // What unification reads.
             tyvar_id: self.tyvar_id,
             equalities: self.equalities.clone(),
             fixed_tyvars: self.fixed_tyvars.clone(),
             assumed_eqs: self.assumed_eqs.clone(),
+            kind_env: self.kind_env.clone(),
+            // What unification writes, and the answer discards.
+            substitution: Substitution::default(),
+            tyvar_expr: Map::default(),
+            predicates: vec![],
+            // What unification leaves alone: empty where a copy would spend its
+            // time, carried where carrying costs a scalar or a reference count.
+            scope: Scope::default(),
+            import_required: vec![],
+            local_assumed_eqs: vec![],
+            opaque_instantiations: Map::default(),
             assumed_preds: self.assumed_preds.clone(),
             trait_env: self.trait_env.clone(),
             type_env: self.type_env.clone(),
-            kind_env: self.kind_env.clone(),
             import_statements: self.import_statements.clone(),
             current_module: self.current_module.clone(),
             cache: self.cache.clone(),
             num_worker_threads: self.num_worker_threads,
             error_tolerant: self.error_tolerant,
-            // What unification writes, and the answer discards.
-            substitution: Substitution::default(),
-            tyvar_expr: Map::default(),
-            predicates: vec![],
-            // What unification leaves alone.
-            scope: Scope::default(),
-            import_required: vec![],
-            local_assumed_eqs: vec![],
-            opaque_instantiations: Map::default(),
         };
-        Ok(UnifOrOtherErr::extract_others(tc.unify(ty1, ty2))?.is_ok())
+        Ok(UnifOrOtherErr::extract_others(tc.unify(&ty1, &ty2))?.is_ok())
     }
 
     // Subroutine of unify().
@@ -2161,8 +2164,7 @@ impl TypeCheckContext {
                 // If match fails, then we cannot reduce the predicate at now.
                 // But we may be able to reduce it after the predicate is substituted further.
                 // To see if there is possibility for further reduction, we check here the unifiability.
-                // One qualified predicate the head is unifiable with settles that, so the rest are
-                // left unasked.
+                // One instance head it unifies with settles the question, so the rest go unasked.
                 unifiable = self.are_unifiable(&qual_pred.predicate.ty, &pred.ty)?;
             }
         }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1989,6 +1989,43 @@ impl TypeCheckContext {
         }
     }
 
+    /// Whether `ty1` and `ty2` can be unified, when the unifier itself is
+    /// not wanted.
+    ///
+    /// Both types must already be substituted under `self`. The query then
+    /// runs on an empty substitution -- a substitution maps each of its
+    /// variables to a type free of them all, so applying it to its own image
+    /// changes nothing -- and so costs the size of the two types rather than
+    /// the size of the inference state, which a copy of `self` would.
+    fn are_unifiable(&self, ty1: &Arc<TypeNode>, ty2: &Arc<TypeNode>) -> Result<bool, Errors> {
+        let mut tc = Self {
+            // What unification reads.
+            tyvar_id: self.tyvar_id,
+            equalities: self.equalities.clone(),
+            fixed_tyvars: self.fixed_tyvars.clone(),
+            assumed_eqs: self.assumed_eqs.clone(),
+            assumed_preds: self.assumed_preds.clone(),
+            trait_env: self.trait_env.clone(),
+            type_env: self.type_env.clone(),
+            kind_env: self.kind_env.clone(),
+            import_statements: self.import_statements.clone(),
+            current_module: self.current_module.clone(),
+            cache: self.cache.clone(),
+            num_worker_threads: self.num_worker_threads,
+            error_tolerant: self.error_tolerant,
+            // What unification writes, and the answer discards.
+            substitution: Substitution::default(),
+            tyvar_expr: Map::default(),
+            predicates: vec![],
+            // What unification leaves alone.
+            scope: Scope::default(),
+            import_required: vec![],
+            local_assumed_eqs: vec![],
+            opaque_instantiations: Map::default(),
+        };
+        Ok(UnifOrOtherErr::extract_others(tc.unify(ty1, ty2))?.is_ok())
+    }
+
     // Subroutine of unify().
     fn unify_tyvar(
         &mut self,
@@ -2100,16 +2137,13 @@ impl TypeCheckContext {
                     self.reduce_predicate(pred, irr_preds, skip)?;
                 }
                 return Ok(());
-            } else {
+            } else if !unifiable {
                 // If match fails, then we cannot reduce the predicate at now.
                 // But we may be able to reduce it after the predicate is substituted further.
                 // To see if there is possibility for further reduction, we check here the unifiability.
-                let mut tc = self.clone();
-                if UnifOrOtherErr::extract_others(tc.unify(&qual_pred.predicate.ty, &pred.ty))?
-                    .is_ok()
-                {
-                    unifiable = true;
-                }
+                // One qualified predicate the head is unifiable with settles that, so the rest are
+                // left unasked.
+                unifiable = self.are_unifiable(&qual_pred.predicate.ty, &pred.ty)?;
             }
         }
         if !unifiable {

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -187,16 +187,16 @@ impl Substitution {
         return true;
     }
 
-    // Apply substitution to predicate.
+    /// Replaces the type variables this substitution binds in the type `p` constrains.
     pub fn substitute_predicate(&self, p: &mut Predicate) {
         p.ty = self.substitute_type(&p.ty);
     }
 
-    // Apply substitution to type
-    //
-    // A type none of whose variables this substitution replaces is returned as
-    // it came: the common case of a substitution that says nothing about a type
-    // walks the type and hands back the same node.
+    /// Replaces each type variable of `ty` that this substitution binds.
+    ///
+    /// A type none of whose variables this substitution replaces is returned as
+    /// it came: the common case of a substitution that says nothing about a type
+    /// walks the type and hands back the same node.
     pub fn substitute_type(&self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
         match &ty.ty {
             Type::TyVar(tyvar) => self.data.get(&tyvar.name).map_or(ty.clone(), |sub| {
@@ -228,6 +228,8 @@ impl Substitution {
         }
     }
 
+    /// Substitutes the types the error carries, so it is reported in terms of
+    /// the current substitution.
     pub fn substitute_unification_error(&self, e: &mut UnificationErr) {
         match e {
             UnificationErr::Unsatisfiable(predicate) => {
@@ -1821,6 +1823,8 @@ impl TypeCheckContext {
         Ok((expr, Errors::empty()))
     }
 
+    /// Composes `subst` into the accumulated substitution, then re-examines the
+    /// pending equalities, which the new bindings may let unify or reduce.
     fn add_substitution(&mut self, subst: &Substitution) -> Result<(), UnifOrOtherErr> {
         self.substitution.compose(subst);
         let eqs = replace(&mut self.equalities, vec![]);
@@ -2051,7 +2055,8 @@ impl TypeCheckContext {
         Ok(UnifOrOtherErr::extract_others(tc.unify(&ty1, &ty2))?.is_ok())
     }
 
-    // Subroutine of unify().
+    /// Binds the type variable `tyvar1` to `ty2` by extending the substitution,
+    /// rejecting a binding that would be circular or kind-mismatched.
     fn unify_tyvar(
         &mut self,
         tyvar1: Arc<TyVar>,

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -195,8 +195,8 @@ impl Substitution {
     // Apply substitution to type
     //
     // A type none of whose variables this substitution replaces is returned as
-    // it came, so that the common case of a substitution that says nothing
-    // about a type costs a walk rather than a rebuild.
+    // it came: the common case of a substitution that says nothing about a type
+    // walks the type and hands back the same node.
     pub fn substitute_type(&self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
         match &ty.ty {
             Type::TyVar(tyvar) => self.data.get(&tyvar.name).map_or(ty.clone(), |sub| {
@@ -901,7 +901,7 @@ impl TypeCheckContext {
         }
     }
 
-    // The substitution that sends each of `tyvars` to a fresh type variable of the same kind.
+    /// The substitution that sends each of `tyvars` to a fresh type variable of the same kind.
     fn instantiate_tyvars(&mut self, tyvars: &[Arc<TyVar>]) -> Substitution {
         let mut sub = Substitution::default();
         for tv in tyvars {
@@ -912,6 +912,7 @@ impl TypeCheckContext {
         sub
     }
 
+    /// Replaces every free type variable of `ty` by a fresh one of the same kind.
     pub fn instantiate_type(&mut self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
         let sub = self.instantiate_tyvars(&ty.free_vars_vec());
         sub.substitute_type(ty)
@@ -2010,14 +2011,14 @@ impl TypeCheckContext {
         }
     }
 
-    /// Whether `ty1` and `ty2` can be unified, when the unifier itself is not
-    /// wanted.
+    /// Whether unification of `ty1` and `ty2` succeeds under the current
+    /// substitution, assumed equalities and fixed type variables.
     ///
-    /// The query costs the size of the two types rather than the size of the
-    /// inference state, which a copy of `self` would. It substitutes both types
-    /// here and runs on an empty substitution of its own: a substitution maps
-    /// each of its variables to a type free of them all, so it has nothing left
-    /// to say about its own image.
+    /// Both types are substituted here, and the unification then runs on an
+    /// empty substitution of its own: a substitution maps each of its variables
+    /// to a type free of them all, so it has nothing left to say about its own
+    /// image. That keeps the query proportional to the two types while the
+    /// inference state grows with the body being checked.
     pub fn are_unifiable(&self, ty1: &Arc<TypeNode>, ty2: &Arc<TypeNode>) -> Result<bool, Errors> {
         let ty1 = self.substitute_type(ty1);
         let ty2 = self.substitute_type(ty2);
@@ -2032,8 +2033,8 @@ impl TypeCheckContext {
             substitution: Substitution::default(),
             tyvar_expr: Map::default(),
             predicates: vec![],
-            // What unification leaves alone: empty where a copy would spend its
-            // time, carried where carrying costs a scalar or a reference count.
+            // What unification leaves alone: the large ones start empty, the
+            // ones that cost a scalar or a reference count are carried.
             scope: Scope::default(),
             import_required: vec![],
             local_assumed_eqs: vec![],

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1910,17 +1910,17 @@ impl TypeCheckContext {
                     inst_subst.substitute_equality(&mut equality);
 
                     // Try to match lhs of `equality` to `ty`.
-                    let subst: Option<Substitution> = Substitution::matching(
+                    let match_subst: Option<Substitution> = Substitution::matching(
                         &equality.lhs(),
                         &ty,
                         &self.fixed_tyvars,
                         &self.kind_env,
                     )?;
-                    if subst.is_none() {
+                    if match_subst.is_none() {
                         continue;
                     }
-                    let subst: Substitution = subst.unwrap();
-                    let rhs = subst.substitute_type(&equality.value);
+                    let match_subst: Substitution = match_subst.unwrap();
+                    let rhs = match_subst.substitute_type(&equality.value);
                     return self.reduce_type_by_equality(rhs);
                 }
                 Ok(ty)
@@ -2141,18 +2141,18 @@ impl TypeCheckContext {
             inst_subst.substitute_qualpred(&mut qual_pred);
 
             // Try to match head of `qual_pred` to `pred`.
-            if let Some(subst) = Substitution::matching(
+            if let Some(match_subst) = Substitution::matching(
                 &qual_pred.predicate.ty,
                 &pred.ty,
                 &self.fixed_tyvars,
                 &self.kind_env,
             )? {
                 for mut eq in qual_pred.eq_constraints {
-                    subst.substitute_equality(&mut eq);
+                    match_subst.substitute_equality(&mut eq);
                     self.add_equality(eq)?;
                 }
                 for mut pred in qual_pred.pred_constraints {
-                    subst.substitute_predicate(&mut pred);
+                    match_subst.substitute_predicate(&mut pred);
                     self.reduce_predicate(pred, irr_preds, skip)?;
                 }
                 return Ok(());
@@ -2193,8 +2193,8 @@ impl TypeCheckContext {
                 let subpat = self.fix_types_for_pattern(subpat.clone())?;
                 pat.set_union_pat(subpat)
             }
-            Pattern::Struct(_, fied_to_pat) => {
-                let mut field_to_pat = fied_to_pat.clone();
+            Pattern::Struct(_, field_to_pat) => {
+                let mut field_to_pat = field_to_pat.clone();
                 for (_field_name, _, subpat) in field_to_pat.iter_mut() {
                     let new_subpat = self.fix_types_for_pattern(subpat.clone())?;
                     *subpat = new_subpat;

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -424,9 +424,11 @@ pub struct TypeCheckContext {
     // Names that should be imported in the current module.
     pub import_required: Vec<FullName>,
     // Equalities assumed.
-    pub assumed_eqs: Map<AssocType, Vec<EqualityScheme>>,
+    // Arc for sharing them among the contexts cloned for speculative type checking.
+    pub assumed_eqs: Arc<Map<AssocType, Vec<EqualityScheme>>>,
     // Predicates assumed.
-    pub assumed_preds: Map<TraitId, Vec<QualPredScheme>>,
+    // Arc for sharing them among the contexts cloned for speculative type checking.
+    pub assumed_preds: Arc<Map<TraitId, Vec<QualPredScheme>>>,
     // Fixed type variables.
     // In unification, these type variables are not allowed to be replaced to another type.
     // NOTE: We use `Vec` instead of `Set` because the expected size is small.
@@ -489,8 +491,8 @@ impl TypeCheckContext {
             substitution: Substitution::default(),
             predicates: vec![],
             equalities: vec![],
-            assumed_preds,
-            assumed_eqs,
+            assumed_preds: Arc::new(assumed_preds),
+            assumed_eqs: Arc::new(assumed_eqs),
             fixed_tyvars: vec![],
             local_assumed_eqs: vec![],
             import_required: vec![],
@@ -952,7 +954,11 @@ impl TypeCheckContext {
                             predicate: pred,
                         },
                     };
-                    insert_to_map_vec(&mut self.assumed_preds, &trait_id, qual_pred_scm);
+                    insert_to_map_vec(
+                        Arc::make_mut(&mut self.assumed_preds),
+                        &trait_id,
+                        qual_pred_scm,
+                    );
                 }
                 for eq in eqs {
                     let assoc_ty = eq.assoc_type.clone();
@@ -960,7 +966,7 @@ impl TypeCheckContext {
                         gen_vars: vec![],
                         equality: eq.clone(),
                     };
-                    insert_to_map_vec(&mut self.assumed_eqs, &assoc_ty, eq_scm);
+                    insert_to_map_vec(Arc::make_mut(&mut self.assumed_eqs), &assoc_ty, eq_scm);
                     self.local_assumed_eqs.push(eq);
                 }
                 return Ok(scheme.ty.clone());
@@ -1870,7 +1876,8 @@ impl TypeCheckContext {
                 let ty = ty.set_assocty_args(args);
 
                 // Try matching to assumed equality.
-                for assumed_eq in &self.assumed_eqs.get(assoc_ty).cloned().unwrap_or(vec![]) {
+                let assumed_eqs = self.assumed_eqs.clone();
+                for assumed_eq in assumed_eqs.get(assoc_ty).map_or(&[][..], Vec::as_slice) {
                     // Instantiate `assumed_eq`.
                     let mut subst = Substitution::default();
                     for tv in &assumed_eq.gen_vars {
@@ -2062,11 +2069,10 @@ impl TypeCheckContext {
         skip.insert(pred_str);
         pred.ty = self.substitute_and_reduce_type(&pred.ty)?;
         let mut unifiable = false;
-        for qual_pred_scm in &self
-            .assumed_preds
+        let assumed_preds = self.assumed_preds.clone();
+        for qual_pred_scm in assumed_preds
             .get(&pred.trait_id)
-            .unwrap_or(&vec![])
-            .clone()
+            .map_or(&[][..], Vec::as_slice)
         {
             // Instantiate qualified predicate.
             let mut subst = Substitution::default();

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -15,11 +15,10 @@ use crate::{
         qual_pred::{QualPred, QualPredScheme},
         qual_type::QualType,
         traits::{TraitEnv, TraitId},
-        types::OpaqueTyConResolution,
         types::{
             is_type_wildcard_tyvar, kind_star, make_tyvar, type_from_tyvar, type_fun, type_tyapp,
-            type_tycon, AssocType, Kind, Scheme, TyCon, TyConInfo, TyConVariant, TyVar, Type,
-            TypeNode,
+            type_tycon, AssocType, Kind, OpaqueTyConResolution, Scheme, TyCon, TyConInfo,
+            TyConVariant, TyVar, Type, TypeNode,
         },
     },
     constants::{
@@ -32,6 +31,7 @@ use crate::{
     parse::sourcefile::Span,
 };
 use serde::{Deserialize, Serialize};
+use std::mem::{replace, swap};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -1822,7 +1822,7 @@ impl TypeCheckContext {
 
     fn add_substitution(&mut self, subst: &Substitution) -> Result<(), UnifOrOtherErr> {
         self.substitution.compose(subst);
-        let eqs = std::mem::replace(&mut self.equalities, vec![]);
+        let eqs = replace(&mut self.equalities, vec![]);
         for eq in eqs {
             self.add_equality(eq)?;
         }
@@ -1958,7 +1958,7 @@ impl TypeCheckContext {
                 }
                 _ => {}
             }
-            std::mem::swap(&mut ty1, &mut ty2);
+            swap(&mut ty1, &mut ty2);
         }
 
         // Case: Either is usage of associated type.
@@ -1973,7 +1973,7 @@ impl TypeCheckContext {
                 self.add_equality(eq)?;
                 return Ok(());
             }
-            std::mem::swap(&mut ty1, &mut ty2);
+            swap(&mut ty1, &mut ty2);
         }
 
         // Other case.

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1905,9 +1905,9 @@ impl TypeCheckContext {
                 let assumed_eqs = self.assumed_eqs.clone();
                 for assumed_eq in assumed_eqs.get(assoc_ty).map_or(&[][..], Vec::as_slice) {
                     // Instantiate `assumed_eq`.
-                    let subst = self.instantiate_tyvars(&assumed_eq.gen_vars);
+                    let inst_subst = self.instantiate_tyvars(&assumed_eq.gen_vars);
                     let mut equality = assumed_eq.equality.clone();
-                    subst.substitute_equality(&mut equality);
+                    inst_subst.substitute_equality(&mut equality);
 
                     // Try to match lhs of `equality` to `ty`.
                     let subst: Option<Substitution> = Substitution::matching(
@@ -2136,9 +2136,9 @@ impl TypeCheckContext {
             .map_or(&[][..], Vec::as_slice)
         {
             // Instantiate qualified predicate.
-            let subst = self.instantiate_tyvars(&qual_pred_scm.gen_vars);
+            let inst_subst = self.instantiate_tyvars(&qual_pred_scm.gen_vars);
             let mut qual_pred = qual_pred_scm.qual_pred.clone();
-            subst.substitute_qualpred(&mut qual_pred);
+            inst_subst.substitute_qualpred(&mut qual_pred);
 
             // Try to match head of `qual_pred` to `pred`.
             if let Some(subst) = Substitution::matching(

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -193,17 +193,37 @@ impl Substitution {
     }
 
     // Apply substitution to type
+    //
+    // A type none of whose variables this substitution replaces is returned as
+    // it came, so that the common case of a substitution that says nothing
+    // about a type costs a walk rather than a rebuild.
     pub fn substitute_type(&self, ty: &Arc<TypeNode>) -> Arc<TypeNode> {
         match &ty.ty {
             Type::TyVar(tyvar) => self.data.get(&tyvar.name).map_or(ty.clone(), |sub| {
                 sub.set_source_if_none(ty.get_source().clone())
             }),
             Type::TyCon(_) => ty.clone(),
-            Type::TyApp(fun, arg) => ty
-                .set_tyapp_fun(self.substitute_type(fun))
-                .set_tyapp_arg(self.substitute_type(arg)),
+            Type::TyApp(fun, arg) => {
+                let new_fun = self.substitute_type(fun);
+                let new_arg = self.substitute_type(arg);
+                if Arc::ptr_eq(&new_fun, fun) && Arc::ptr_eq(&new_arg, arg) {
+                    return ty.clone();
+                }
+                ty.set_tyapp_fun(new_fun).set_tyapp_arg(new_arg)
+            }
             Type::AssocTy(_, args) => {
-                ty.set_assocty_args(args.iter().map(|arg| self.substitute_type(arg)).collect())
+                let new_args = args
+                    .iter()
+                    .map(|arg| self.substitute_type(arg))
+                    .collect::<Vec<_>>();
+                if new_args
+                    .iter()
+                    .zip(args)
+                    .all(|(new_arg, arg)| Arc::ptr_eq(new_arg, arg))
+                {
+                    return ty.clone();
+                }
+                ty.set_assocty_args(new_args)
             }
         }
     }

--- a/src/tests/test_ffi.rs
+++ b/src/tests/test_ffi.rs
@@ -961,3 +961,38 @@ pub fn test_get_funptr_retain_error() {
     "##;
     test_source_fail(&source, Configuration::develop_mode(), "");
 }
+
+/// A non-variadic `FFI_CALL` signature fixes the number of arguments the call takes, and both too
+/// many and too few are reported as a source-level diagnostic.
+#[test]
+pub fn test_ffi_call_wrong_argument_count() {
+    let too_many = r##"
+        module Main;
+
+        main : IO ();
+        main = (
+            eval *FFI_CALL_IO[CInt puts(Ptr), "hi".borrow_c_str(|p| p), 1];
+            pure()
+        );
+    "##;
+    test_source_fail(
+        too_many,
+        Configuration::develop_mode(),
+        "Wrong number of arguments in FFI_CALL_IO expression.",
+    );
+
+    let too_few = r##"
+        module Main;
+
+        main : IO ();
+        main = (
+            eval *FFI_CALL_IO[CInt puts(Ptr)];
+            pure()
+        );
+    "##;
+    test_source_fail(
+        too_few,
+        Configuration::develop_mode(),
+        "Wrong number of arguments in FFI_CALL_IO expression.",
+    );
+}

--- a/src/tests/test_struct_destructure.rs
+++ b/src/tests/test_struct_destructure.rs
@@ -118,3 +118,52 @@ main : IO () = (
         test_source(DESTRUCTURED_PARAMETER_SOURCE, config);
     }
 }
+
+// A struct pattern names the fields of one struct type, so a name the type does not declare and a
+// name given twice are both rejected with a source-level diagnostic.
+#[cfg(test)]
+mod struct_pattern_validation_tests {
+    use crate::{configuration::Configuration, tests::test_util::test_source_fail};
+
+    /// A field named twice in one struct pattern is reported rather than bound twice.
+    #[test]
+    pub fn test_struct_pattern_duplicate_field_rejected() {
+        let source = r#"
+module Main;
+
+type S = struct { a : I64, b : I64 };
+
+main : IO ();
+main = (
+    let S { a : x, a : y } = S { a : 1, b : 2 };
+    println((x + y).to_string)
+);
+"#;
+        test_source_fail(
+            source,
+            Configuration::develop_mode(),
+            "Duplicate field in struct pattern.",
+        );
+    }
+
+    /// A field the struct does not declare is reported rather than matched.
+    #[test]
+    pub fn test_struct_pattern_unknown_field_rejected() {
+        let source = r#"
+module Main;
+
+type S = struct { a : I64 };
+
+main : IO ();
+main = (
+    let S { zz : x } = S { a : 1 };
+    println(x.to_string)
+);
+"#;
+        test_source_fail(
+            source,
+            Configuration::develop_mode(),
+            "Unknown field `zz` for struct `Main::S`.",
+        );
+    }
+}


### PR DESCRIPTION
Part of #160.

Type checking copies its whole `TypeCheckContext` whenever it tries something it may have to abandon: once per candidate of an overloaded name, and once per instance the predicate reducer cannot match. The copy carries state that grows with the body being checked — the substitution, the local scope, the map from type variables to the expressions that gave rise to them — and state that does not depend on the body at all: every instance the program declares, around 480 qualified predicates for `Std` alone. With one copy per name occurrence, both are paid over and over, and `Predicate::clone` and its drop sat at the top of the profile.

Measured on the reproduction in #160 at N=1600: 89,956 context copies, 72% of them from the reducer's unifiability question and 11% from name resolution.

Four changes, each its own commit:

- **The assumed constraints move behind an `Arc`.** They are written once per constraint of a signature being assumed and read everywhere else, so the writes go through `Arc::make_mut` and the two loops that copied an instance list to borrow `self` mutably hold the `Arc` across the loop instead.
- **The unifiability question gets a context holding what unification reads and nothing else.** The substitution is left out: `are_unifiable` substitutes both types itself and then runs on an empty substitution, since a substitution maps each of its variables to a type free of them all and so has nothing left to say about its own image. `Program::instantiate_symbol` asked the same question with a full copy and now asks it here too.
- **The resolved candidate's context is moved into the checker** rather than copied out of the result list.
- **Substituting into a type the substitution does not mention returns it unchanged.** Composing a substitution applies the new binding to every type already bound, and that allocated a fresh node per node of every one of them whether or not the binding occurred in it.

## What it buys

`fix build -O none`, retired instructions — stable under machine load, which wall clock was not while this was measured:

| | main | this branch |
| --- | --- | --- |
| hello world, cold cache | 37.8 G | 3.8 G |
| N=400 | 20.9 G | 4.8 G |
| N=800 | 42.9 G | 6.6 G |
| N=1600 | 116.2 G | 12.9 G |

The three `N` rows are #160's reproduction with `Std` already cached, which is the shape of an ordinary edit-and-rebuild; the first row is a first build, where the whole standard library is type-checked. On a quiet machine that first build goes from 9.2s to 1.7s.

Growth is not fixed. Above the floor the body still costs about N^1.7, and after this change that is no longer attributable to resolving the operator: the same body written as calls to a monomorphic global grows the same way. What is left is the context copy at each name occurrence — the substitution and the type-variable source map, of comparable size, are what it copies — and `Substitution::compose` rewriting every bound type on every new binding. #160 stays open for that.

## Tests

Full suite at `FIX_MAX_OPT_LEVEL` of `basic`, `max` and `experimental`: 1133 passed, 0 failed at each.

The emitted code is unchanged: `--emit-llvm` output, before and after LLVM's own passes, is byte-identical between the two compilers for all 17 programs in `examples/` at `-O max`, up to the module identifier the compiler stamps per run.

`are_unifiable` was checked against the copy it replaces by computing both answers and asserting they agree at every call — silent over the full suite, `examples/`, and 36 of the `benchmark/speedtest` cases, after confirming the assertion fires when the query context is given the wrong fixed type variables. The reducer stops asking once one instance head answers yes, which skips a query that could have raised a non-unification error; a second probe asserted the skipped queries stay error-free, and was silent over the same corpus.

No changelog entry: the emitted code and every diagnostic are unchanged.


## Checked against `fixlang_minilib`

`pt9999/fixlang_minilib` at its current releases — 16 libraries whose use of the type system goes well past `Std`'s: trait hierarchies, associated types, higher-kinded instances and stacked monad transformers. It exercises overload resolution and the instance scan, which is what this change touches, far more heavily than the compiler's own suite does.

**Tests.** `fix test` in each of the 16, on the released sources with no local overrides: **90 test suites, 2538 assertions, 0 failures**, and the per-library counts are identical to the same run on `main`.

**Emitted code.** The LLVM IR of each library's test binary at `-O max`, before and after LLVM's own passes, is **identical between the two compilers for all 16** — about 10.3 million lines in total, compared as the multiset of per-module content hashes with the per-run module identifier normalized away. The comparison was checked both ways before being trusted: two runs of one compiler give the same fingerprint, and two different libraries give different ones.

**What it costs to build them.** `fix test` end to end, cold caches, retired instructions — this counts code generation, LLVM optimization, linking and running the tests, not type checking alone:

| | main | this branch |
| --- | --- | --- |
| minilib-common | 246.7 G | 140.3 G |
| minilib-monad | 463.2 G | 235.3 G |
| minilib-math | 454.2 G | 156.9 G |
| minilib-text | 263.6 G | 126.8 G |
