### PR TITLE
Compute an element buffer's byte count in one place

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -34,8 +34,8 @@ use crate::fixstd::runtime::{RUNTIME_ABORT, RUNTIME_EPRINTLN, RUNTIME_REALLOC};
 use crate::generator::{Generator, Object};
 use crate::misc::{make_map, Map, Set};
 use crate::object::{
-    alloc_array_storage, build_array_storage_shift, build_storage_is_aligned, create_obj,
-    get_array_storage, get_array_storage_buf, read_alloc_offset, write_alloc_offset,
+    alloc_array_storage, build_array_storage_shift, build_elems_bytes, build_storage_is_aligned,
+    create_obj, get_array_storage, get_array_storage_buf, read_alloc_offset, write_alloc_offset,
     ObjectFieldType,
 };
 use crate::optimization::rename::generate_new_names;
@@ -2162,29 +2162,16 @@ fn realloc_array<'c, 'm>(
             .unwrap()
     };
     let len = array.extract_field(gc, ARRAY_SIZE_IDX).into_int_value();
-    let elem_value_ty = elem_ty.get_embedded_type(gc, &vec![]);
-    let elems_size_as_ptr = unsafe {
-        gc.builder()
-            .build_gep(
-                elem_value_ty,
-                gc.context.ptr_type(AddressSpace::from(0)).const_null(),
-                &[len],
-                "elems_size_as_ptr@realloc_array",
-            )
-            .unwrap()
-    };
+    let elems_bytes = build_elems_bytes(gc, &elem_ty, len, "elems_size@realloc_array");
+    let header_size = gc
+        .target_data
+        .offset_of_element(&struct_type, STORAGE_BUF_IDX)
+        .unwrap();
     let live_bytes = gc
         .builder()
         .build_int_add(
-            gc.builder()
-                .build_ptr_to_int(elems_size_as_ptr, i64_ty, "elems_size@realloc_array")
-                .unwrap(),
-            i64_ty.const_int(
-                gc.target_data
-                    .offset_of_element(&struct_type, STORAGE_BUF_IDX)
-                    .unwrap(),
-                false,
-            ),
+            elems_bytes,
+            i64_ty.const_int(header_size, false),
             "live_bytes@realloc_array",
         )
         .unwrap();
@@ -2437,20 +2424,7 @@ impl LLVMGen for InlineLLVMArrayAppendCapacityBoundsUnchecked {
         // Unique `src`: memcpy the elements and zero `src`'s length so releasing it frees the block
         // without touching the moved-out elements. No reference counting.
         gc.builder().position_at_end(src_unique_bb);
-        let n_span = unsafe {
-            gc.builder()
-                .build_gep(
-                    elem_value_ty,
-                    gc.context.ptr_type(AddressSpace::from(0)).const_null(),
-                    &[n],
-                    "append_n_span",
-                )
-                .unwrap()
-        };
-        let n_bytes = gc
-            .builder()
-            .build_ptr_to_int(n_span, gc.context.i64_type(), "append_n_bytes")
-            .unwrap();
+        let n_bytes = build_elems_bytes(gc, &elem_ty, n, "append_n_bytes");
         gc.builder()
             .build_memcpy(dst_write, 1, src_buf, 1, n_bytes)
             .ok()

--- a/src/object.rs
+++ b/src/object.rs
@@ -1133,10 +1133,7 @@ impl ObjectType {
                 ObjectFieldType::ArrayStorageBuf(ty) => ty.clone(),
                 _ => panic!(),
             };
-            // The buffer holds elements as they are embedded -- a pointer where the element type is
-            // boxed -- which is the stride every read and write of it uses.
-            let embedded_elem_ty = elem_ty.get_embedded_type(gc, &vec![]);
-            let elem_size = gc.target_data.get_abi_size(&embedded_elem_ty);
+            let elem_size = elem_stride(gc, &elem_ty);
             let struct_ty = self.to_struct_type(gc, vec![]);
             let buf_field_idx = struct_ty.count_fields() - 1;
             let header_size = gc
@@ -1587,6 +1584,29 @@ fn build_malloc<'c, 'm>(
         .left()
         .unwrap()
         .into_pointer_value()
+}
+
+/// The number of bytes one element of `elem_ty` occupies in an element buffer.
+///
+/// The buffer holds elements as they are embedded -- a pointer where the element type is boxed --
+/// which is the stride every read and write of it uses.
+fn elem_stride<'c, 'm>(gc: &mut Generator<'c, 'm>, elem_ty: &Arc<TypeNode>) -> u64 {
+    let embedded_elem_ty = elem_ty.get_embedded_type(gc, &vec![]);
+    gc.target_data.get_abi_size(&embedded_elem_ty)
+}
+
+/// The number of bytes `count` elements of `elem_ty` occupy in an element buffer, as a value of
+/// `count`'s type named `name`.
+pub fn build_elems_bytes<'c, 'm>(
+    gc: &mut Generator<'c, 'm>,
+    elem_ty: &Arc<TypeNode>,
+    count: IntValue<'c>,
+    name: &str,
+) -> IntValue<'c> {
+    let stride = elem_stride(gc, elem_ty);
+    gc.builder()
+        .build_int_mul(count.get_type().const_int(stride, false), count, name)
+        .unwrap()
 }
 
 /// Where an `#ArrayStorage` object is placed in a block starting at `base`, as a distance from that


### PR DESCRIPTION
`realloc_array` and `append` each built the bytes of k elements as a `getelementptr` on a null pointer followed by `ptrtoint`, while `ObjectType::size_of` multiplies by the stride the target data layout reports. All three now go through `build_elems_bytes`, and the stride itself through `elem_stride`, so one answer serves every site that asks how many bytes some number of elements takes.

The two `builtin.rs` sites lose ten lines of gep-and-ptrtoint boilerplate each.

## Evidence that the emitted code is unchanged

`examples/` built with the compiler at the fork point and with this one, LLVM's value numbering normalized away, at `-O none` and `-O max`:

- **`-O max`, optimized: 17 of 17 programs match instruction for instruction.** The only difference is the name of two SSA values (`%"elems_size_as_ptr@realloc_array.idx.i"` becomes `%"elems_size@realloc_array.i"`), because LLVM canonicalizes the gep-and-ptrtoint pair into the same `shl` the multiply becomes.
- **`-O none`: six lines per program**, which is the two sites turning two instructions into one.

The comparison was checked against a case it must report before its silence was believed: the same programs at `-O none` against `-O max` differ by 7742 lines.

The array tests pass locally; the rest is left to CI.
