### PR TITLE
Tests a bug hunt on the type checker confirmed pass

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -55,6 +55,7 @@ mod test_union_as_borrow;
 mod test_union_catchall_match;
 mod test_union_layout;
 mod test_union_match;
+mod test_unrelated_module_cache;
 mod test_util;
 mod test_valgrind_suppression;
 mod test_wide_return_tail_call;

--- a/src/tests/test_associated_type.rs
+++ b/src/tests/test_associated_type.rs
@@ -1013,3 +1013,37 @@ main = pure();
     "#;
     test_source(source, Configuration::develop_mode());
 }
+
+/// A type variable of a signature that is tied to the rest only through equality constraints —
+/// the shape `Std::Iterator::flatten` has — is resolved and the value it types runs.
+#[test]
+pub fn test_associated_type_inner_bound_only_by_equalities() {
+    let source = r##"
+    module Main;
+
+    import Std::* hiding Indexable::Elem;
+
+    trait c : Coll {
+        type Elem c;
+        head : c -> Elem c;
+        wrap : Elem c -> c;
+    }
+
+    impl Array a : Coll {
+        type Elem (Array a) = a;
+        head = |x| x.@(0);
+        wrap = |x| [x];
+    }
+
+    flatten2 : [out : Coll, Elem out = e, inner : Coll, Elem inner = e, input : Coll, Elem input = inner] input -> out;
+    flatten2 = |xs| Coll::wrap(xs.head.head);
+
+    main : IO ();
+    main = (
+        let r : Array I64 = flatten2([[1, 2], [3]]);
+        assert_eq(|_|"", r, [1]);;
+        pure()
+    );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -10456,3 +10456,40 @@ fn test_global_accessors_across_compilation_units() {
     config.max_cu_size = 1;
     test_source(source, config);
 }
+
+/// A higher-kinded trait whose instance is pinned down by the annotation at the use site rather
+/// than by the argument: each annotation selects a different instance of the same value.
+#[test]
+pub fn test_higher_kinded_instance_selected_by_annotation() {
+    let source = r##"
+    module Main;
+
+    trait [f : * -> *] f : Container {
+        cmap : (a -> b) -> f a -> f b;
+        cone : a -> f a;
+    }
+
+    impl Array : Container {
+        cmap = |g, xs| xs.to_iter.map(g).to_array;
+        cone = |x| [x];
+    }
+
+    impl Option : Container {
+        cmap = |g, x| x.map(g);
+        cone = |x| Option::some(x);
+    }
+
+    build : [c : Container] I64 -> c I64;
+    build = |n| Container::cone(n);
+
+    main : IO ();
+    main = (
+        let a = (build(3) : Array I64);
+        let o = (build(4) : Option I64);
+        assert_eq(|_|"", a.@(0), 3);;
+        assert_eq(|_|"", o.as_some, 4);;
+        pure()
+    );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}

--- a/src/tests/test_unrelated_module_cache.rs
+++ b/src/tests/test_unrelated_module_cache.rs
@@ -1,0 +1,145 @@
+//! A module that no other module imports must not change the compiled program. Nothing imports
+//! it, so no existing module's `module_dependency_hash` changes and every pre-existing global
+//! value is served from the type-check cache on the second build — while the trait environment,
+//! the type-constructor set and the set of global values have all grown underneath it.
+
+#[cfg(test)]
+mod integration_tests {
+    use crate::tests::test_util::fix_command;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    const FIXPROJ_WITHOUT_INTRUDER: &str = r#"[general]
+name = "unrelated-module"
+version = "0.1.0"
+[build]
+files = ["main.fix"]
+"#;
+
+    const FIXPROJ_WITH_INTRUDER: &str = r#"[general]
+name = "unrelated-module"
+version = "0.1.0"
+[build]
+files = ["main.fix", "intruder.fix"]
+"#;
+
+    const MAIN_FIX: &str = r#"module Main;
+
+type MainData = struct { x : I64 };
+
+impl MainData : ToString {
+    to_string = |d| d.@x.to_string;
+}
+
+main : IO ();
+main = println((1, 2, 3, 4, 5).to_string + MainData { x : 7 }.to_string);
+"#;
+
+    /// Declares a trait, a type and three instances, and defines a global value. No module
+    /// imports it.
+    const INTRUDER_FIX: &str = r#"module Intruder;
+
+type IntruderT = struct { v : I64 };
+
+trait a : IntruderTrait {
+    itr : a -> I64;
+}
+
+impl IntruderT : IntruderTrait {
+    itr = |x| x.@v;
+}
+
+impl IntruderT : ToString {
+    to_string = |x| x.@v.to_string;
+}
+
+impl IntruderT : Eq {
+    eq = |x, y| x.@v == y.@v;
+}
+
+intruder_value : I64;
+intruder_value = IntruderT { v : 1 }.itr;
+"#;
+
+    fn write_project(dir: &Path, fixproj: &str, with_intruder: bool) {
+        fs::write(dir.join("fixproj.toml"), fixproj).unwrap();
+        fs::write(dir.join("main.fix"), MAIN_FIX).unwrap();
+        if with_intruder {
+            fs::write(dir.join("intruder.fix"), INTRUDER_FIX).unwrap();
+        }
+    }
+
+    /// `-g` so that source spans reach the emitted IR as debug info: a stale cached typed
+    /// expression shows up there as a stale `DIFile` or line number.
+    fn build(dir: &Path) {
+        let out = fix_command()
+            .args(["build", "-g", "--emit-llvm", "-o", "out"])
+            .current_dir(dir)
+            .output()
+            .expect("failed to run fix build");
+        assert!(
+            out.status.success(),
+            "fix build failed in {}:\n{}",
+            dir.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn remove_emitted_ir(dir: &Path) {
+        for entry in fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
+            if entry.path().extension().is_some_and(|e| e == "ll") {
+                fs::remove_file(entry.path()).unwrap();
+            }
+        }
+    }
+
+    /// The emitted `.ll` files concatenated in name order.
+    fn emitted_ir(dir: &Path) -> String {
+        let mut paths: Vec<PathBuf> = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|e| e == "ll"))
+            .collect();
+        paths.sort();
+        assert!(!paths.is_empty(), "no LLVM IR emitted in {}", dir.display());
+        paths
+            .iter()
+            .map(|p| fs::read_to_string(p).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn unrelated_module_does_not_change_the_compiled_program() {
+        // Both builds run at the same absolute path: the module identifier the compiler stamps is
+        // derived from the build path.
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("proj");
+
+        // Cold: the intruder is present from the first build.
+        fs::create_dir_all(&dir).unwrap();
+        write_project(&dir, FIXPROJ_WITH_INTRUDER, true);
+        build(&dir);
+        let cold_ir = emitted_ir(&dir);
+
+        // Warm: build without the intruder first, so every global value of `Main` and `Std` lands
+        // in the type-check cache; then add the intruder and build again. Dropping the object
+        // files forces code generation to run again while the type-check cache stays warm.
+        fs::remove_dir_all(&dir).unwrap();
+        fs::create_dir_all(&dir).unwrap();
+        write_project(&dir, FIXPROJ_WITHOUT_INTRUDER, false);
+        build(&dir);
+        write_project(&dir, FIXPROJ_WITH_INTRUDER, true);
+        remove_emitted_ir(&dir);
+        fs::remove_dir_all(dir.join(".fixlang/intermediate")).ok();
+        build(&dir);
+        let warm_ir = emitted_ir(&dir);
+
+        assert_eq!(
+            cold_ir, warm_ir,
+            "a module that nothing imports changed the emitted program between a cold and a warm \
+             type-check cache"
+        );
+    }
+}


### PR DESCRIPTION
Three invariants a bug hunt on the type checker suspected and found intact. Each is green; together they state ground the suite reaches only by other routes.

- **A signature whose type variable is tied to the rest only through equality constraints resolves.** This is the shape `Std::Iterator::flatten` has. `reduce_predicates` makes a single pass rather than reaching a fixpoint — a predicate deferred early is not revisited when a later reduction extends the substitution — and a probe for that shows it happens (101 times over the suite, always the `inner : Std::Iterator` of `flatten`), at points where the residue does not affect the verdict. This is the shape that breaks first if it ever does.
- **A higher-kinded trait's instance is selected by the annotation at the use site**, one value yielding a different instance per annotation. #167 is about the overlap check failing on exactly these heads.
- **A module nothing imports leaves the compiled program alone across a cold and a warm type-check cache.** It builds three times with debug info, so that a typed expression served from a stale cache entry would show up as a stale source attribution.

The third is one line away from the regression test for #176: putting a tuple in the unimported module makes it fail, which is that issue.

## Cost

The three take 8.1s, 2.7s and 4.4s of test time. The suite runs its tests in parallel and takes 400-650s, so this does not move its wall clock.
