### PR TITLE
Fail the build when gcc does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 #### Tool
 
+- `fix build` now exits with a failure status when linking fails. It printed the linker's error and exited 0, so a build that produced no output file looked like a success to `fix build && ./prog`, to a `make` rule and to a CI step.
 - On AArch64 targets (Apple Silicon and other 64-bit ARM), an integer narrower than 32 bits crossed the FFI boundary as a wrong number: a function exported with `FFI_EXPORT` returned one to its foreign caller, and `FFI_CALL` passed one to a foreign function that takes one. A function of type `I8 -> I8 -> I8` exported and called from C with `-100` and `30` answered 186 instead of -70. This covers `I8`, `U8`, `I16` and `U16`, and the `Std::FFI` aliases of the same widths such as `CChar` and `CShort`. x86-64 targets were unaffected.
 - Writing `()` as a parameter type in `FFI_CALL` now reports an error pointing at that parameter, instead of aborting the compiler.
 - Tail call optimization now applies in more cases. Code that overflowed the stack at `-O none` or `-O basic` — typically a loop written with monadic binds, whose result or state is too wide for the target's registers — now runs in constant stack.

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -12,11 +12,25 @@ use std::path::PathBuf;
 use std::process::Command;
 
 /// Run `gcc` as prepared in `com`, passing on whatever it writes to standard error.
-fn run_gcc(com: &mut Command) {
-    let output = com.output().expect("Failed to run gcc.");
+///
+/// # Arguments
+/// * `step` — what the invocation is for, as a verb phrase that completes "Failed to ...", so that
+///   a failure says which of the compiler's several `gcc` calls it was.
+fn run_gcc(com: &mut Command, step: &str) -> Result<(), Errors> {
+    let output = com
+        .output()
+        .map_err(|e| Errors::from_msg(format!("Failed to {}: {:?}", step, e)))?;
     if output.stderr.len() > 0 {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
     }
+    if !output.status.success() {
+        return Err(Errors::from_msg(format!(
+            "Failed to {}: gcc exited with code {}.",
+            step,
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(())
 }
 
 /// Builds the program specified in the configuration, linking the object files and the runtime into
@@ -111,7 +125,7 @@ pub fn build(config: &Configuration) -> Result<(), Errors> {
         if matches!(config.output_file_type, OutputFileType::DynamicLibrary) {
             com = com.arg("-fPIC");
         }
-        run_gcc(com);
+        run_gcc(com, "compile the runtime")?;
 
         // Rename the temporary file to the final file.
         fs::rename(&runtime_tmp_path, &runtime_obj_path).expect(&format!(
@@ -143,7 +157,7 @@ pub fn build(config: &Configuration) -> Result<(), Errors> {
     com.arg(runtime_obj_path.to_str().unwrap())
         .args(library_search_path_opts)
         .args(libs_opts);
-    run_gcc(&mut com);
+    run_gcc(&mut com, "link the output file")?;
 
     Ok(())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod test_assert;
 mod test_associated_type;
 mod test_basic;
 mod test_bool_union;
+mod test_build_exit_status;
 mod test_check;
 mod test_debug_info;
 mod test_deep_expression;

--- a/src/tests/test_build_exit_status.rs
+++ b/src/tests/test_build_exit_status.rs
@@ -1,0 +1,54 @@
+//! `fix build` reports a failed build through its exit status, so that a caller which chains on
+//! success — a shell `&&`, a `make` rule, a CI step — stops rather than carrying on with an output
+//! file the build never produced.
+
+#[cfg(test)]
+mod integration_tests {
+    use crate::tests::test_util::fix_build_source_command;
+    use tempfile::TempDir;
+
+    const SOURCE: &str = r#"module Main;
+
+main : IO ();
+main = println("hi");
+"#;
+
+    /// Linking against a library that does not exist fails the build, and the same build without
+    /// that library succeeds — so the failing case is a link failure rather than a program the
+    /// compiler rejects for its own reasons.
+    #[test]
+    fn test_build_fails_when_linking_fails() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let out_path = temp_dir.path().join("out");
+
+        let control = fix_build_source_command(temp_dir.path(), SOURCE, "none")
+            .arg("-o")
+            .arg(&out_path)
+            .output()
+            .expect("Failed to execute fix build");
+        assert!(
+            control.status.success() && out_path.exists(),
+            "the control build failed, so the test below would prove nothing:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&control.stdout),
+            String::from_utf8_lossy(&control.stderr)
+        );
+        std::fs::remove_file(&out_path).expect("Failed to remove the control build's output");
+
+        let output = fix_build_source_command(temp_dir.path(), SOURCE, "none")
+            .arg("-o")
+            .arg(&out_path)
+            .arg("-d")
+            .arg("no_such_library_for_this_test")
+            .output()
+            .expect("Failed to execute fix build");
+        assert!(
+            !output.status.success(),
+            "linking against a library that does not exist reported success, and left {}",
+            if out_path.exists() {
+                "an output file"
+            } else {
+                "no output file"
+            }
+        );
+    }
+}


### PR DESCRIPTION
Closes #151.

`run_gcc` passed gcc's standard error on and returned, whatever gcc's exit status. A link that failed therefore left `fix build` reporting success with no output file to show for it, and a caller that chains on success — a shell `&&`, a `make` rule, a CI step — carried on.

## Reproduction

Linking against a library that does not exist is a deterministic way in:

```
$ fix build -f main.fix -o out -d no_such_library_xyz
/usr/bin/ld: cannot find -lno_such_library_xyz: No such file or directory
collect2: error: ld returned 1 exit status
$ echo $?
0
$ ls out
ls: cannot access 'out': No such file or directory
```

After:

```
/usr/bin/ld: cannot find -lno_such_library_xyz: No such file or directory
collect2: error: ld returned 1 exit status
error: Failed to link the output file: gcc exited with code 1.
$ echo $?
1
```

gcc's own diagnostics still come through; the compiler then says which of its two `gcc` invocations failed, since the other one compiles the runtime.

A failure to start gcc at all — gcc not installed — was `.expect("Failed to run gcc.")`, a panic where a diagnostic is owed. It is an error now.

Both follow the shape `PreliminaryCommand::run` and the C-type-size probe in `Configuration` already use: check the spawn, check the status, return `Errors`.

## One correction to the issue

The issue says a stale artifact would be run in place of the new one. For a failure of the final link that does not happen — the linker removes its output on failure — so the certain consequence is the false success rather than a stale binary. A failure earlier in the build, while compiling the runtime, would leave a previous output file in place.

## Tests

`src/tests/test_build_exit_status.rs` builds a trivial program twice: once plainly, which must succeed and produce the file, and once against a library that does not exist, which must fail. The first half is what keeps the second from passing vacuously — a program the compiler rejects for its own reasons would fail both.

Reverting the fix makes it fail, which was checked before trusting it.

Full suite at `FIX_MAX_OPT_LEVEL` of `none` and `max`: 1145 passed, 0 failed at each.
