### PR TITLE
Abort when an array's capacity does not fit in the address space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 #### Std
 
 - Fixed a bug where `String::from_bytes` updated the length of a shared byte array in place instead of cloning it, truncating the caller's array.
-- Creating or growing an array whose elements need more bytes than the address space holds now aborts the program. `Array::empty(2305843009213693952) : Array I64` used to hand `malloc` a byte count that had wrapped around and return an array whose block had room for none of it, so writing to that array corrupted the heap. `--no-runtime-check` disables this check as it does the bounds checks.
+- Creating or growing an array whose elements need more bytes than the address space holds now aborts the program. `Array::empty(2305843009213693952) : Array I64` used to return an array whose memory had room for none of its elements, so writing to that array corrupted the heap. `--no-runtime-check` disables this check as it does the bounds checks.
 - An `Array` whose element type is boxed now uses one pointer of memory per element. An array of a boxed struct of eight `I64` fields used nine times the memory it needed.
 
 #### Tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 #### Std
 
 - Fixed a bug where `String::from_bytes` updated the length of a shared byte array in place instead of cloning it, truncating the caller's array.
+- Creating or growing an array whose elements need more bytes than the address space holds now aborts the program. `Array::empty(2305843009213693952) : Array I64` used to hand `malloc` a byte count that had wrapped around and return an array whose block had room for none of it, so writing to that array corrupted the heap. `--no-runtime-check` disables this check as it does the bounds checks.
 - An `Array` whose element type is boxed now uses one pointer of memory per element. An array of a boxed struct of eight `I64` fields used nine times the memory it needed.
 
 #### Tool

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -123,6 +123,11 @@ pub const STORAGE_BUF_IDX: u32 = STORAGE_CTRL_IDX + 1;
 // not, so a buffer off this boundary makes every second vector access straddle a line.
 pub const ARRAY_BUF_ALIGNMENT: u64 = 32;
 
+// The bytes an `#ArrayStorage` allocation carries on top of the object, so that the object can be
+// placed off the base of its block and land with its element buffer on `ARRAY_BUF_ALIGNMENT`. The
+// object is placed by less than the alignment, so this is the widest that distance can be.
+pub const ARRAY_STORAGE_ALLOC_SLACK: u64 = ARRAY_BUF_ALIGNMENT - 1;
+
 // The `#ArrayStorage` allocation size, in bytes, from which the element buffer is worth aligning.
 // Below it the loop over the elements is too short for the alignment to pay for the bytes the
 // alignment costs, and such arrays are numerous enough that those bytes show up on their own.

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -18,7 +18,7 @@ use crate::ast::{
     },
 };
 use crate::constants::{
-    TraverserWorkType, ARRAY_BUF_ALIGNMENT, ARRAY_CAP_IDX, ARRAY_NAME, ARRAY_SIZE_IDX,
+    TraverserWorkType, ARRAY_CAP_IDX, ARRAY_NAME, ARRAY_SIZE_IDX, ARRAY_STORAGE_ALLOC_SLACK,
     ARRAY_STORAGE_IDX, ARRAY_STORAGE_NAME, ARRAY_UNSAFE_EMPTY_NAME, ARROW_NAME, BOOL_NAME,
     BOXED_TRAIT_NAME, BOXED_TYPE_DATA_IDX, CAP_NAME, CLOSURE_CAPTURE_IDX, CLOSURE_FUNPTR_IDX,
     CONST_NAME, DESTRUCTOR_NAME, DESTRUCTOR_OBJECT_DTOR_FIELD_IDX,
@@ -2080,7 +2080,7 @@ fn realloc_array<'c, 'm>(
         .builder()
         .build_select(
             is_aligned,
-            i64_ty.const_int(ARRAY_BUF_ALIGNMENT - 1, false),
+            i64_ty.const_int(ARRAY_STORAGE_ALLOC_SLACK, false),
             old_alloc_offset,
             "slack@realloc_array",
         )

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -320,6 +320,12 @@ __attribute__((noreturn)) void fixruntime_negative_array_size(int64_t size)
     fixruntime_abort();
 }
 
+__attribute__((noreturn)) void fixruntime_array_size_overflow(int64_t size)
+{
+    fprintf(stderr, "Array size or capacity too large: %" PRId64 "\n", size);
+    fixruntime_abort();
+}
+
 // void fixruntime_union_variant_mismatch(uint8_t expected, uint8_t actual)
 // {
 //     fprintf(stderr, "Union variant mismatch: expected=%" PRIu8 ", actual=%" PRIu8 "\n", expected, actual);

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -322,7 +322,7 @@ __attribute__((noreturn)) void fixruntime_negative_array_size(int64_t size)
 
 __attribute__((noreturn)) void fixruntime_array_size_overflow(int64_t size)
 {
-    fprintf(stderr, "Array size or capacity too large: %" PRId64 "\n", size);
+    fprintf(stderr, "Array size or capacity exceeds the address space: %" PRId64 "\n", size);
     fixruntime_abort();
 }
 

--- a/src/fixstd/runtime.rs
+++ b/src/fixstd/runtime.rs
@@ -8,6 +8,7 @@ use inkwell::AddressSpace;
 pub const RUNTIME_ABORT: &str = "fixruntime_abort";
 pub const RUNTIME_INDEX_OUT_OF_RANGE: &str = "fixruntime_index_out_of_range";
 pub const RUNTIME_NEGATIVE_ARRAY_SIZE: &str = "fixruntime_negative_array_size";
+pub const RUNTIME_ARRAY_SIZE_OVERFLOW: &str = "fixruntime_array_size_overflow";
 pub const RUNTIME_EPRINTLN: &str = "fixruntime_eprintln";
 pub const RUNTIME_SPRINTF: &str = "sprintf";
 pub const RUNTIME_SUBTRACT_PTR: &str = "fixruntime_subtract_ptr";
@@ -34,6 +35,7 @@ pub fn build_runtime<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     build_abort_function(gc, mode);
     build_index_out_of_range_function(gc, mode);
     build_negative_array_size_function(gc, mode);
+    build_array_size_overflow_function(gc, mode);
     build_eprintf_function(gc, mode);
     build_sprintf_function(gc, mode);
     build_subtract_ptr_function(gc, mode);
@@ -118,6 +120,25 @@ fn build_negative_array_size_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: 
     let func = gc
         .module
         .add_function(RUNTIME_NEGATIVE_ARRAY_SIZE, fn_ty, None);
+    set_noreturn(gc, func);
+    return;
+}
+
+fn build_array_size_overflow_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
+    if mode != BuildMode::Declare {
+        return;
+    }
+    if let Some(_func) = gc.module.get_function(RUNTIME_ARRAY_SIZE_OVERFLOW) {
+        return;
+    }
+
+    let fn_ty = gc
+        .context
+        .void_type()
+        .fn_type(&[gc.context.i64_type().into()], false);
+    let func = gc
+        .module
+        .add_function(RUNTIME_ARRAY_SIZE_OVERFLOW, fn_ty, None);
     set_noreturn(gc, func);
     return;
 }

--- a/src/fixstd/runtime.rs
+++ b/src/fixstd/runtime.rs
@@ -124,7 +124,7 @@ fn build_negative_array_size_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: 
     return;
 }
 
-fn build_array_size_overflow_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
+fn build_array_size_overflow_function<'c, 'm>(gc: &Generator<'c, 'm>, mode: BuildMode) {
     if mode != BuildMode::Declare {
         return;
     }

--- a/src/fixstd/runtime.rs
+++ b/src/fixstd/runtime.rs
@@ -56,7 +56,7 @@ pub fn build_runtime<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     build_realloc_function(gc, mode);
 }
 
-/// Which part of a runtime function a `build_*_function` call emits.
+/// Which part of a runtime function a call in `build_runtime` emits.
 ///
 /// The runtime functions split into two groups: those provided externally (by
 /// the C runtime, e.g. `malloc`), which need only a declaration, and those

--- a/src/fixstd/runtime.rs
+++ b/src/fixstd/runtime.rs
@@ -122,6 +122,8 @@ fn declare_or_lookup_runtime_function<'c, 'm>(
     }
 }
 
+/// Declare `fixruntime_eprintln`, which writes a C string to stderr followed by a newline and
+/// flushes it.
 fn build_eprintf_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
     if mode != BuildMode::Declare {
         return;
@@ -167,6 +169,8 @@ fn build_sprintf_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
     return;
 }
 
+/// Build `fixruntime_subtract_ptr`, which returns the distance in bytes from its second pointer
+/// argument to its first.
 fn build_subtract_ptr_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
     let fn_ty = gc
@@ -197,6 +201,9 @@ fn build_subtract_ptr_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: Bui
     return;
 }
 
+/// Build `fixruntime_ptr_add_offset`, which returns the address `offset` bytes past the pointer it
+/// is given. The offset is applied to the integer address, so it may be negative and may land
+/// outside the object the pointer points into.
 fn build_ptr_add_offset_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     let i64_ty = gc.context.i64_type();
     let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
@@ -247,6 +254,9 @@ pub fn build_pthread_once_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode:
     return;
 }
 
+/// Build `fixruntime_get_argc`, which returns the number of command line arguments the program was
+/// started with, together with the module-internal global variable holding that number, which the C
+/// `main` function stores it into.
 fn build_get_argc_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     let argc_gv_ty = gc.context.i32_type();
     let fn_ty = argc_gv_ty.fn_type(&[], false);
@@ -278,6 +288,9 @@ fn build_get_argc_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMo
     return;
 }
 
+/// Build `fixruntime_get_argv`, which returns a pointer to the command line argument string at the
+/// index it is given, together with the module-internal global variable holding the argument array,
+/// which the C `main` function stores it into.
 fn build_get_argv_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
     let fn_ty = ptr_ty.fn_type(&[gc.context.i64_type().into()], false);

--- a/src/fixstd/runtime.rs
+++ b/src/fixstd/runtime.rs
@@ -2,6 +2,7 @@ use crate::constants::{GLOBAL_VAR_NAME_ARGC, GLOBAL_VAR_NAME_ARGV};
 use crate::generator::Generator;
 use inkwell::attributes::AttributeLoc;
 use inkwell::module::Linkage;
+use inkwell::types::{BasicMetadataTypeEnum, FunctionType};
 use inkwell::values::{BasicValue, FunctionValue};
 use inkwell::AddressSpace;
 
@@ -32,10 +33,16 @@ pub const RUNTIME_REALLOC: &str = "realloc";
 /// Emits the runtime support functions into the module: their declarations when
 /// `mode` is `Declare`, the bodies of the ones implemented here when it is `Implement`.
 pub fn build_runtime<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
-    build_abort_function(gc, mode);
-    build_index_out_of_range_function(gc, mode);
-    build_negative_array_size_function(gc, mode);
-    build_array_size_overflow_function(gc, mode);
+    let i64_ty = gc.context.i64_type();
+    declare_noreturn_runtime_function(gc, mode, RUNTIME_ABORT, &[]);
+    declare_noreturn_runtime_function(
+        gc,
+        mode,
+        RUNTIME_INDEX_OUT_OF_RANGE,
+        &[i64_ty.into(), i64_ty.into()],
+    );
+    declare_noreturn_runtime_function(gc, mode, RUNTIME_NEGATIVE_ARRAY_SIZE, &[i64_ty.into()]);
+    declare_noreturn_runtime_function(gc, mode, RUNTIME_ARRAY_SIZE_OVERFLOW, &[i64_ty.into()]);
     build_eprintf_function(gc, mode);
     build_sprintf_function(gc, mode);
     build_subtract_ptr_function(gc, mode);
@@ -64,83 +71,55 @@ pub enum BuildMode {
     Implement,
 }
 
-/// Mark a runtime function as `noreturn` so LLVM knows control never continues past a call to it.
-/// Without this, a bounds-check failure path (which calls the function and then flows to a merge)
-/// keeps contributing an `undef` value to the merge, forcing an aggregate phi that hides the array
-/// size and defeats bounds-check elimination.
-fn set_noreturn<'c, 'm>(gc: &Generator<'c, 'm>, func: FunctionValue<'c>) {
+/// Declare a runtime function that ends the program: it takes `param_types`, returns nothing, and
+/// is marked `noreturn` so LLVM knows control never continues past a call to it.
+///
+/// Without `noreturn`, a bounds-check failure path (which calls the function and then flows to a
+/// merge) keeps contributing an `undef` value to the merge, forcing an aggregate phi that hides the
+/// array size and defeats bounds-check elimination.
+fn declare_noreturn_runtime_function<'c, 'm>(
+    gc: &Generator<'c, 'm>,
+    mode: BuildMode,
+    name: &str,
+    param_types: &[BasicMetadataTypeEnum<'c>],
+) {
+    if mode != BuildMode::Declare {
+        return;
+    }
+    if gc.module.get_function(name).is_some() {
+        return;
+    }
+
+    let fn_ty = gc.context.void_type().fn_type(param_types, false);
+    let func = gc.module.add_function(name, fn_ty, None);
     gc.add_enum_attribute(func, "noreturn", AttributeLoc::Function);
 }
 
-fn build_abort_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
-    if mode != BuildMode::Declare {
-        return;
+/// Prepare the runtime function `name` of type `fn_ty`, which this module implements itself: in
+/// `Declare` mode add its declaration, in `Implement` mode look the declaration up.
+///
+/// Returns the function whose body the caller is to emit, and `None` in `Declare` mode, where there
+/// is no body to emit yet.
+fn declare_or_lookup_runtime_function<'c, 'm>(
+    gc: &Generator<'c, 'm>,
+    mode: BuildMode,
+    name: &str,
+    fn_ty: FunctionType<'c>,
+) -> Option<FunctionValue<'c>> {
+    match mode {
+        BuildMode::Declare => {
+            if gc.module.get_function(name).is_none() {
+                gc.module
+                    .add_function(name, fn_ty, Some(gc.config.external_if_separated()));
+            }
+            None
+        }
+        BuildMode::Implement => Some(
+            gc.module
+                .get_function(name)
+                .unwrap_or_else(|| panic!("Runtime function {} is not declared", name)),
+        ),
     }
-    if let Some(_func) = gc.module.get_function(RUNTIME_ABORT) {
-        return;
-    }
-
-    let fn_ty = gc.context.void_type().fn_type(&[], false);
-    let func = gc.module.add_function(RUNTIME_ABORT, fn_ty, None);
-    set_noreturn(gc, func);
-    return;
-}
-
-fn build_index_out_of_range_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
-    if mode != BuildMode::Declare {
-        return;
-    }
-    if let Some(_func) = gc.module.get_function(RUNTIME_INDEX_OUT_OF_RANGE) {
-        return;
-    }
-
-    let fn_ty = gc.context.void_type().fn_type(
-        &[gc.context.i64_type().into(), gc.context.i64_type().into()],
-        false,
-    );
-    let func = gc
-        .module
-        .add_function(RUNTIME_INDEX_OUT_OF_RANGE, fn_ty, None);
-    set_noreturn(gc, func);
-    return;
-}
-
-fn build_negative_array_size_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
-    if mode != BuildMode::Declare {
-        return;
-    }
-    if let Some(_func) = gc.module.get_function(RUNTIME_NEGATIVE_ARRAY_SIZE) {
-        return;
-    }
-
-    let fn_ty = gc
-        .context
-        .void_type()
-        .fn_type(&[gc.context.i64_type().into()], false);
-    let func = gc
-        .module
-        .add_function(RUNTIME_NEGATIVE_ARRAY_SIZE, fn_ty, None);
-    set_noreturn(gc, func);
-    return;
-}
-
-fn build_array_size_overflow_function<'c, 'm>(gc: &Generator<'c, 'm>, mode: BuildMode) {
-    if mode != BuildMode::Declare {
-        return;
-    }
-    if let Some(_func) = gc.module.get_function(RUNTIME_ARRAY_SIZE_OVERFLOW) {
-        return;
-    }
-
-    let fn_ty = gc
-        .context
-        .void_type()
-        .fn_type(&[gc.context.i64_type().into()], false);
-    let func = gc
-        .module
-        .add_function(RUNTIME_ARRAY_SIZE_OVERFLOW, fn_ty, None);
-    set_noreturn(gc, func);
-    return;
 }
 
 fn build_eprintf_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
@@ -189,27 +168,14 @@ fn build_sprintf_function<'c, 'm, 'b>(gc: &Generator<'c, 'm>, mode: BuildMode) {
 }
 
 fn build_subtract_ptr_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
-    let func = match mode {
-        BuildMode::Declare => {
-            if let Some(_func) = gc.module.get_function(RUNTIME_SUBTRACT_PTR) {
-                return;
-            }
-            let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
-            let fn_ty = gc
-                .context
-                .i64_type()
-                .fn_type(&[ptr_ty.into(), ptr_ty.into()], false);
-            gc.module.add_function(
-                RUNTIME_SUBTRACT_PTR,
-                fn_ty,
-                Some(gc.config.external_if_separated()),
-            );
-            return;
-        }
-        BuildMode::Implement => match gc.module.get_function(RUNTIME_SUBTRACT_PTR) {
-            Some(func) => func,
-            None => panic!("Runtime function {} is not declared", RUNTIME_SUBTRACT_PTR),
-        },
+    let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
+    let fn_ty = gc
+        .context
+        .i64_type()
+        .fn_type(&[ptr_ty.into(), ptr_ty.into()], false);
+    let Some(func) = declare_or_lookup_runtime_function(gc, mode, RUNTIME_SUBTRACT_PTR, fn_ty)
+    else {
+        return;
     };
 
     let bb = gc.context.append_basic_block(func, "entry");
@@ -235,26 +201,10 @@ fn build_ptr_add_offset_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: B
     let i64_ty = gc.context.i64_type();
     let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
 
-    let func = match mode {
-        BuildMode::Declare => {
-            if let Some(_func) = gc.module.get_function(RUNTIME_PTR_ADD_OFFSET) {
-                return;
-            }
-            let fn_ty = ptr_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false);
-            gc.module.add_function(
-                RUNTIME_PTR_ADD_OFFSET,
-                fn_ty,
-                Some(gc.config.external_if_separated()),
-            );
-            return;
-        }
-        BuildMode::Implement => match gc.module.get_function(RUNTIME_PTR_ADD_OFFSET) {
-            Some(func) => func,
-            None => panic!(
-                "Runtime function {} is not declared",
-                RUNTIME_PTR_ADD_OFFSET
-            ),
-        },
+    let fn_ty = ptr_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false);
+    let Some(func) = declare_or_lookup_runtime_function(gc, mode, RUNTIME_PTR_ADD_OFFSET, fn_ty)
+    else {
+        return;
     };
 
     let bb = gc.context.append_basic_block(func, "entry");
@@ -299,23 +249,9 @@ pub fn build_pthread_once_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode:
 
 fn build_get_argc_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
     let argc_gv_ty = gc.context.i32_type();
-    let func = match mode {
-        BuildMode::Declare => {
-            if let Some(_func) = gc.module.get_function(RUNTIME_GET_ARGC) {
-                return;
-            }
-            let fn_ty = argc_gv_ty.fn_type(&[], false);
-            gc.module.add_function(
-                RUNTIME_GET_ARGC,
-                fn_ty,
-                Some(gc.config.external_if_separated()),
-            );
-            return;
-        }
-        BuildMode::Implement => match gc.module.get_function(RUNTIME_GET_ARGC) {
-            Some(func) => func,
-            None => panic!("Runtime function {} is not declared", RUNTIME_GET_ARGC),
-        },
+    let fn_ty = argc_gv_ty.fn_type(&[], false);
+    let Some(func) = declare_or_lookup_runtime_function(gc, mode, RUNTIME_GET_ARGC, fn_ty) else {
+        return;
     };
     // Add GLOBAL_VAR_NAME_ARGC global variable.
     let argc_gv = gc.module.add_global(argc_gv_ty, None, GLOBAL_VAR_NAME_ARGC);
@@ -343,31 +279,13 @@ fn build_get_argc_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMo
 }
 
 fn build_get_argv_function<'c, 'm, 'b>(gc: &mut Generator<'c, 'm>, mode: BuildMode) {
-    let func = match mode {
-        BuildMode::Declare => {
-            if let Some(_func) = gc.module.get_function(RUNTIME_GET_ARGV) {
-                return;
-            }
-
-            let fn_ty = gc
-                .context
-                .ptr_type(AddressSpace::from(0))
-                .fn_type(&[gc.context.i64_type().into()], false);
-            gc.module.add_function(
-                RUNTIME_GET_ARGV,
-                fn_ty,
-                Some(gc.config.external_if_separated()),
-            );
-            return;
-        }
-        BuildMode::Implement => match gc.module.get_function(RUNTIME_GET_ARGV) {
-            Some(func) => func,
-            None => panic!("Runtime function {} is not declared", RUNTIME_GET_ARGV),
-        },
+    let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
+    let fn_ty = ptr_ty.fn_type(&[gc.context.i64_type().into()], false);
+    let Some(func) = declare_or_lookup_runtime_function(gc, mode, RUNTIME_GET_ARGV, fn_ty) else {
+        return;
     };
 
     // Add GLOBAL_VAR_NAME_ARGV global variable.
-    let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
     let argv_gv = gc.module.add_global(ptr_ty, None, GLOBAL_VAR_NAME_ARGV);
     argv_gv.set_initializer(&ptr_ty.const_zero());
     argv_gv.set_linkage(Linkage::Internal);

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -126,7 +126,7 @@ namespace Array {
     // 
     // # Parameters
     // 
-    // * `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements do not fit in memory, the program will abort.
+    // * `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements exceed the address space, the program will abort.
     empty : I64 -> Array a;
     empty = |cap|(
         let cap = Array::_check_size(cap);
@@ -141,7 +141,7 @@ namespace Array {
     // 
     // # Parameters
     // 
-    // * `size` - The number of elements in the array.
+    // * `size` - The number of elements in the array. If negative, or so large that the elements exceed the address space, the program will abort.
     // * `value` - The value to fill the array with.
     fill : I64 -> a -> Array a;
     fill = |size, value| (
@@ -424,7 +424,7 @@ namespace Array {
     // 
     // # Parameters
     // 
-    // * `capacity` - The capacity to be reserved.
+    // * `capacity` - The capacity to be reserved. If so large that the elements exceed the address space, the program will abort.
     // * `array` - The array to be reserved.
     reserve : I64 -> Array a -> Array a;
     reserve = |cap, arr| (

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -126,7 +126,7 @@ namespace Array {
     // 
     // # Parameters
     // 
-    // * `capacity` - The number of elements the array can hold without allocating more space. If negative, the program will abort.
+    // * `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements do not fit in memory, the program will abort.
     empty : I64 -> Array a;
     empty = |cap|(
         let cap = Array::_check_size(cap);

--- a/src/object.rs
+++ b/src/object.rs
@@ -3,12 +3,12 @@ use crate::ast::program::TypeEnv;
 use crate::ast::types::{TyConVariant, TypeNode};
 use crate::constants::{
     TraverserWorkType, ARRAY_ALIGNED_ALLOC_THRESHOLD, ARRAY_BUF_ALIGNMENT, ARRAY_CAP_IDX,
-    ARRAY_SIZE_IDX, ARRAY_STORAGE_IDX, BOOL_NAME, BOXED_TYPE_DATA_IDX, CTRL_BLK_ALLOC_OFFSET_IDX,
-    CTRL_BLK_REFCNT_IDX, CTRL_BLK_REFCNT_STATE_IDX, DEBUG_ARRAY_ASSUMED_LEN, DW_ATE_ADDRESS,
-    DW_ATE_BOOLEAN, DW_ATE_FLOAT, DW_ATE_SIGNED, DW_ATE_UNSIGNED, DYNAMIC_OBJ_CAP_IDX,
-    DYNAMIC_OBJ_TRAVARSER_IDX, REFCNT_STATE_LOCAL, STD_NAME, STORAGE_BUF_IDX,
-    TRAVERSER_WORK_MARK_GLOBAL, TRAVERSER_WORK_MARK_THREADED, TRAVERSER_WORK_RELEASE,
-    UNION_DATA_IDX, UNION_TAG_IDX,
+    ARRAY_SIZE_IDX, ARRAY_STORAGE_ALLOC_SLACK, ARRAY_STORAGE_IDX, BOOL_NAME, BOXED_TYPE_DATA_IDX,
+    CTRL_BLK_ALLOC_OFFSET_IDX, CTRL_BLK_REFCNT_IDX, CTRL_BLK_REFCNT_STATE_IDX,
+    DEBUG_ARRAY_ASSUMED_LEN, DW_ATE_ADDRESS, DW_ATE_BOOLEAN, DW_ATE_FLOAT, DW_ATE_SIGNED,
+    DW_ATE_UNSIGNED, DYNAMIC_OBJ_CAP_IDX, DYNAMIC_OBJ_TRAVARSER_IDX, REFCNT_STATE_LOCAL, STD_NAME,
+    STORAGE_BUF_IDX, TRAVERSER_WORK_MARK_GLOBAL, TRAVERSER_WORK_MARK_THREADED,
+    TRAVERSER_WORK_RELEASE, UNION_DATA_IDX, UNION_TAG_IDX,
 };
 use crate::error::panic_with_msg;
 use crate::fixstd::builtin::{
@@ -1149,7 +1149,7 @@ impl ObjectType {
                 .build_int_cast(array_capacity, ptr_int_ty, "cap_as_ptr_int_ty")
                 .unwrap();
             if gc.config.runtime_check() {
-                panic_if_capacity_overflows(gc, cap, elem_size, header_size);
+                panic_if_byte_count_exceeds_address_space(gc, cap, elem_size, header_size);
             }
             let elems_size = gc
                 .builder()
@@ -1653,7 +1653,7 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// system cannot supply still fails in `malloc`. It is a constant, so the whole check is one
 /// unsigned comparison, which also rejects the negative capacity an `_unsafe_` primitive can be
 /// handed.
-fn panic_if_capacity_overflows<'c, 'm>(
+fn panic_if_byte_count_exceeds_address_space<'c, 'm>(
     gc: &Generator<'c, 'm>,
     cap: IntValue<'c>,
     elem_size: u64,
@@ -1666,7 +1666,7 @@ fn panic_if_capacity_overflows<'c, 'm>(
     // The bound below is the widest byte count of a 64-bit address space, so it bounds a capacity
     // of that width.
     assert_eq!(cap.get_type().get_bit_width(), 64);
-    let max_cap = (u64::MAX - (ARRAY_BUF_ALIGNMENT - 1) - header_size) / elem_size;
+    let max_cap = (u64::MAX - ARRAY_STORAGE_ALLOC_SLACK - header_size) / elem_size;
     let is_capacity_overflow = gc
         .builder()
         .build_int_compare(
@@ -1747,7 +1747,7 @@ fn build_alloc_array_storage<'c, 'm>(
         .builder()
         .build_and(
             aligned_mask,
-            i64_ty.const_int(ARRAY_BUF_ALIGNMENT - 1, false),
+            i64_ty.const_int(ARRAY_STORAGE_ALLOC_SLACK, false),
             "slack@alloc_array_storage",
         )
         .unwrap();

--- a/src/object.rs
+++ b/src/object.rs
@@ -1110,7 +1110,8 @@ impl ObjectType {
         gc.context.struct_type(&fields, false)
     }
 
-    /// The size of this object in bytes, as a value computed at run time.
+    /// The size of this object in bytes: a constant, except for an object that ends in an element
+    /// buffer, whose size takes a capacity the program computes at run time.
     ///
     /// # Arguments
     /// * `array_capacity` - the number of elements the trailing element buffer is to hold, for an

--- a/src/object.rs
+++ b/src/object.rs
@@ -1649,10 +1649,10 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// block corrupts the heap. The elements must therefore leave room for the header in front of them
 /// and for the padding that puts the element buffer on `ARRAY_BUF_ALIGNMENT`.
 ///
-/// The bound is the widest capacity whose byte count cannot wrap: a byte count within it that the
-/// system cannot supply still fails in `malloc`. It is a constant, so the whole check is one
-/// unsigned comparison, which also rejects the negative capacity an `_unsafe_` primitive can be
-/// handed.
+/// The bound is the widest capacity whose byte count cannot wrap, and a constant, so the whole check
+/// is one unsigned comparison. A byte count within the bound that the system cannot supply is a
+/// separate matter, left where it was: `malloc` answers null and the program faults on the store
+/// that initializes the object.
 fn panic_if_byte_count_exceeds_address_space<'c, 'm>(
     gc: &Generator<'c, 'm>,
     cap: IntValue<'c>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -565,12 +565,12 @@ impl ObjectFieldType {
     }
 
     // Panic if size is negative
-    pub fn panic_if_size_negative<'c, 'm>(gc: &mut Generator<'c, 'm>, len: IntValue<'c>) {
+    pub fn panic_if_size_negative<'c, 'm>(gc: &mut Generator<'c, 'm>, size: IntValue<'c>) {
         let is_neg_size = gc
             .builder()
             .build_int_compare(
                 IntPredicate::SLT,
-                len,
+                size,
                 gc.context.i64_type().const_zero(),
                 "is_neg_size",
             )
@@ -579,7 +579,7 @@ impl ObjectFieldType {
             gc,
             is_neg_size,
             RUNTIME_NEGATIVE_ARRAY_SIZE,
-            &[len.into()],
+            &[size.into()],
             "neg_size",
         );
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1649,48 +1649,48 @@ fn panic_if_capacity_overflows<'c, 'm>(
     // of that width.
     assert_eq!(cap.get_type().get_bit_width(), 64);
     let max_cap = (u64::MAX - (ARRAY_BUF_ALIGNMENT - 1) - header_size) / elem_size;
-    let overflows = gc
+    let is_capacity_overflow = gc
         .builder()
         .build_int_compare(
             IntPredicate::UGT,
             cap,
             cap.get_type().const_int(max_cap, false),
-            "capacity_overflows",
+            "is_capacity_overflow",
         )
         .unwrap();
     build_abort_if(
         gc,
-        overflows,
+        is_capacity_overflow,
         RUNTIME_ARRAY_SIZE_OVERFLOW,
         &[cap.into()],
         "capacity_overflow",
     );
 }
 
-/// Emit a call to the runtime function `runtime_fn` with `args` for the case that `cond` holds, and
+/// Emit a call to the runtime function `func_name` with `args` for the case that `cond` holds, and
 /// leave the builder at the block reached when it does not.
 ///
 /// The runtime function ends the program, so the call is followed by a branch to the continuation
-/// only to close its basic block. `name` names that pair of blocks in the emitted IR.
+/// only to close its basic block. `bb_name` names that pair of blocks in the emitted IR.
 fn build_abort_if<'c, 'm>(
     gc: &Generator<'c, 'm>,
     cond: IntValue<'c>,
-    runtime_fn: &str,
+    func_name: &str,
     args: &[BasicMetadataValueEnum<'c>],
-    name: &str,
+    bb_name: &str,
 ) {
     let current_func = gc.current_function();
     let abort_bb = gc
         .context
-        .append_basic_block(current_func, &format!("{}_bb", name));
+        .append_basic_block(current_func, &format!("{}_bb", bb_name));
     let continue_bb = gc
         .context
-        .append_basic_block(current_func, &format!("{}_continue_bb", name));
+        .append_basic_block(current_func, &format!("{}_continue_bb", bb_name));
     gc.builder()
         .build_conditional_branch(cond, abort_bb, continue_bb)
         .unwrap();
     gc.builder().position_at_end(abort_bb);
-    gc.call_runtime(runtime_fn, args);
+    gc.call_runtime(func_name, args);
     gc.builder()
         .build_unconditional_branch(continue_bb)
         .unwrap();

--- a/src/object.rs
+++ b/src/object.rs
@@ -17,7 +17,8 @@ use crate::fixstd::builtin::{
     make_u64_ty, make_u8_ty,
 };
 use crate::fixstd::runtime::{
-    RUNTIME_INDEX_OUT_OF_RANGE, RUNTIME_MALLOC, RUNTIME_NEGATIVE_ARRAY_SIZE,
+    RUNTIME_ARRAY_SIZE_OVERFLOW, RUNTIME_INDEX_OUT_OF_RANGE, RUNTIME_MALLOC,
+    RUNTIME_NEGATIVE_ARRAY_SIZE,
 };
 use crate::generator::{is_const_one, Generator, Object};
 use inkwell::context::Context;
@@ -1115,10 +1116,11 @@ impl ObjectType {
         array_capacity: Option<IntValue<'c>>,
     ) -> IntValue<'c> {
         if array_capacity.is_some() {
-            // Get pointer to the first element (which is properly aligned) and add it to sizeof(elem_ty) * size.
+            // The size is the header -- the fields laid out ahead of the element buffer -- plus the
+            // bytes the elements take.
 
-            // Calculate sizeof(elem_ty) * size. The element buffer is the last field, of `Array`
-            // (with a preceding capacity slot) or of `#ArrayStorage` (right after the control block).
+            // The element buffer is the last field, of `Array` (with a preceding capacity slot) or
+            // of `#ArrayStorage` (right after the control block).
             let elem_ty = match self.field_types.last().unwrap() {
                 ObjectFieldType::Array(ty) => ty.clone(),
                 ObjectFieldType::ArrayStorageBuf(ty) => ty.clone(),
@@ -1126,36 +1128,35 @@ impl ObjectType {
             };
             // The buffer holds elements as they are embedded -- a pointer where the element type is
             // boxed -- which is the stride every read and write of it uses.
-            let elem_sizeof = elem_ty.get_embedded_type(gc, &vec![]).size_of().unwrap();
+            let embedded_elem_ty = elem_ty.get_embedded_type(gc, &vec![]);
+            let elem_size = gc.target_data.get_abi_size(&embedded_elem_ty);
             let struct_ty = self.to_struct_type(gc, vec![]);
+            let buf_field_idx = struct_ty.count_fields() - 1;
+            let header_size = gc
+                .target_data
+                .offset_of_element(&struct_ty, buf_field_idx)
+                .unwrap();
+
             let ptr_int_ty = gc.context.ptr_sized_int_type(&gc.target_data, None);
-            let cap = array_capacity.unwrap();
             let cap = gc
                 .builder()
-                .build_int_cast(cap, ptr_int_ty, "cap_as_ptr_int_ty")
+                .build_int_cast(array_capacity.unwrap(), ptr_int_ty, "cap_as_ptr_int_ty")
                 .unwrap();
+            if gc.config.runtime_check() {
+                panic_if_capacity_overflows(gc, cap, elem_size, header_size);
+            }
             let elems_size = gc
                 .builder()
-                .build_int_mul(elem_sizeof, cap, "elems_size")
+                .build_int_mul(ptr_int_ty.const_int(elem_size, false), cap, "elems_size")
                 .unwrap();
-
-            // Get pointer to the first element (the buffer is the last struct field).
-            let buf_field_idx = struct_ty.count_fields() - 1;
-            let null = gc.context.ptr_type(AddressSpace::from(0)).const_null();
-            let first_elm_ptr = gc
+            return gc
                 .builder()
-                .build_struct_gep(struct_ty, null, buf_field_idx, "gep_first_elem_size_of")
+                .build_int_add(
+                    ptr_int_ty.const_int(header_size, false),
+                    elems_size,
+                    "size_with_elems",
+                )
                 .unwrap();
-            let header_size = gc
-                .builder()
-                .build_ptr_to_int(first_elm_ptr, ptr_int_ty, "header_size")
-                .unwrap();
-
-            let size_with_elems = gc
-                .builder()
-                .build_int_add(header_size, elems_size, "size_with_elems")
-                .unwrap();
-            return size_with_elems;
         } else {
             self.to_struct_type(gc, vec![]).size_of().unwrap()
         }
@@ -1630,6 +1631,57 @@ pub fn build_storage_is_aligned<'c, 'm>(
             "storage_is_aligned",
         )
         .unwrap()
+}
+
+/// Abort the program unless a buffer of `cap` elements of `elem_size` bytes each, laid out behind a
+/// header of `header_size` bytes, fits in the address space.
+///
+/// Left unchecked, a capacity whose byte count wraps around asks `malloc` for a small block, gets
+/// one, and leaves an object claiming a capacity its block has no room for; the first write past the
+/// block corrupts the heap. The elements must therefore leave room for the header in front of them
+/// and for the bytes `build_alloc_array_storage` adds on top of the object.
+///
+/// The bound is the widest capacity that cannot wrap, rather than a limit worth imposing: a byte
+/// count within it that the system cannot supply still fails in `malloc` as it did before. It is a
+/// constant, so the whole check is one unsigned comparison, which also rejects the negative capacity
+/// an `_unsafe_` primitive can be handed.
+fn panic_if_capacity_overflows<'c, 'm>(
+    gc: &mut Generator<'c, 'm>,
+    cap: IntValue<'c>,
+    elem_size: u64,
+    header_size: u64,
+) {
+    // A buffer of elements of no size is no bytes long, however many of them the capacity asks for.
+    if elem_size == 0 {
+        return;
+    }
+    let max_cap = (u64::MAX - (ARRAY_BUF_ALIGNMENT - 1) - header_size) / elem_size;
+    let overflows = gc
+        .builder()
+        .build_int_compare(
+            IntPredicate::UGT,
+            cap,
+            cap.get_type().const_int(max_cap, false),
+            "capacity_overflows",
+        )
+        .unwrap();
+
+    let current_func = gc.current_function();
+    let overflow_bb = gc
+        .context
+        .append_basic_block(current_func, "capacity_overflow_bb");
+    let in_range_bb = gc
+        .context
+        .append_basic_block(current_func, "capacity_in_range_bb");
+    gc.builder()
+        .build_conditional_branch(overflows, overflow_bb, in_range_bb)
+        .unwrap();
+    gc.builder().position_at_end(overflow_bb);
+    gc.call_runtime(RUNTIME_ARRAY_SIZE_OVERFLOW, &[cap.into()]);
+    gc.builder()
+        .build_unconditional_branch(in_range_bb)
+        .unwrap();
+    gc.builder().position_at_end(in_range_bb);
 }
 
 /// Allocate the block of an `#ArrayStorage` object of `sizeof` bytes and return the object's address

--- a/src/object.rs
+++ b/src/object.rs
@@ -1563,6 +1563,13 @@ pub fn alloc_array_storage<'c, 'm>(
 /// We bypass inkwell's `build_malloc` / `build_array_malloc` because they declare `@malloc` with an
 /// i32 size parameter and truncate the size, which breaks allocations >= 4 GiB. Instead we call our
 /// own `@malloc(i64)` declaration registered in `runtime.rs`.
+///
+/// The result is used without a test for null, so an allocation the system cannot supply ends the
+/// program with SIGSEGV. That failure is deterministic because `create_obj` initializes the control
+/// block before it hands the object on: the first access to a block that was never allocated is
+/// within the header, at a fixed low address, and no capacity or index the program computed reaches
+/// it. Deferring that initialization would put a value the program chose into the faulting address
+/// and turn this into a wild write.
 fn build_malloc<'c, 'm>(
     gc: &Generator<'c, 'm>,
     sizeof: IntValue<'c>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -23,7 +23,9 @@ use crate::fixstd::runtime::{
 use crate::generator::{is_const_one, Generator, Object};
 use inkwell::context::Context;
 use inkwell::types::{BasicTypeEnum, FunctionType, IntType, StructType};
-use inkwell::values::{BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue};
+use inkwell::values::{
+    BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue,
+};
 use inkwell::{
     basic_block::BasicBlock,
     debug_info::{AsDIScope, DIType, DebugInfoBuilder},
@@ -549,29 +551,21 @@ impl ObjectFieldType {
         len: IntValue<'c>,
         idx: IntValue<'c>,
     ) {
-        let current_func = gc.current_function();
         let is_out_of_range = gc
             .builder()
             .build_int_compare(IntPredicate::UGE, idx, len, "is_out_of_range")
             .unwrap();
-        let out_of_range_bb = gc
-            .context
-            .append_basic_block(current_func, "out_of_range_bb");
-        let in_range_bb = gc.context.append_basic_block(current_func, "in_range_bb");
-        gc.builder()
-            .build_conditional_branch(is_out_of_range, out_of_range_bb, in_range_bb)
-            .unwrap();
-        gc.builder().position_at_end(out_of_range_bb);
-        gc.call_runtime(RUNTIME_INDEX_OUT_OF_RANGE, &[idx.into(), len.into()]);
-        gc.builder()
-            .build_unconditional_branch(in_range_bb)
-            .unwrap();
-        gc.builder().position_at_end(in_range_bb);
+        build_abort_if(
+            gc,
+            is_out_of_range,
+            RUNTIME_INDEX_OUT_OF_RANGE,
+            &[idx.into(), len.into()],
+            "out_of_range",
+        );
     }
 
     // Panic if size is negative
     pub fn panic_if_size_negative<'c, 'm>(gc: &mut Generator<'c, 'm>, len: IntValue<'c>) {
-        let current_func = gc.current_function();
         let is_neg_size = gc
             .builder()
             .build_int_compare(
@@ -581,17 +575,13 @@ impl ObjectFieldType {
                 "is_neg_size",
             )
             .unwrap();
-        let neg_size_bb = gc.context.append_basic_block(current_func, "neg_size_bb");
-        let pos_size_bb = gc.context.append_basic_block(current_func, "pos_size_bb");
-        gc.builder()
-            .build_conditional_branch(is_neg_size, neg_size_bb, pos_size_bb)
-            .unwrap();
-        gc.builder().position_at_end(neg_size_bb);
-        gc.call_runtime(RUNTIME_NEGATIVE_ARRAY_SIZE, &[len.into()]);
-        gc.builder()
-            .build_unconditional_branch(pos_size_bb)
-            .unwrap();
-        gc.builder().position_at_end(pos_size_bb);
+        build_abort_if(
+            gc,
+            is_neg_size,
+            RUNTIME_NEGATIVE_ARRAY_SIZE,
+            &[len.into()],
+            "neg_size",
+        );
     }
 
     // Read an element of array.
@@ -1115,7 +1105,7 @@ impl ObjectType {
         gc: &mut Generator<'c, 'm>,
         array_capacity: Option<IntValue<'c>>,
     ) -> IntValue<'c> {
-        if array_capacity.is_some() {
+        if let Some(array_capacity) = array_capacity {
             // The size is the header -- the fields laid out ahead of the element buffer -- plus the
             // bytes the elements take.
 
@@ -1140,7 +1130,7 @@ impl ObjectType {
             let ptr_int_ty = gc.context.ptr_sized_int_type(&gc.target_data, None);
             let cap = gc
                 .builder()
-                .build_int_cast(array_capacity.unwrap(), ptr_int_ty, "cap_as_ptr_int_ty")
+                .build_int_cast(array_capacity, ptr_int_ty, "cap_as_ptr_int_ty")
                 .unwrap();
             if gc.config.runtime_check() {
                 panic_if_capacity_overflows(gc, cap, elem_size, header_size);
@@ -1646,7 +1636,7 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// constant, so the whole check is one unsigned comparison, which also rejects the negative capacity
 /// an `_unsafe_` primitive can be handed.
 fn panic_if_capacity_overflows<'c, 'm>(
-    gc: &mut Generator<'c, 'm>,
+    gc: &Generator<'c, 'm>,
     cap: IntValue<'c>,
     elem_size: u64,
     header_size: u64,
@@ -1668,23 +1658,43 @@ fn panic_if_capacity_overflows<'c, 'm>(
             "capacity_overflows",
         )
         .unwrap();
+    build_abort_if(
+        gc,
+        overflows,
+        RUNTIME_ARRAY_SIZE_OVERFLOW,
+        &[cap.into()],
+        "capacity_overflow",
+    );
+}
 
+/// Emit a call to the runtime function `runtime_fn` with `args` for the case that `cond` holds, and
+/// leave the builder at the block reached when it does not.
+///
+/// The runtime function ends the program, so the call is followed by a branch to the continuation
+/// only to close its basic block. `name` names that pair of blocks in the emitted IR.
+fn build_abort_if<'c, 'm>(
+    gc: &Generator<'c, 'm>,
+    cond: IntValue<'c>,
+    runtime_fn: &str,
+    args: &[BasicMetadataValueEnum<'c>],
+    name: &str,
+) {
     let current_func = gc.current_function();
-    let overflow_bb = gc
+    let abort_bb = gc
         .context
-        .append_basic_block(current_func, "capacity_overflow_bb");
-    let in_range_bb = gc
+        .append_basic_block(current_func, &format!("{}_bb", name));
+    let continue_bb = gc
         .context
-        .append_basic_block(current_func, "capacity_in_range_bb");
+        .append_basic_block(current_func, &format!("{}_continue_bb", name));
     gc.builder()
-        .build_conditional_branch(overflows, overflow_bb, in_range_bb)
+        .build_conditional_branch(cond, abort_bb, continue_bb)
         .unwrap();
-    gc.builder().position_at_end(overflow_bb);
-    gc.call_runtime(RUNTIME_ARRAY_SIZE_OVERFLOW, &[cap.into()]);
+    gc.builder().position_at_end(abort_bb);
+    gc.call_runtime(runtime_fn, args);
     gc.builder()
-        .build_unconditional_branch(in_range_bb)
+        .build_unconditional_branch(continue_bb)
         .unwrap();
-    gc.builder().position_at_end(in_range_bb);
+    gc.builder().position_at_end(continue_bb);
 }
 
 /// Allocate the block of an `#ArrayStorage` object of `sizeof` bytes and return the object's address

--- a/src/object.rs
+++ b/src/object.rs
@@ -1655,6 +1655,9 @@ fn panic_if_capacity_overflows<'c, 'm>(
     if elem_size == 0 {
         return;
     }
+    // The bound below is the widest byte count of a 64-bit address space, so it bounds a capacity
+    // of that width.
+    assert_eq!(cap.get_type().get_bit_width(), 64);
     let max_cap = (u64::MAX - (ARRAY_BUF_ALIGNMENT - 1) - header_size) / elem_size;
     let overflows = gc
         .builder()

--- a/src/object.rs
+++ b/src/object.rs
@@ -545,7 +545,8 @@ impl ObjectFieldType {
         gc.release(value);
     }
 
-    // Panic if idx is out_of_range for the array.
+    /// Abort the program if `idx` falls outside `[0, len)`, the indices an array of `len` elements
+    /// has. The comparison is unsigned, so a negative index is out of range as well.
     pub fn panic_if_out_of_range<'c, 'm>(
         gc: &mut Generator<'c, 'm>,
         len: IntValue<'c>,
@@ -584,11 +585,15 @@ impl ObjectFieldType {
         );
     }
 
-    // Read an element of array.
-    // Returned object is not retained.
+    /// Read the element at `idx` out of an array's buffer, borrowing the array's own reference to
+    /// it: the caller has to retain the result to hold it past the array's lifetime.
+    ///
+    /// # Arguments
+    /// * `len` - the number of elements the array holds, against which `idx` is bounds-checked.
+    ///   `None` omits the check.
     pub fn read_from_array_buf_noretain<'c, 'm>(
         gc: &mut Generator<'c, 'm>,
-        len: Option<IntValue<'c>>, // If none, bounds checking is omitted.
+        len: Option<IntValue<'c>>,
         buffer: PointerValue<'c>,
         elem_ty: Arc<TypeNode>,
         idx: IntValue<'c>,
@@ -616,11 +621,15 @@ impl ObjectFieldType {
         Object::new(elem_val, elem_ty, gc)
     }
 
-    // Read an element of array.
-    // Returned object is retained.
+    /// Read the element at `idx` out of an array's buffer and retain it, giving the caller a
+    /// reference of its own.
+    ///
+    /// # Arguments
+    /// * `len` - the number of elements the array holds, against which `idx` is bounds-checked.
+    ///   `None` omits the check.
     pub fn read_from_array_buf<'c, 'm>(
         gc: &mut Generator<'c, 'm>,
-        len: Option<IntValue<'c>>, // If none, bounds checking is omitted.
+        len: Option<IntValue<'c>>,
         buffer: PointerValue<'c>,
         elem_ty: Arc<TypeNode>,
         idx: IntValue<'c>,
@@ -630,7 +639,14 @@ impl ObjectFieldType {
         elem
     }
 
-    // Write an element into array.
+    /// Store `value` into the slot at `idx` of an array's buffer, handing the caller's reference to
+    /// it over to the array.
+    ///
+    /// # Arguments
+    /// * `len` - the number of elements the array holds, against which `idx` is bounds-checked.
+    ///   `None` omits the check.
+    /// * `release_old_value` - `true` when the slot holds a live element, whose reference is
+    ///   released before the store; `false` when the slot is uninitialized.
     pub fn write_to_array_buf<'c, 'm>(
         gc: &mut Generator<'c, 'm>,
         len: Option<IntValue<'c>>,
@@ -1152,9 +1168,11 @@ impl ObjectType {
         }
     }
 
-    // Get type used when this object is embedded.
-    // i.e., for unboxed type, a pointer; for unboxed type, a struct.
-    // * `unboxed_path` -  See the comment for ObjectType::to_struct_type.
+    /// The type this object takes where it is embedded in another value: a struct for an unboxed
+    /// type, a pointer for a boxed one.
+    ///
+    /// # Arguments
+    /// * `unboxed_path` - see `ObjectType::to_struct_type`.
     pub fn to_embedded_type<'c, 'm>(
         &self,
         gc: &mut Generator<'c, 'm>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -564,7 +564,7 @@ impl ObjectFieldType {
         );
     }
 
-    // Panic if size is negative
+    /// Abort the program if the array size or capacity `size` is negative.
     pub fn panic_if_size_negative<'c, 'm>(gc: &mut Generator<'c, 'm>, size: IntValue<'c>) {
         let is_neg_size = gc
             .builder()
@@ -1629,12 +1629,12 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// Left unchecked, a capacity whose byte count wraps around asks `malloc` for a small block, gets
 /// one, and leaves an object claiming a capacity its block has no room for; the first write past the
 /// block corrupts the heap. The elements must therefore leave room for the header in front of them
-/// and for the bytes `build_alloc_array_storage` adds on top of the object.
+/// and for the padding that puts the element buffer on `ARRAY_BUF_ALIGNMENT`.
 ///
-/// The bound is the widest capacity that cannot wrap, rather than a limit worth imposing: a byte
-/// count within it that the system cannot supply still fails in `malloc` as it did before. It is a
-/// constant, so the whole check is one unsigned comparison, which also rejects the negative capacity
-/// an `_unsafe_` primitive can be handed.
+/// The bound is the widest capacity whose byte count cannot wrap: a byte count within it that the
+/// system cannot supply still fails in `malloc`. It is a constant, so the whole check is one
+/// unsigned comparison, which also rejects the negative capacity an `_unsafe_` primitive can be
+/// handed.
 fn panic_if_capacity_overflows<'c, 'm>(
     gc: &Generator<'c, 'm>,
     cap: IntValue<'c>,

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -123,10 +123,9 @@ pub fn test_fill_negative_size() {
 
 // The bytes an array's elements need must fit in the address space. A capacity whose byte count
 // exceeds it wraps around to a small number, which `malloc` supplies, leaving an array whose block
-// has no room for the capacity it claims; the first write past the block corrupts the heap. The two
-// capacities below are caught by different halves of the check.
+// has no room for the capacity it claims; the first write past the block corrupts the heap.
 
-// A capacity of 2^61 elements of 8 bytes comes to exactly 2^64 bytes, which wraps to zero.
+/// A capacity of 2^61 elements of 8 bytes comes to exactly 2^64 bytes, which wraps to zero.
 #[test]
 pub fn test_empty_capacity_byte_count_wraps() {
     let source = r#"
@@ -143,12 +142,12 @@ pub fn test_empty_capacity_byte_count_wraps() {
     test_source_fail(
         &source,
         config,
-        "Array size or capacity too large: 2305843009213693952",
+        "Array size or capacity exceeds the address space: 2305843009213693952",
     );
 }
 
-// A capacity of 2^61-3 elements of 8 bytes comes to 24 bytes short of 2^64: the elements fit, while
-// the header and the padding that puts the element buffer on its alignment do not.
+/// A capacity of 2^61-3 elements of 8 bytes comes to 24 bytes short of 2^64: the elements fit, while
+/// the header and the padding that puts the element buffer on its alignment do not.
 #[test]
 pub fn test_empty_capacity_byte_count_leaves_no_room_for_the_header() {
     let source = r#"
@@ -165,14 +164,14 @@ pub fn test_empty_capacity_byte_count_leaves_no_room_for_the_header() {
     test_source_fail(
         &source,
         config,
-        "Array size or capacity too large: 2305843009213693949",
+        "Array size or capacity exceeds the address space: 2305843009213693949",
     );
 }
 
-// A capacity the compiler cannot see the value of is checked where the program allocates, rather
-// than by folding the check away at the capacity a literal gives.
+/// A capacity the compiler cannot see the value of is checked where the program allocates, rather
+/// than by folding the check away at the capacity a literal gives.
 #[test]
-pub fn test_capacity_byte_count_is_checked_at_run_time() {
+pub fn test_empty_capacity_byte_count_is_checked_at_run_time() {
     let source = r#"
             module Main;
 
@@ -189,12 +188,12 @@ pub fn test_capacity_byte_count_is_checked_at_run_time() {
     test_source_fail(
         &source,
         config,
-        "Array size or capacity too large: 2305843009213693949",
+        "Array size or capacity exceeds the address space: 2305843009213693949",
     );
 }
 
-// Growing an array's capacity reallocates its storage, and the byte count of the new capacity is
-// checked as the one an array is created with is.
+/// Growing an array's capacity reallocates its storage, and the byte count of the new capacity is
+/// checked as the one an array is created with is.
 #[test]
 pub fn test_reserve_capacity_byte_count_wraps() {
     let source = r#"
@@ -211,8 +210,97 @@ pub fn test_reserve_capacity_byte_count_wraps() {
     test_source_fail(
         &source,
         config,
-        "Array size or capacity too large: 2305843009213693952",
+        "Array size or capacity exceeds the address space: 2305843009213693952",
     );
+}
+
+/// The bound scales with the element stride: 2^60 elements of 32 bytes overflow where the same
+/// capacity of 8-byte elements is far below the bound.
+#[test]
+pub fn test_capacity_byte_count_wraps_for_a_wide_element() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array (I64, I64, I64, I64) = Array::empty(1152921504606846976);
+                println(arr.push_back((1, 2, 3, 4)).@size.to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity exceeds the address space: 1152921504606846976",
+    );
+}
+
+/// An element type of no size gives a buffer of no bytes, whatever the capacity, so any capacity is
+/// allocatable and the check has no bound to compare against.
+#[test]
+pub fn test_capacity_of_a_zero_sized_element_is_allocatable() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array () = Array::fill(3, ());
+                println(arr.@size.to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source(&source, config);
+}
+
+/// A capacity reaches the check through the `_unsafe_` primitives as well, which take one the caller
+/// promises is in range; a negative one is out of range read as the byte count it asks for.
+#[test]
+pub fn test_unsafe_empty_capacity_unchecked_checks_the_byte_count() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::_unsafe_empty_capacity_unchecked(-1);
+                println(arr.@capacity.to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity exceeds the address space: -1",
+    );
+}
+
+/// `--no-runtime-check` drops the byte-count check with the bounds checks, so the same capacity that
+/// aborts with checks on runs to completion with them off.
+#[test]
+pub fn test_capacity_byte_count_respects_no_runtime_check() {
+    // The array is never written to, so the run with the check off stays memory-safe: the wrapped
+    // byte count reaches `malloc`, and the array it returns is only asked for its capacity.
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::empty(2305843009213693952);
+                println(arr.@capacity.to_string)
+            );
+        "#;
+    let mut checked = Configuration::develop_mode();
+    checked.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        checked,
+        "Array size or capacity exceeds the address space: 2305843009213693952",
+    );
+    let mut unchecked = Configuration::develop_mode();
+    unchecked.no_runtime_check = true;
+    test_source(&source, unchecked);
 }
 
 // `--no-runtime-check` disables array bounds checks (documented in the CLI help), so `set`

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -1,5 +1,5 @@
 use crate::{
-    configuration::Configuration,
+    configuration::{Configuration, FixOptimizationLevel},
     tests::test_util::{test_source, test_source_fail},
 };
 
@@ -255,7 +255,8 @@ pub fn test_capacity_of_a_zero_sized_element_is_allocatable() {
 }
 
 /// A capacity reaches the check through the `_unsafe_` primitives as well, which take one the caller
-/// promises is in range; a negative one is out of range read as the byte count it asks for.
+/// promises is in range. Read as the byte count it asks for, a negative capacity of an eight-byte
+/// element exceeds the address space.
 #[test]
 pub fn test_unsafe_empty_capacity_unchecked_checks_the_byte_count() {
     let source = r#"
@@ -273,6 +274,82 @@ pub fn test_unsafe_empty_capacity_unchecked_checks_the_byte_count() {
         &source,
         config,
         "Array size or capacity exceeds the address space: -1",
+    );
+}
+
+/// The bound is exact at its top end: one element above the widest capacity that fits, the byte
+/// count plus the header and the alignment padding comes to 2^64 + 7, which wraps to 7 bytes that
+/// `malloc` supplies.
+#[test]
+pub fn test_empty_capacity_one_element_past_the_bound_is_rejected() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::empty(2305843009213693948);
+                println(arr.push_back(42).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity exceeds the address space: 2305843009213693948",
+    );
+}
+
+/// Growing a shared array allocates a fresh storage instead of reallocating in place, and the byte
+/// count of the new capacity is checked on that branch as it is on the in-place one.
+#[test]
+pub fn test_reserve_capacity_byte_count_wraps_for_a_shared_array() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::fill(3, 7);
+                // Two live references to one storage send `reserve` down the shared branch.
+                let pair = (arr, arr);
+                let big = pair.@0.reserve(2305843009213693952);
+                println((big.@(0) + pair.@1.@(0)).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity exceeds the address space: 2305843009213693952",
+    );
+}
+
+/// The runtime function the check calls is declared in every compilation unit and defined in one, so
+/// a program split into one unit per symbol links and aborts where a single-unit program does. The
+/// optimization level comes down to `Basic` because separate compilation, which `max_cu_size`
+/// divides, runs only there and below.
+#[test]
+pub fn test_capacity_byte_count_under_separate_compilation() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let args = *get_args;
+                // A program run with no argument gets one element in `args`, so this is 2^61-3.
+                let arr : Array I64 = Array::empty(2305843009213693950 - args.@size);
+                println(arr.push_back(42).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    config.set_fix_opt_level(FixOptimizationLevel::Basic);
+    config.max_cu_size = 1;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity exceeds the address space: 2305843009213693949",
     );
 }
 

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -117,13 +117,10 @@ pub fn test_fill_negative_size() {
 
 // The bytes an array's elements need must fit in the address space. A capacity whose byte count
 // exceeds it wraps around to a small number, which `malloc` supplies, leaving an array whose block
-// has no room for the capacity it claims; the first write past the block corrupts the heap.
-//
-// The capacities below are caught by different halves of the check: 2^61 elements of 8 bytes come
-// to exactly 2^64 and wrap to zero, while 2^61-3 elements come to 24 bytes short of 2^64, which
-// does fit, but leaves no room for the header and for the bytes the allocation adds to place the
-// element buffer on its alignment.
+// has no room for the capacity it claims; the first write past the block corrupts the heap. The two
+// capacities below are caught by different halves of the check.
 
+// A capacity of 2^61 elements of 8 bytes comes to exactly 2^64 bytes, which wraps to zero.
 #[test]
 pub fn test_empty_capacity_byte_count_wraps() {
     let source = r#"
@@ -144,6 +141,8 @@ pub fn test_empty_capacity_byte_count_wraps() {
     );
 }
 
+// A capacity of 2^61-3 elements of 8 bytes comes to 24 bytes short of 2^64: the elements fit, while
+// the header and the padding that puts the element buffer on its alignment do not.
 #[test]
 pub fn test_empty_capacity_byte_count_leaves_no_room_for_the_header() {
     let source = r#"

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -35,6 +35,7 @@ pub fn test_set() {
     test_source_fail(&source, config, "Index out of range");
 }
 
+/// `mod` bounds-checks the index it is given.
 #[test]
 pub fn test_mod() {
     let source = r#"    
@@ -51,6 +52,7 @@ pub fn test_mod() {
     test_source_fail(&source, config, "Index out of range");
 }
 
+/// `act` bounds-checks the index it is given.
 #[test]
 pub fn test_act() {
     let source = r#"    
@@ -67,6 +69,7 @@ pub fn test_act() {
     test_source_fail(&source, config, "Index out of range");
 }
 
+/// The `arr[idx]` index syntax bounds-checks the index as `@` does.
 #[test]
 pub fn test_index_syntax() {
     let source = r#"    
@@ -83,6 +86,8 @@ pub fn test_index_syntax() {
     test_source_fail(&source, config, "Index out of range");
 }
 
+/// A negative capacity given to `Array::empty` aborts the program, and the message reports the
+/// capacity.
 #[test]
 pub fn test_empty_negative_capacity() {
     let source = r#"    
@@ -99,6 +104,7 @@ pub fn test_empty_negative_capacity() {
     test_source_fail(&source, config, "Negative array size or capacity: -1");
 }
 
+/// A negative size given to `Array::fill` aborts the program.
 #[test]
 pub fn test_fill_negative_size() {
     let source = r#"

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -115,6 +115,101 @@ pub fn test_fill_negative_size() {
     test_source_fail(&source, config, "Negative array size or capacity");
 }
 
+// The bytes an array's elements need must fit in the address space. A capacity whose byte count
+// exceeds it wraps around to a small number, which `malloc` supplies, leaving an array whose block
+// has no room for the capacity it claims; the first write past the block corrupts the heap.
+//
+// The capacities below are caught by different halves of the check: 2^61 elements of 8 bytes come
+// to exactly 2^64 and wrap to zero, while 2^61-3 elements come to 24 bytes short of 2^64, which
+// does fit, but leaves no room for the header and for the bytes the allocation adds to place the
+// element buffer on its alignment.
+
+#[test]
+pub fn test_empty_capacity_byte_count_wraps() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::empty(2305843009213693952);
+                println(arr.push_back(42).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity too large: 2305843009213693952",
+    );
+}
+
+#[test]
+pub fn test_empty_capacity_byte_count_leaves_no_room_for_the_header() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = Array::empty(2305843009213693949);
+                println(arr.push_back(42).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity too large: 2305843009213693949",
+    );
+}
+
+// A capacity the compiler cannot see the value of is checked where the program allocates, rather
+// than by folding the check away at the capacity a literal gives.
+#[test]
+pub fn test_capacity_byte_count_is_checked_at_run_time() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let args = *get_args;
+                // A program run with no argument gets one element in `args`, so this is 2^61-3.
+                let arr : Array I64 = Array::empty(2305843009213693950 - args.@size);
+                println(arr.push_back(42).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity too large: 2305843009213693949",
+    );
+}
+
+// Growing an array's capacity reallocates its storage, and the byte count of the new capacity is
+// checked as the one an array is created with is.
+#[test]
+pub fn test_reserve_capacity_byte_count_wraps() {
+    let source = r#"
+            module Main;
+
+            main : IO ();
+            main = (
+                let arr : Array I64 = [1, 2, 3];
+                println(arr.reserve(2305843009213693952).@(0).to_string)
+            );
+        "#;
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    test_source_fail(
+        &source,
+        config,
+        "Array size or capacity too large: 2305843009213693952",
+    );
+}
+
 // `--no-runtime-check` disables array bounds checks (documented in the CLI help), so `set`
 // and `swap` must honor it like `@` / `mod` / `act`. An index within the array's capacity but
 // past its size stays inside the allocated buffer, so the access itself is memory-safe; only

--- a/std_doc/Std.md
+++ b/std_doc/Std.md
@@ -364,7 +364,7 @@ Creates an empty array with specified capacity.
 
 ##### Parameters
 
-* `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements do not fit in memory, the program will abort.
+* `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements exceed the address space, the program will abort.
 
 #### fill
 
@@ -378,7 +378,7 @@ Example: `fill(n, x) == [x, x, x, ..., x]` (of length `n`).
 
 ##### Parameters
 
-* `size` - The number of elements in the array.
+* `size` - The number of elements in the array. If negative, or so large that the elements exceed the address space, the program will abort.
 * `value` - The value to fill the array with.
 
 #### find_by
@@ -564,7 +564,7 @@ Reserves the memory region for an array.
 
 ##### Parameters
 
-* `capacity` - The capacity to be reserved.
+* `capacity` - The capacity to be reserved. If so large that the elements exceed the address space, the program will abort.
 * `array` - The array to be reserved.
 
 #### resize

--- a/std_doc/Std.md
+++ b/std_doc/Std.md
@@ -364,7 +364,7 @@ Creates an empty array with specified capacity.
 
 ##### Parameters
 
-* `capacity` - The number of elements the array can hold without allocating more space. If negative, the program will abort.
+* `capacity` - The number of elements the array can hold without allocating more space. If negative, or so large that the elements do not fit in memory, the program will abort.
 
 #### fill
 


### PR DESCRIPTION
Closes #132.

An array's byte count `header + capacity * elem_size` was computed with wrapping arithmetic and never checked, so a capacity whose byte count wrapped asked `malloc` for a few bytes, got them, and produced an array claiming a capacity its block had no room for. `Array::empty(2305843009213693952) : Array I64` aborted in `realloc()` three `push_back`s later, with the heap already corrupted.

## The check

`ObjectType::size_of` — the one place an array's byte count is computed, reached from `create_obj` for a fresh `#ArrayStorage` and from `realloc_array` for a capacity change — now compares the capacity, unsigned, against the widest one whose elements, header and alignment padding fit in the address space. The bound is a constant, so the check is one `icmp` and a branch, and it folds away entirely where the capacity is a constant the compiler can see.

Because both allocation paths compute the byte count there, the check covers creating an array and growing one alike, `Array::empty` / `fill` / `reserve` and the `_unsafe_` primitives together. `--no-runtime-check` drops it as it does the bounds checks.

The bound is the widest capacity that cannot wrap rather than a limit worth imposing: for a one-byte element type it lands above `I64::MAX`, so no non-negative capacity is ever rejected for a byte array, which is correct — `header + n` cannot reach 2^64 there.

## Alongside

`ARRAY_STORAGE_ALLOC_SLACK` names the bytes an aligned `#ArrayStorage` allocation carries on top of the object. Two other places derived it from `ARRAY_BUF_ALIGNMENT` independently, and the bound would have been a third; widening the slack can no longer leave the bound behind.

`size_of` reads the element stride and the header size from the target data layout instead of building them a second time as LLVM constant expressions, so the check and the arithmetic use the same two numbers. In the emitted IR this folds `mul i64 ptrtoint (ptr getelementptr ({i8}, ptr null, i32 1) to i64), %n` to `mul i64 1, %n`, and `malloc(<constant expression>)` to `malloc(10)`.

Two refactors the review asked for: the three `panic_if_*` helpers share one abort-branch emitter, and eight runtime declarations share two helpers.

## Evidence

- Full suite at `-O none` / `basic` / `max`: green.
- LLVM IR differential over `examples/` against the fork point, at three levels: pre-optimization, no difference other than the new declaration, the check's two blocks, and the constant folding above. The attribute table gains exactly one row (`fixruntime_array_size_overflow fn=[noreturn]`) and changes none; linkage matches for all eight declarations, verified under `--max-cu-size 1` at 337 compilation units.
- Instruction counts (cachegrind, `-O experimental`) over twelve benchmark cases: eleven identical to the instruction, `levenshtein` +0.15%.
- A compiler that computes the byte count both ways — the old LLVM constant expressions against the new target-data constants — and aborts on disagreement was silent over 30 element shapes and the whole suite, after being shown to fire when either side is broken.
