### PR TITLE
Check an array's capacity where the program chooses one

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -2270,14 +2270,15 @@ pub fn array_append_value_capacity_unchecked() -> (Arc<ExprNode>, Arc<Scheme>) {
     (expr, scm)
 }
 
-// Resize a uniquely owned array's storage to hold `new_cap` elements, then update its capacity
-// field. The elements move as raw bytes, with their reference counts left alone: the caller must
-// ensure the array is unique.
-//
-// The whole block goes to `realloc`, base and all, so that it can resize in place -- for a block
-// large enough to have its own pages, by remapping them, which costs nothing per element. What comes
-// back starts wherever the allocator put it, so the object is placed in it afresh, and the contents
-// move only in the case where that lands the object somewhere other than `realloc` left it.
+/// Resize a uniquely owned array's storage to hold `new_cap` elements, then update its capacity
+/// field. The elements move as raw bytes, with their reference counts left alone: the caller must
+/// ensure the array is unique.
+///
+/// The whole block goes to `realloc`, base and all, so that it can resize in place -- for a block
+/// large enough to have its own pages, by remapping them, which costs nothing per element. What
+/// comes back starts wherever the allocator put it, so the object is placed in it afresh, and the
+/// contents move only in the case where that lands the object somewhere other than `realloc` left
+/// it.
 fn realloc_array<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     array: Object<'c>,

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -35,7 +35,7 @@ use crate::generator::{Generator, Object};
 use crate::misc::{make_map, Map, Set};
 use crate::object::{
     alloc_array_storage, build_array_storage_shift, build_elems_bytes, build_storage_is_aligned,
-    create_obj, get_array_storage, get_array_storage_buf, panic_if_capacity_exceeds_address_space,
+    create_obj, get_array_storage, get_array_storage_buf, build_capacity_check,
     read_alloc_offset, write_alloc_offset, CapacityCheck, ObjectFieldType,
 };
 use crate::optimization::rename::generate_new_names;
@@ -2290,7 +2290,7 @@ fn realloc_array<'c, 'm>(
     let storage_ptr = storage.value(gc).into_pointer_value();
     let object_type = storage.ty.get_object_type(&vec![], gc.type_env());
     let struct_type = object_type.to_struct_type(gc, vec![]);
-    panic_if_capacity_exceeds_address_space(gc, &elem_ty, new_cap, capacity_check);
+    build_capacity_check(gc, &elem_ty, new_cap, capacity_check);
     let sizeof = object_type.size_of(gc, Some(new_cap));
 
     let old_alloc_offset = read_alloc_offset(gc, storage_ptr);
@@ -2467,7 +2467,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         let elem_ty = array.ty.field_types(gc.type_env())[0].clone();
         let storage = get_array_storage(gc, &array);
         let storage_ptr = storage.value(gc).into_pointer_value();
-        panic_if_capacity_exceeds_address_space(gc, &elem_ty, new_cap, CapacityCheck::Run);
+        build_capacity_check(gc, &elem_ty, new_cap, CapacityCheck::Run);
         let (unique_bb, shared_bb) =
             gc.build_branch_by_is_unique(storage_ptr, assumed_state(self.assume_local));
         let current_func = unique_bb.get_parent().unwrap();

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -35,8 +35,8 @@ use crate::generator::{Generator, Object};
 use crate::misc::{make_map, Map, Set};
 use crate::object::{
     alloc_array_storage, build_array_storage_shift, build_elems_bytes, build_storage_is_aligned,
-    create_obj, get_array_storage, get_array_storage_buf, read_alloc_offset, write_alloc_offset,
-    ObjectFieldType,
+    create_obj, get_array_storage, get_array_storage_buf, panic_if_capacity_exceeds_address_space,
+    read_alloc_offset, write_alloc_offset, CapacityCheck, ObjectFieldType,
 };
 use crate::optimization::rename::generate_new_names;
 use crate::parse::sourcefile::Span;
@@ -856,7 +856,7 @@ pub fn make_byte_array_copy<'c, 'm>(
 ) -> Object<'c> {
     // Create `Array U8` which contains null-terminated string.
     let array_ty = type_tyapp(make_array_ty(), make_u8_ty());
-    let storage = alloc_array_storage(gc, make_u8_ty(), len);
+    let storage = alloc_array_storage(gc, make_u8_ty(), len, CapacityCheck::Run);
     let array = create_obj(
         array_ty,
         &vec![],
@@ -1754,7 +1754,7 @@ impl LLVMGen for InlineLLVMArrayUnsafeEmpty {
         // Allocate the storage with room for `cap` elements, then build the array value
         // `{ storage, size = 0, cap }`.
         let elem_ty = arr_ty.field_types(gc.type_env())[0].clone();
-        let storage = alloc_array_storage(gc, elem_ty, cap);
+        let storage = alloc_array_storage(gc, elem_ty, cap, CapacityCheck::Run);
         let array = create_obj(
             arr_ty.clone(),
             &vec![],
@@ -2279,6 +2279,7 @@ fn realloc_array<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     array: Object<'c>,
     new_cap: IntValue<'c>,
+    capacity_check: CapacityCheck,
 ) -> Object<'c> {
     let i64_ty = gc.context.i64_type();
     let elem_ty = array.ty.field_types(gc.type_env())[0].clone();
@@ -2286,6 +2287,7 @@ fn realloc_array<'c, 'm>(
     let storage_ptr = storage.value(gc).into_pointer_value();
     let object_type = storage.ty.get_object_type(&vec![], gc.type_env());
     let struct_type = object_type.to_struct_type(gc, vec![]);
+    panic_if_capacity_exceeds_address_space(gc, &elem_ty, new_cap, capacity_check);
     let sizeof = object_type.size_of(gc, Some(new_cap));
 
     let old_alloc_offset = read_alloc_offset(gc, storage_ptr);
@@ -2454,7 +2456,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         let new_cap = gc.get_scoped_obj_field(&self.cap_name, 0).into_int_value();
 
         if !self.force_unique {
-            return realloc_array(gc, array, new_cap);
+            return realloc_array(gc, array, new_cap, CapacityCheck::Run);
         }
 
         // Branch on whether the storage is unique. `build_branch_by_is_unique` routes a GLOBAL
@@ -2462,6 +2464,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         let elem_ty = array.ty.field_types(gc.type_env())[0].clone();
         let storage = get_array_storage(gc, &array);
         let storage_ptr = storage.value(gc).into_pointer_value();
+        panic_if_capacity_exceeds_address_space(gc, &elem_ty, new_cap, CapacityCheck::Run);
         let (unique_bb, shared_bb) =
             gc.build_branch_by_is_unique(storage_ptr, assumed_state(self.assume_local));
         let current_func = unique_bb.get_parent().unwrap();
@@ -2471,7 +2474,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
 
         // Unique: resize the storage in place with `realloc`.
         gc.builder().position_at_end(unique_bb);
-        let realloced = realloc_array(gc, array.clone(), new_cap);
+        let realloced = realloc_array(gc, array.clone(), new_cap, CapacityCheck::Skip);
         let succ_of_unique_bb = gc.builder().get_insert_block().unwrap();
         gc.builder().build_unconditional_branch(end_bb).unwrap();
 
@@ -2479,7 +2482,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         // reference to the old shared storage.
         gc.builder().position_at_end(shared_bb);
         let len = array.extract_field(gc, ARRAY_SIZE_IDX).into_int_value();
-        let new_storage = alloc_array_storage(gc, elem_ty.clone(), new_cap);
+        let new_storage = alloc_array_storage(gc, elem_ty.clone(), new_cap, CapacityCheck::Skip);
         let dst_buf = new_storage.gep_boxed(gc, STORAGE_BUF_IDX);
         let src_buf = storage.gep_boxed(gc, STORAGE_BUF_IDX);
         ObjectFieldType::clone_array_buf(
@@ -3053,7 +3056,7 @@ fn make_array_unique_with_hole<'c, 'm>(
     gc.builder().position_at_end(shared_bb);
     let size = array.extract_field(gc, ARRAY_SIZE_IDX).into_int_value();
     let cap = array.extract_field(gc, ARRAY_CAP_IDX).into_int_value();
-    let new_storage = alloc_array_storage(gc, elem_ty.clone(), cap);
+    let new_storage = alloc_array_storage(gc, elem_ty.clone(), cap, CapacityCheck::Skip);
     let src_buf = storage.gep_boxed(gc, STORAGE_BUF_IDX);
     let dst_buf = new_storage.gep_boxed(gc, STORAGE_BUF_IDX);
     ObjectFieldType::clone_array_buf(gc, size, src_buf, dst_buf, elem_ty, hole, state);
@@ -4299,7 +4302,7 @@ impl LLVMGen for InlineLLVMArrayLitBody {
             .i64_type()
             .const_int(self.elem_names.len() as u64, false);
         let elem_ty = ty.field_types(gc.type_env())[0].clone();
-        let storage = alloc_array_storage(gc, elem_ty, len);
+        let storage = alloc_array_storage(gc, elem_ty, len, CapacityCheck::Run);
         let array = create_obj(ty.clone(), &vec![], None, gc, Some("array_literal"));
         let storage_val = storage.value(gc);
         let array = array.insert_field(gc, ARRAY_STORAGE_IDX, storage_val);

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -848,7 +848,7 @@ pub fn expr_bool_lit(val: bool, source: Option<Span>) -> Arc<ExprNode> {
     expr_app(expr_var(ctor, source.clone()), vec![unit], source)
 }
 
-// Create a byte array by copying from given pointer.
+/// An `Array U8` of `len` bytes, holding a copy of the `len` bytes at `buf`.
 pub fn make_byte_array_copy<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     buf: PointerValue<'c>,
@@ -885,8 +885,11 @@ pub fn make_byte_array_copy<'c, 'm>(
     array
 }
 
+/// Evaluates a string literal to the `Array U8` backing a `String`: the literal's bytes plus the
+/// null terminator, copied out of a global into a fresh array.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStringBuf {
+    /// The literal's bytes, without the null terminator.
     string: String,
 }
 
@@ -1741,8 +1744,12 @@ pub fn bit_not_function(ty: Arc<TypeNode>) -> (Arc<ExprNode>, Arc<Scheme>) {
     (expr, scm)
 }
 
+/// Evaluates `Array::_unsafe_empty_capacity_unchecked`: an array of size 0 whose storage has room
+/// for the given capacity, its elements left uninitialized.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMArrayUnsafeEmpty {
+    /// The local binding holding the capacity, in elements. The caller of the primitive is what
+    /// establishes it is non-negative.
     capacity_name: FullName,
 }
 
@@ -2444,9 +2451,9 @@ pub struct InlineLLVMArraySetCapacityBoundsUnchecked {
     arr_name: FullName,
     /// The local binding holding the new capacity, in elements.
     cap_name: FullName,
-    // When true, branch on uniqueness: `realloc` a unique array in place, or allocate a new one and
-    // retain-copy a shared array's elements. Set false only where the array is statically known to
-    // be unique, leaving just the `realloc`.
+    /// When true, branch on uniqueness: `realloc` a unique array in place, or allocate a new one and
+    /// retain-copy a shared array's elements. Set false only where the array is statically known to
+    /// be unique, leaving just the `realloc`.
     pub(crate) force_unique: bool,
     /// Whether the object this op's declared uniqueness check tests is known to be in the local
     /// reference-counting state, so that the check reads the count without reading the state.
@@ -4290,11 +4297,12 @@ impl LLVMGen for InlineLLVMMakeStructBody {
     }
 }
 
-// Allocate an array whose length equals the number of operands and fill it with them. The array
-// type is the value type of the enclosing expression. This is the RC IR counterpart of the
-// `Expr::ArrayLit` AST node, reading its operands as pre-evaluated atoms.
+/// Allocate an array whose length equals the number of operands and fill it with them. The array
+/// type is the value type of the enclosing expression. This is the RC IR counterpart of the
+/// `Expr::ArrayLit` AST node, reading its operands as pre-evaluated atoms.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMArrayLitBody {
+    /// The local bindings holding the elements, in the order they are written into the array.
     pub elem_names: Vec<FullName>,
 }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -869,15 +869,18 @@ pub fn make_byte_array_copy<'c, 'm>(
     let array = array.insert_field(gc, ARRAY_SIZE_IDX, len);
     let array = array.insert_field(gc, ARRAY_CAP_IDX, len);
     let dst = get_array_storage_buf(gc, &array);
-    let len = gc
+    let len_ptr_int = gc
         .builder()
         .build_int_cast(
             len,
             gc.context.ptr_sized_int_type(&gc.target_data, None),
-            "len_ptr@make_byte_array_copy",
+            "len_ptr_int@make_byte_array_copy",
         )
         .unwrap();
-    gc.builder().build_memcpy(dst, 1, buf, 1, len).ok().unwrap();
+    gc.builder()
+        .build_memcpy(dst, 1, buf, 1, len_ptr_int)
+        .ok()
+        .unwrap();
 
     array
 }
@@ -4308,19 +4311,11 @@ impl LLVMGen for InlineLLVMArrayLitBody {
         let array = array.insert_field(gc, ARRAY_STORAGE_IDX, storage_val);
         let array = array.insert_field(gc, ARRAY_SIZE_IDX, len);
         let array = array.insert_field(gc, ARRAY_CAP_IDX, len);
-        let buffer = get_array_storage_buf(gc, &array);
+        let buf = get_array_storage_buf(gc, &array);
         for (i, name) in self.elem_names.iter().enumerate() {
             let value = gc.get_scoped_obj_noretain(name);
             let idx = gc.context.i64_type().const_int(i as u64, false);
-            ObjectFieldType::write_to_array_buf(
-                gc,
-                None,
-                buffer,
-                idx,
-                value,
-                false,
-                RcState::Unknown,
-            );
+            ObjectFieldType::write_to_array_buf(gc, None, buf, idx, value, false, RcState::Unknown);
         }
         array
     }

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -34,8 +34,8 @@ use crate::fixstd::runtime::{RUNTIME_ABORT, RUNTIME_EPRINTLN, RUNTIME_REALLOC};
 use crate::generator::{Generator, Object};
 use crate::misc::{make_map, Map, Set};
 use crate::object::{
-    alloc_array_storage, build_array_storage_shift, build_elems_bytes, build_storage_is_aligned,
-    create_obj, get_array_storage, get_array_storage_buf, build_capacity_check,
+    alloc_array_storage, build_array_storage_shift, build_capacity_check, build_elems_bytes,
+    build_storage_is_aligned, create_obj, get_array_storage, get_array_storage_buf,
     read_alloc_offset, write_alloc_offset, CapacityCheck, ObjectFieldType,
 };
 use crate::optimization::rename::generate_new_names;

--- a/src/object.rs
+++ b/src/object.rs
@@ -1239,8 +1239,8 @@ impl ObjectType {
         unboxed_path: Vec<String>,
     ) -> BasicTypeEnum<'c> {
         if self.is_unbox {
-            let str_ty = self.to_struct_type(gc, unboxed_path);
-            str_ty.into()
+            let struct_ty = self.to_struct_type(gc, unboxed_path);
+            struct_ty.into()
         } else {
             gc.context.ptr_type(AddressSpace::from(0)).into()
         }
@@ -1314,14 +1314,14 @@ pub fn control_block_type<'c, 'm>(gc: &Generator<'c, 'm>) -> StructType<'c> {
 /// The debug info type describing the control block that heads every boxed object. It presents the
 /// reference counter alone, the one field a debugger session has use for.
 pub fn control_block_di_type<'c, 'm>(gc: &mut Generator<'c, 'm>) -> DIType<'c> {
-    let str_type = control_block_type(gc);
+    let struct_type = control_block_type(gc);
 
     let refcnt_ty = refcnt_type(gc.context);
     let refcnt_size_in_bits = gc.target_data.get_bit_size(&refcnt_ty);
     let refcnt_align_in_bits = gc.target_data.get_abi_alignment(&refcnt_ty) * 8;
     let refcnt_offset_in_bits = gc
         .target_data
-        .offset_of_element(&str_type, CTRL_BLK_REFCNT_IDX)
+        .offset_of_element(&struct_type, CTRL_BLK_REFCNT_IDX)
         .unwrap()
         * 8;
     let refcnt_member = gc
@@ -1341,8 +1341,8 @@ pub fn control_block_di_type<'c, 'm>(gc: &mut Generator<'c, 'm>) -> DIType<'c> {
     let elements = vec![refcnt_member];
 
     let name = "<control block>";
-    let size_in_bits = gc.target_data.get_bit_size(&str_type);
-    let align_in_bits = gc.target_data.get_abi_alignment(&str_type) * 8;
+    let size_in_bits = gc.target_data.get_bit_size(&struct_type);
+    let align_in_bits = gc.target_data.get_abi_alignment(&struct_type) * 8;
     gc.get_di_builder()
         .create_struct_type(
             gc.get_di_compile_unit().as_debug_info_scope(),
@@ -2358,7 +2358,7 @@ pub fn ty_to_debug_embedded_ty<'c, 'm>(
     ty: Arc<TypeNode>,
     gc: &mut Generator<'c, 'm>,
 ) -> DIType<'c> {
-    let debug_str_ty = ty_to_debug_struct_ty(ty.clone(), gc);
+    let debug_struct_ty = ty_to_debug_struct_ty(ty.clone(), gc);
     if ty.is_box(&gc.type_env()) {
         let ptr_ty = gc.context.ptr_type(AddressSpace::from(0));
         let size_in_bits = gc.target_data.get_bit_size(&ptr_ty);
@@ -2366,14 +2366,14 @@ pub fn ty_to_debug_embedded_ty<'c, 'm>(
         gc.get_di_builder()
             .create_pointer_type(
                 "<pointer to boxed value>",
-                debug_str_ty,
+                debug_struct_ty,
                 size_in_bits,
                 align_in_bits,
                 AddressSpace::from(0),
             )
             .as_type()
     } else {
-        debug_str_ty
+        debug_struct_ty
     }
 }
 
@@ -2434,9 +2434,9 @@ fn ty_to_debug_struct_ty_body<'c, 'm>(ty: Arc<TypeNode>, gc: &mut Generator<'c, 
         }
     } else {
         // NOTE: Maybe we should use llvm's DataLayout::getStructLayout instead of get_abi_alignment, but it seems that the function isn't wrapped in llvm-sys.
-        let str_type = obj_type.to_struct_type(gc, vec![]);
-        let size_in_bits = gc.target_data.get_bit_size(&str_type);
-        let align_in_bits = gc.target_data.get_abi_alignment(&str_type) * 8;
+        let struct_type = obj_type.to_struct_type(gc, vec![]);
+        let size_in_bits = gc.target_data.get_bit_size(&struct_type);
+        let align_in_bits = gc.target_data.get_abi_alignment(&struct_type) * 8;
 
         let mut subelement_names = vec![];
         if !ty.is_closure() {
@@ -2496,7 +2496,7 @@ fn ty_to_debug_struct_ty_body<'c, 'm>(ty: Arc<TypeNode>, gc: &mut Generator<'c, 
             let align_in_bits = gc.target_data.get_abi_alignment(&elemet_ty) * 8;
             let offset_in_bits = gc
                 .target_data
-                .offset_of_element(&str_type, i as u32)
+                .offset_of_element(&struct_type, i as u32)
                 .unwrap()
                 * 8;
             let mem_ty = gc

--- a/src/object.rs
+++ b/src/object.rs
@@ -1103,6 +1103,15 @@ impl ObjectFieldType {
     }
 }
 
+/// How an object that ends in an element buffer is laid out around that buffer.
+struct ElementBufferLayout {
+    /// The bytes of the fields laid out ahead of the buffer.
+    header_size: u64,
+    /// The bytes one element takes in the buffer, which is the stride every read and write of it
+    /// uses.
+    elem_size: u64,
+}
+
 #[derive(Eq, PartialEq, Clone)]
 pub struct ObjectType {
     pub field_types: Vec<ObjectFieldType>,
@@ -1153,8 +1162,32 @@ impl ObjectType {
         gc.context.struct_type(&fields, false)
     }
 
+    /// The bytes laid out ahead of the element buffer, and the bytes one element takes in it, for an
+    /// object type that ends in such a buffer (`Array`, `#ArrayStorage`).
+    fn element_buffer_layout<'c, 'm>(&self, gc: &mut Generator<'c, 'm>) -> ElementBufferLayout {
+        // The element buffer is the last field, of `Array` (with a preceding capacity slot) or of
+        // `#ArrayStorage` (right after the control block).
+        let elem_ty = match self.field_types.last().unwrap() {
+            ObjectFieldType::Array(ty) => ty.clone(),
+            ObjectFieldType::ArrayStorageBuf(ty) => ty.clone(),
+            _ => panic!("this object type does not end in an element buffer"),
+        };
+        let struct_ty = self.to_struct_type(gc, vec![]);
+        let buf_field_idx = struct_ty.count_fields() - 1;
+        ElementBufferLayout {
+            header_size: gc
+                .target_data
+                .offset_of_element(&struct_ty, buf_field_idx)
+                .unwrap(),
+            elem_size: elem_stride(gc, &elem_ty),
+        }
+    }
+
     /// The size of this object in bytes: a constant, except for an object that ends in an element
     /// buffer, whose size takes a capacity the program computes at run time.
+    ///
+    /// The capacity is taken as one whose byte count fits in the address space;
+    /// `panic_if_capacity_exceeds_address_space` is what establishes that.
     ///
     /// # Arguments
     /// * `array_capacity` - the number of elements the trailing element buffer is to hold, for an
@@ -1168,38 +1201,24 @@ impl ObjectType {
         if let Some(array_capacity) = array_capacity {
             // The size is the header -- the fields laid out ahead of the element buffer -- plus the
             // bytes the elements take.
-
-            // The element buffer is the last field, of `Array` (with a preceding capacity slot) or
-            // of `#ArrayStorage` (right after the control block).
-            let elem_ty = match self.field_types.last().unwrap() {
-                ObjectFieldType::Array(ty) => ty.clone(),
-                ObjectFieldType::ArrayStorageBuf(ty) => ty.clone(),
-                _ => panic!(),
-            };
-            let elem_size = elem_stride(gc, &elem_ty);
-            let struct_ty = self.to_struct_type(gc, vec![]);
-            let buf_field_idx = struct_ty.count_fields() - 1;
-            let header_size = gc
-                .target_data
-                .offset_of_element(&struct_ty, buf_field_idx)
-                .unwrap();
-
+            let layout = self.element_buffer_layout(gc);
             let ptr_int_ty = gc.context.ptr_sized_int_type(&gc.target_data, None);
             let cap = gc
                 .builder()
                 .build_int_cast(array_capacity, ptr_int_ty, "cap_as_ptr_int_ty")
                 .unwrap();
-            if gc.config.runtime_check() {
-                panic_if_byte_count_exceeds_address_space(gc, cap, elem_size, header_size);
-            }
             let elems_size = gc
                 .builder()
-                .build_int_mul(ptr_int_ty.const_int(elem_size, false), cap, "elems_size")
+                .build_int_mul(
+                    ptr_int_ty.const_int(layout.elem_size, false),
+                    cap,
+                    "elems_size",
+                )
                 .unwrap();
             return gc
                 .builder()
                 .build_int_add(
-                    ptr_int_ty.const_int(header_size, false),
+                    ptr_int_ty.const_int(layout.header_size, false),
                     elems_size,
                     "size_with_elems",
                 )
@@ -1588,13 +1607,30 @@ pub fn get_array_storage_buf<'c, 'm>(
     get_array_storage(gc, array).gep_boxed(gc, STORAGE_BUF_IDX)
 }
 
+/// Whether an allocation checks the capacity it is given against the address space.
+///
+/// Every allocation asks for one, so that a new allocation site states which of the two it is
+/// instead of inheriting an answer: the check is what keeps a wrapped-around byte count from
+/// reaching `malloc`, and a site that skipped it silently would corrupt the heap.
+#[derive(Clone, Copy)]
+pub enum CapacityCheck {
+    /// Nothing has checked this capacity, so this allocation checks it.
+    Run,
+    /// The capacity is already within the bound -- read off an array that holds it, or checked by
+    /// the caller ahead of a branch whose arms both allocate -- so checking it here would only add
+    /// a branch to the emitted code.
+    Skip,
+}
+
 // Allocate a fresh `#ArrayStorage` object for element type `elem_ty` with room for `cap` elements,
 // its control block initialized to a reference count of one and its buffer left uninitialized.
 pub fn alloc_array_storage<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     elem_ty: Arc<TypeNode>,
     cap: IntValue<'c>,
+    capacity_check: CapacityCheck,
 ) -> Object<'c> {
+    panic_if_capacity_exceeds_address_space(gc, &elem_ty, cap, capacity_check);
     let storage_ty = make_array_storage_ty(elem_ty);
     create_obj(storage_ty, &vec![], Some(cap), gc, Some("array_storage"))
 }
@@ -1712,8 +1748,8 @@ pub fn build_storage_is_aligned<'c, 'm>(
         .unwrap()
 }
 
-/// Abort the program unless a buffer of `cap` elements of `elem_size` bytes each, laid out behind a
-/// header of `header_size` bytes, fits in the address space.
+/// Abort the program unless an `#ArrayStorage` holding `cap` elements of `elem_ty` fits in the
+/// address space.
 ///
 /// Left unchecked, a capacity whose byte count wraps around asks `malloc` for a small block, gets
 /// one, and leaves an object claiming a capacity its block has no room for; the first write past the
@@ -1724,20 +1760,32 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// is one unsigned comparison. A byte count within the bound that the system cannot supply is a
 /// separate matter, left where it was: `malloc` answers null and the program faults on the store
 /// that initializes the object.
-fn panic_if_byte_count_exceeds_address_space<'c, 'm>(
-    gc: &Generator<'c, 'm>,
+///
+/// Every allocation given a capacity nothing has checked runs this, which is what makes it an
+/// invariant that an array's capacity field is within the bound. `capacity_check` says whether this
+/// allocation is one of those; `CapacityCheck::Skip` is for the capacities that invariant already
+/// covers.
+pub fn panic_if_capacity_exceeds_address_space<'c, 'm>(
+    gc: &mut Generator<'c, 'm>,
+    elem_ty: &Arc<TypeNode>,
     cap: IntValue<'c>,
-    elem_size: u64,
-    header_size: u64,
+    capacity_check: CapacityCheck,
 ) {
+    if matches!(capacity_check, CapacityCheck::Skip) || !gc.config.runtime_check() {
+        return;
+    }
+    let storage_ty = make_array_storage_ty(elem_ty.clone());
+    let layout = storage_ty
+        .get_object_type(&vec![], gc.type_env())
+        .element_buffer_layout(gc);
     // A buffer of elements of no size is no bytes long, however many of them the capacity asks for.
-    if elem_size == 0 {
+    if layout.elem_size == 0 {
         return;
     }
     // The bound below is the widest byte count of a 64-bit address space, so it bounds a capacity
     // of that width.
     assert_eq!(cap.get_type().get_bit_width(), 64);
-    let max_cap = (u64::MAX - ARRAY_STORAGE_ALLOC_SLACK - header_size) / elem_size;
+    let max_cap = (u64::MAX - ARRAY_STORAGE_ALLOC_SLACK - layout.header_size) / layout.elem_size;
     let is_capacity_overflow = gc
         .builder()
         .build_int_compare(

--- a/src/object.rs
+++ b/src/object.rs
@@ -1112,16 +1112,27 @@ struct ElementBufferLayout {
     elem_stride: u64,
 }
 
+/// The layout the code generator gives a Fix type: the fields it is made of, and whether a value of
+/// it is held in place or behind a pointer.
 #[derive(Eq, PartialEq, Clone)]
 pub struct ObjectType {
+    /// The fields in the order they are laid out. A boxed type leads with its `ControlBlock`.
     pub field_types: Vec<ObjectFieldType>,
+    /// Whether a value of this type is held in place. A boxed value is a pointer to a heap block
+    /// whose contents this layout describes.
     pub is_unbox: bool,
+    /// The normalized name of the Fix type this is the layout of, which `to_struct_type` compares
+    /// against `unboxed_path` to find a cycle of unboxed types.
     pub name: Name,
 }
 
 impl ObjectType {
-    // Convert ObjectType to inkwell's StructType.
-    // * `unboxed_path` - When unboxed types are used recursively in each definition, this function can fall into infinite recursion. `unboxed_path` is an argument to detect this infinite loop and to generate a good error message. When you call to_struct_type from outside, specify an empty Vec. When to_struct_type calls itself (possibly via another function), unboxed_path contains the sequence of unboxed types that to_struct_type has been called on so far.
+    /// The LLVM struct type this object is laid out as.
+    ///
+    /// # Arguments
+    /// * `unboxed_path` - the unboxed types this call is already nested inside, which is what turns
+    ///   a circular definition by unboxed types into a diagnostic instead of an infinite recursion.
+    ///   A call from outside passes an empty `Vec`.
     pub fn to_struct_type<'c, 'm>(
         &self,
         gc: &mut Generator<'c, 'm>,
@@ -1247,10 +1258,14 @@ impl ObjectType {
     }
 }
 
+/// The integer type of the control block field holding an object's reference count. Its width is
+/// what bounds the number of references to one object a program can hold.
 pub fn refcnt_type<'ctx>(context: &'ctx Context) -> IntType<'ctx> {
     context.i32_type()
 }
 
+/// The debug info type of an object's reference count, which presents it to a debugger session as an
+/// unsigned integer.
 pub fn refcnt_di_type<'ctx>(builder: &DebugInfoBuilder<'ctx>) -> DIType<'ctx> {
     builder
         .create_basic_type("<refcnt>", 32, DW_ATE_UNSIGNED, 0)
@@ -1258,8 +1273,8 @@ pub fn refcnt_di_type<'ctx>(builder: &DebugInfoBuilder<'ctx>) -> DIType<'ctx> {
         .as_type()
 }
 
-// State for reference counting.
-// Values of this fields are REFCNT_STATE_* constants.
+/// The integer type of the control block field holding which reference-counting scheme an object is
+/// under. Its values are the `REFCNT_STATE_*` constants.
 pub fn refcnt_state_type<'c>(context: &'c Context) -> IntType<'c> {
     context.i8_type()
 }
@@ -1272,8 +1287,11 @@ pub fn alloc_offset_type<'c>(context: &'c Context) -> IntType<'c> {
     context.i8_type()
 }
 
-// Type of traverser function.
-// - is_dynamic: If true, the traverser is dynamic and takes the work type as the second argument.
+/// The function type of a traverser, which walks an object's reference-counted leaves.
+///
+/// # Arguments
+/// * `is_dynamic` - whether the traverser takes the work to do as a second argument, of
+///   `traverser_work_type`, instead of having it fixed at the point the traverser is generated.
 pub fn traverser_type<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     ty: &Arc<TypeNode>,
@@ -1296,10 +1314,15 @@ pub fn traverser_type<'c, 'm>(
     gc.context.void_type().fn_type(&arg_tys, false)
 }
 
+/// The integer type of the work argument a dynamic traverser takes, whose values are the
+/// `TRAVERSER_WORK_*` constants.
 pub fn traverser_work_type<'c>(context: &'c Context) -> IntType<'c> {
     context.i8_type()
 }
 
+/// The LLVM struct type of the control block that heads every boxed object, holding the reference
+/// count, the reference-counting state, and the distance the object sits above the base of its
+/// allocation.
 pub fn control_block_type<'c, 'm>(gc: &Generator<'c, 'm>) -> StructType<'c> {
     let mut fields = vec![];
     assert_eq!(fields.len(), CTRL_BLK_REFCNT_IDX as usize);
@@ -1590,8 +1613,8 @@ pub fn ty_to_object_ty(
     ret
 }
 
-// The `#ArrayStorage` object a flipped `Array` value points to, wrapped as an `Object` of its real
-// type so the reference-count helpers and buffer GEPs operate on it directly.
+/// The `#ArrayStorage` object a flipped `Array` value points to, wrapped as an `Object` of its real
+/// type so the reference-count helpers and buffer GEPs operate on it directly.
 pub fn get_array_storage<'c, 'm>(gc: &mut Generator<'c, 'm>, array: &Object<'c>) -> Object<'c> {
     let elem_ty = array.ty.field_types(gc.type_env())[0].clone();
     let storage_ty = make_array_storage_ty(elem_ty);
@@ -1599,7 +1622,7 @@ pub fn get_array_storage<'c, 'm>(gc: &mut Generator<'c, 'm>, array: &Object<'c>)
     Object::new(storage_ptr, storage_ty, gc)
 }
 
-// A pointer to the first element of a flipped `Array`'s element buffer.
+/// A pointer to the first element of a flipped `Array`'s element buffer.
 pub fn get_array_storage_buf<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     array: &Object<'c>,
@@ -1845,9 +1868,9 @@ fn build_abort_if<'c, 'm>(
 /// an allocator is free to hand out any alignment the requested size can hold, and mimalloc, for
 /// one, aligns an 8-byte allocation -- the size of an empty array's storage -- to 8 bytes.
 ///
-/// The threshold is applied as a mask rather than a branch. An array allocation is a handful of
-/// instructions that many callers inline, and the basic blocks a branch here adds to every one of
-/// them cost more in inlining decisions downstream than the arithmetic they save.
+/// The threshold is applied by masking, so the allocation stays a single basic block: an array
+/// allocation is a handful of instructions that many callers inline, and extra blocks in every one
+/// of them cost more in inlining decisions downstream than the arithmetic the mask spends.
 fn build_alloc_array_storage<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     struct_type: StructType<'c>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -1609,9 +1609,9 @@ pub fn get_array_storage_buf<'c, 'm>(
 
 /// Whether an allocation checks the capacity it is given against the address space.
 ///
-/// Every allocation asks for one, so that a new allocation site states which of the two it is
-/// instead of inheriting an answer: the check is what keeps a wrapped-around byte count from
-/// reaching `malloc`, and a site that skipped it silently would corrupt the heap.
+/// Every allocation asks for one, so each allocation site states which of the two it is: the check
+/// is what keeps a wrapped-around byte count from reaching `malloc`, and a site that skipped it
+/// silently would corrupt the heap.
 #[derive(Clone, Copy)]
 pub enum CapacityCheck {
     /// Nothing has checked this capacity, so this allocation checks it.
@@ -1622,8 +1622,8 @@ pub enum CapacityCheck {
     Skip,
 }
 
-// Allocate a fresh `#ArrayStorage` object for element type `elem_ty` with room for `cap` elements,
-// its control block initialized to a reference count of one and its buffer left uninitialized.
+/// Allocate a fresh `#ArrayStorage` object for element type `elem_ty` with room for `cap` elements,
+/// its control block initialized to a reference count of one and its buffer left uninitialized.
 pub fn alloc_array_storage<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     elem_ty: Arc<TypeNode>,
@@ -1758,8 +1758,8 @@ pub fn build_storage_is_aligned<'c, 'm>(
 ///
 /// The bound is the widest capacity whose byte count cannot wrap, and a constant, so the whole check
 /// is one unsigned comparison. A byte count within the bound that the system cannot supply is a
-/// separate matter, left where it was: `malloc` answers null and the program faults on the store
-/// that initializes the object.
+/// separate matter: `malloc` answers null and the program faults on the store that initializes the
+/// object.
 ///
 /// Every allocation given a capacity nothing has checked runs this, which is what makes it an
 /// invariant that an array's capacity field is within the bound. `capacity_check` says whether this

--- a/src/object.rs
+++ b/src/object.rs
@@ -1109,7 +1109,7 @@ struct ElementBufferLayout {
     header_size: u64,
     /// The bytes one element takes in the buffer, which is the stride every read and write of it
     /// uses.
-    elem_size: u64,
+    elem_stride: u64,
 }
 
 #[derive(Eq, PartialEq, Clone)]
@@ -1179,7 +1179,7 @@ impl ObjectType {
                 .target_data
                 .offset_of_element(&struct_ty, buf_field_idx)
                 .unwrap(),
-            elem_size: elem_stride(gc, &elem_ty),
+            elem_stride: elem_stride(gc, &elem_ty),
         }
     }
 
@@ -1187,7 +1187,7 @@ impl ObjectType {
     /// buffer, whose size takes a capacity the program computes at run time.
     ///
     /// The capacity is taken as one whose byte count fits in the address space;
-    /// `panic_if_capacity_exceeds_address_space` is what establishes that.
+    /// `build_capacity_check` is what establishes that.
     ///
     /// # Arguments
     /// * `array_capacity` - the number of elements the trailing element buffer is to hold, for an
@@ -1210,7 +1210,7 @@ impl ObjectType {
             let elems_size = gc
                 .builder()
                 .build_int_mul(
-                    ptr_int_ty.const_int(layout.elem_size, false),
+                    ptr_int_ty.const_int(layout.elem_stride, false),
                     cap,
                     "elems_size",
                 )
@@ -1630,7 +1630,7 @@ pub fn alloc_array_storage<'c, 'm>(
     cap: IntValue<'c>,
     capacity_check: CapacityCheck,
 ) -> Object<'c> {
-    panic_if_capacity_exceeds_address_space(gc, &elem_ty, cap, capacity_check);
+    build_capacity_check(gc, &elem_ty, cap, capacity_check);
     let storage_ty = make_array_storage_ty(elem_ty);
     create_obj(storage_ty, &vec![], Some(cap), gc, Some("array_storage"))
 }
@@ -1748,8 +1748,8 @@ pub fn build_storage_is_aligned<'c, 'm>(
         .unwrap()
 }
 
-/// Abort the program unless an `#ArrayStorage` holding `cap` elements of `elem_ty` fits in the
-/// address space.
+/// Emit the check `capacity_check` asks for: the program aborts unless an `#ArrayStorage` holding
+/// `cap` elements of `elem_ty` fits in the address space.
 ///
 /// Left unchecked, a capacity whose byte count wraps around asks `malloc` for a small block, gets
 /// one, and leaves an object claiming a capacity its block has no room for; the first write past the
@@ -1765,7 +1765,7 @@ pub fn build_storage_is_aligned<'c, 'm>(
 /// invariant that an array's capacity field is within the bound. `capacity_check` says whether this
 /// allocation is one of those; `CapacityCheck::Skip` is for the capacities that invariant already
 /// covers.
-pub fn panic_if_capacity_exceeds_address_space<'c, 'm>(
+pub fn build_capacity_check<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     elem_ty: &Arc<TypeNode>,
     cap: IntValue<'c>,
@@ -1779,13 +1779,13 @@ pub fn panic_if_capacity_exceeds_address_space<'c, 'm>(
         .get_object_type(&vec![], gc.type_env())
         .element_buffer_layout(gc);
     // A buffer of elements of no size is no bytes long, however many of them the capacity asks for.
-    if layout.elem_size == 0 {
+    if layout.elem_stride == 0 {
         return;
     }
     // The bound below is the widest byte count of a 64-bit address space, so it bounds a capacity
     // of that width.
     assert_eq!(cap.get_type().get_bit_width(), 64);
-    let max_cap = (u64::MAX - ARRAY_STORAGE_ALLOC_SLACK - layout.header_size) / layout.elem_size;
+    let max_cap = (u64::MAX - ARRAY_STORAGE_ALLOC_SLACK - layout.header_size) / layout.elem_stride;
     let is_capacity_overflow = gc
         .builder()
         .build_int_compare(

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -8,6 +8,21 @@ use crate::{
 };
 use tempfile::TempDir;
 
+/// A configuration whose runtime checks are on, which is what makes the checks under test part of
+/// the emitted program.
+fn runtime_checked_config() -> Configuration {
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = false;
+    config
+}
+
+/// A configuration whose runtime checks are off, as `--no-runtime-check` leaves them.
+fn runtime_unchecked_config() -> Configuration {
+    let mut config = Configuration::develop_mode();
+    config.no_runtime_check = true;
+    config
+}
+
 #[test]
 pub fn test_get() {
     let source = r#"    
@@ -19,8 +34,7 @@ pub fn test_get() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Index out of range: index=3, size=3");
 }
 
@@ -35,8 +49,7 @@ pub fn test_set() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Index out of range");
 }
 
@@ -52,8 +65,7 @@ pub fn test_mod() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Index out of range");
 }
 
@@ -69,8 +81,7 @@ pub fn test_act() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Index out of range");
 }
 
@@ -86,8 +97,7 @@ pub fn test_index_syntax() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Index out of range");
 }
 
@@ -104,8 +114,7 @@ pub fn test_empty_negative_capacity() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Negative array size or capacity: -1");
 }
 
@@ -121,8 +130,7 @@ pub fn test_fill_negative_size() {
                 pure()
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(&source, config, "Negative array size or capacity");
 }
 
@@ -142,8 +150,7 @@ pub fn test_empty_capacity_byte_count_wraps() {
                 println(arr.push_back(42).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -164,8 +171,7 @@ pub fn test_empty_capacity_byte_count_leaves_no_room_for_the_header() {
                 println(arr.push_back(42).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -188,8 +194,7 @@ pub fn test_empty_capacity_byte_count_is_checked_at_run_time() {
                 println(arr.push_back(42).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -210,8 +215,7 @@ pub fn test_reserve_capacity_byte_count_wraps() {
                 println(arr.reserve(2305843009213693952).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -232,8 +236,7 @@ pub fn test_capacity_byte_count_wraps_for_a_wide_element() {
                 println(arr.push_back((1, 2, 3, 4)).@size.to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -254,8 +257,7 @@ pub fn test_capacity_of_a_zero_sized_element_is_allocatable() {
                 println(arr.@size.to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source(&source, config);
 }
 
@@ -273,8 +275,7 @@ pub fn test_unsafe_empty_capacity_unchecked_checks_the_byte_count() {
                 println(arr.@capacity.to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -296,8 +297,7 @@ pub fn test_empty_capacity_one_element_past_the_bound_is_rejected() {
                 println(arr.push_back(42).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -321,8 +321,7 @@ pub fn test_reserve_capacity_byte_count_wraps_for_a_shared_array() {
                 println((big.@(0) + pair.@1.@(0)).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let config = runtime_checked_config();
     test_source_fail(
         &source,
         config,
@@ -347,8 +346,7 @@ pub fn test_capacity_byte_count_under_separate_compilation() {
                 println(arr.push_back(42).@(0).to_string)
             );
         "#;
-    let mut config = Configuration::develop_mode();
-    config.no_runtime_check = false;
+    let mut config = runtime_checked_config();
     config.set_fix_opt_level(FixOptimizationLevel::Basic);
     config.max_cu_size = 1;
     test_source_fail(
@@ -373,15 +371,13 @@ pub fn test_capacity_byte_count_respects_no_runtime_check() {
                 println(arr.@capacity.to_string)
             );
         "#;
-    let mut checked = Configuration::develop_mode();
-    checked.no_runtime_check = false;
+    let checked = runtime_checked_config();
     test_source_fail(
         &source,
         checked,
         "Array size or capacity exceeds the address space: 2305843009213693952",
     );
-    let mut unchecked = Configuration::develop_mode();
-    unchecked.no_runtime_check = true;
+    let unchecked = runtime_unchecked_config();
     test_source(&source, unchecked);
 }
 
@@ -404,12 +400,10 @@ pub fn test_set_bounds_check_respects_no_runtime_check() {
             );
         "#;
     // Checks on: the out-of-range index aborts.
-    let mut checked = Configuration::develop_mode();
-    checked.no_runtime_check = false;
+    let checked = runtime_checked_config();
     test_source_fail(&source, checked, "Index out of range");
     // Checks off: no bounds check, so the (memory-safe) access completes.
-    let mut unchecked = Configuration::develop_mode();
-    unchecked.no_runtime_check = true;
+    let unchecked = runtime_unchecked_config();
     test_source(&source, unchecked);
 }
 
@@ -425,11 +419,9 @@ pub fn test_swap_bounds_check_respects_no_runtime_check() {
                 pure()
             );
         "#;
-    let mut checked = Configuration::develop_mode();
-    checked.no_runtime_check = false;
+    let checked = runtime_checked_config();
     test_source_fail(&source, checked, "Index out of range");
-    let mut unchecked = Configuration::develop_mode();
-    unchecked.no_runtime_check = true;
+    let unchecked = runtime_unchecked_config();
     test_source(&source, unchecked);
 }
 
@@ -446,8 +438,7 @@ pub fn test_unsafe_swap_bounds_unchecked_skips_check() {
                 pure()
             );
         "#;
-    let mut checked = Configuration::develop_mode();
-    checked.no_runtime_check = false;
+    let checked = runtime_checked_config();
     test_source(&source, checked);
 }
 

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -2,7 +2,8 @@ use crate::{
     configuration::{Configuration, FixOptimizationLevel},
     fixstd::runtime::{RUNTIME_ARRAY_SIZE_OVERFLOW, RUNTIME_MALLOC},
     tests::test_util::{
-        emitted_llvm_ir, fix_build_source_command, test_source, test_source_fail, EmittedIr,
+        emitted_llvm_ir, fix_build_source_command, llvm_function_bodies, test_source,
+        test_source_fail, EmittedIr,
     },
 };
 use tempfile::TempDir;
@@ -464,26 +465,6 @@ main = (
     println((arr.@(0) + shared.@(0)).to_string)
 );
 "#;
-
-/// The bodies of the LLVM functions of `ir` whose names contain `name_part`, one string each.
-fn llvm_function_bodies(ir: &str, name_part: &str) -> Vec<String> {
-    let mut bodies = vec![];
-    let mut current: Option<Vec<&str>> = None;
-    for line in ir.lines() {
-        if line.starts_with("define ") {
-            current = line.contains(name_part).then(Vec::new);
-        }
-        if let Some(body) = current.as_mut() {
-            body.push(line);
-        }
-        if line == "}" {
-            if let Some(body) = current.take() {
-                bodies.push(body.join("\n"));
-            }
-        }
-    }
-    bodies
-}
 
 /// Writing into a shared array clones its storage with the capacity that array already holds, and
 /// the clone allocates without checking that capacity: the allocation that gave the array its

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -489,27 +489,27 @@ pub fn test_array_write_clones_without_rechecking_the_capacity() {
         "the build should check the capacity where the program chooses one"
     );
 
-    let writes = llvm_function_bodies(&ir, "@\"Std::Array::set#");
+    let write_fn_bodies = llvm_function_bodies(&ir, "@\"Std::Array::set#");
     assert!(
-        !writes.is_empty(),
+        !write_fn_bodies.is_empty(),
         "the build should emit `Std::Array::set`"
     );
-    let allocating = writes
+    let allocating_bodies = write_fn_bodies
         .iter()
         .filter(|body| body.contains(&format!("@{}(", RUNTIME_MALLOC)))
         .collect::<Vec<_>>();
     assert!(
-        !allocating.is_empty(),
+        !allocating_bodies.is_empty(),
         "`Std::Array::set` should allocate, which is the clone the shared answer takes"
     );
-    let rechecking = allocating
+    let rechecking_bodies = allocating_bodies
         .iter()
         .filter(|body| body.contains(&overflow_call))
         .collect::<Vec<_>>();
     assert!(
-        rechecking.is_empty(),
+        rechecking_bodies.is_empty(),
         "the clone in `Std::Array::set` should allocate without checking the capacity again, \
          but {} of its functions do",
-        rechecking.len()
+        rechecking_bodies.len()
     );
 }

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -1,7 +1,11 @@
 use crate::{
     configuration::{Configuration, FixOptimizationLevel},
-    tests::test_util::{test_source, test_source_fail},
+    fixstd::runtime::{RUNTIME_ARRAY_SIZE_OVERFLOW, RUNTIME_MALLOC},
+    tests::test_util::{
+        emitted_llvm_ir, fix_build_source_command, test_source, test_source_fail, EmittedIr,
+    },
 };
+use tempfile::TempDir;
 
 #[test]
 pub fn test_get() {
@@ -444,4 +448,96 @@ pub fn test_unsafe_swap_bounds_unchecked_skips_check() {
     let mut checked = Configuration::develop_mode();
     checked.no_runtime_check = false;
     test_source(&source, checked);
+}
+
+/// A program that writes into an array while a second handle to it is alive, so that the build emits
+/// `Array::set` with both answers of its uniqueness check -- including the clone the shared answer
+/// takes.
+const SHARED_WRITE_SOURCE: &str = r#"
+module Main;
+
+main : IO ();
+main = (
+    let arr = Array::fill(4, 0);
+    let shared = arr;
+    let arr = arr.set(0, 7);
+    println((arr.@(0) + shared.@(0)).to_string)
+);
+"#;
+
+/// The bodies of the LLVM functions of `ir` whose names contain `name_part`, one string each.
+fn llvm_function_bodies(ir: &str, name_part: &str) -> Vec<String> {
+    let mut bodies = vec![];
+    let mut current: Option<Vec<&str>> = None;
+    for line in ir.lines() {
+        if line.starts_with("define ") {
+            current = line.contains(name_part).then(Vec::new);
+        }
+        if let Some(body) = current.as_mut() {
+            body.push(line);
+        }
+        if line == "}" {
+            if let Some(body) = current.take() {
+                bodies.push(body.join("\n"));
+            }
+        }
+    }
+    bodies
+}
+
+/// Writing into a shared array clones its storage with the capacity that array already holds, and
+/// the clone allocates without checking that capacity: the allocation that gave the array its
+/// capacity checked it.
+///
+/// The check is a comparison and a branch, and an array write is the innermost thing a loop over an
+/// array does, so a check emitted here is what costs the enclosing loop its unrolling. The property
+/// is read off the emitted LLVM IR because it is about the code the build emits rather than the
+/// answer it computes: a program cannot observe a check that never fires.
+#[test]
+pub fn test_array_write_clones_without_rechecking_the_capacity() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let dir = temp_dir.path();
+    // At `-O none` the array write keeps its uniqueness check, so the clone is in the emitted code
+    // whatever the program does at run time.
+    let build = fix_build_source_command(dir, SHARED_WRITE_SOURCE, "none")
+        .arg("--emit-llvm")
+        .output()
+        .expect("Failed to execute fix build");
+    assert!(
+        build.status.success(),
+        "the build should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr),
+    );
+
+    let ir = emitted_llvm_ir(dir, EmittedIr::BeforeOptimization);
+    let overflow_call = format!("call void @{}(", RUNTIME_ARRAY_SIZE_OVERFLOW);
+    assert!(
+        ir.contains(&overflow_call),
+        "the build should check the capacity where the program chooses one"
+    );
+
+    let writes = llvm_function_bodies(&ir, "@\"Std::Array::set#");
+    assert!(
+        !writes.is_empty(),
+        "the build should emit `Std::Array::set`"
+    );
+    let allocating = writes
+        .iter()
+        .filter(|body| body.contains(&format!("@{}(", RUNTIME_MALLOC)))
+        .collect::<Vec<_>>();
+    assert!(
+        !allocating.is_empty(),
+        "`Std::Array::set` should allocate, which is the clone the shared answer takes"
+    );
+    let rechecking = allocating
+        .iter()
+        .filter(|body| body.contains(&overflow_call))
+        .collect::<Vec<_>>();
+    assert!(
+        rechecking.is_empty(),
+        "the clone in `Std::Array::set` should allocate without checking the capacity again, \
+         but {} of its functions do",
+        rechecking.len()
+    );
 }

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -23,6 +23,7 @@ fn runtime_unchecked_config() -> Configuration {
     config
 }
 
+/// `@` bounds-checks the index it is given, and the message reports both the index and the size.
 #[test]
 pub fn test_get() {
     let source = r#"    
@@ -38,6 +39,7 @@ pub fn test_get() {
     test_source_fail(&source, config, "Index out of range: index=3, size=3");
 }
 
+/// `set` bounds-checks the index it is given.
 #[test]
 pub fn test_set() {
     let source = r#"    
@@ -384,9 +386,11 @@ pub fn test_capacity_byte_count_respects_no_runtime_check() {
 // `--no-runtime-check` disables array bounds checks (documented in the CLI help), so `set`
 // and `swap` must honor it like `@` / `mod` / `act`. An index within the array's capacity but
 // past its size stays inside the allocated buffer, so the access itself is memory-safe; only
-// the bounds check decides whether it aborts. That makes "the check was removed" observable
-// as a completed run rather than an out-of-range abort.
+// the bounds check decides whether it aborts. Such an access therefore runs to completion
+// exactly when the check is gone, and that is what the tests below read off.
 
+/// `set` honors `--no-runtime-check`: one index, in capacity and past the size, aborts with the
+/// checks on and completes with them off.
 #[test]
 pub fn test_set_bounds_check_respects_no_runtime_check() {
     let source = r#"
@@ -407,6 +411,7 @@ pub fn test_set_bounds_check_respects_no_runtime_check() {
     test_source(&source, unchecked);
 }
 
+/// `swap` honors `--no-runtime-check` for both of the indices it checks.
 #[test]
 pub fn test_swap_bounds_check_respects_no_runtime_check() {
     let source = r#"
@@ -425,9 +430,10 @@ pub fn test_swap_bounds_check_respects_no_runtime_check() {
     test_source(&source, unchecked);
 }
 
+/// `unsafe_swap_bounds_unchecked` skips the bounds check even with the runtime checks on, so a pair
+/// of indices in capacity and past the size runs to completion.
 #[test]
 pub fn test_unsafe_swap_bounds_unchecked_skips_check() {
-    // `unsafe_swap_bounds_unchecked` never bounds-checks, even with runtime checks on.
     let source = r#"
             module Main;
 

--- a/src/tests/test_array_bounds_check.rs
+++ b/src/tests/test_array_bounds_check.rs
@@ -463,8 +463,8 @@ main = (
 ///
 /// The check is a comparison and a branch, and an array write is the innermost thing a loop over an
 /// array does, so a check emitted here is what costs the enclosing loop its unrolling. The property
-/// is read off the emitted LLVM IR because it is about the code the build emits rather than the
-/// answer it computes: a program cannot observe a check that never fires.
+/// is read off the emitted LLVM IR: it is about the code the build emits, and a program cannot
+/// observe a check that never fires.
 #[test]
 pub fn test_array_write_clones_without_rechecking_the_capacity() {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -155,6 +155,26 @@ pub fn emitted_llvm_ir(dir: &Path, which: EmittedIr) -> String {
         .join("\n")
 }
 
+/// The bodies of the LLVM functions of `ir` whose names contain `name_part`, one string each.
+pub fn llvm_function_bodies(ir: &str, name_part: &str) -> Vec<String> {
+    let mut bodies = vec![];
+    let mut current: Option<Vec<&str>> = None;
+    for line in ir.lines() {
+        if line.starts_with("define ") {
+            current = line.contains(name_part).then(Vec::new);
+        }
+        if let Some(body) = current.as_mut() {
+            body.push(line);
+        }
+        if line == "}" {
+            if let Some(body) = current.take() {
+                bodies.push(body.join("\n"));
+            }
+        }
+    }
+    bodies
+}
+
 #[cfg(test)]
 mod tests {
     use super::EmittedIr;

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -73,9 +73,9 @@ fn path_env_with_fix_binary_dir() -> OsString {
 
 /// A `Command` that runs this worktree's freshly built `fix` binary by absolute
 /// path. Building is triggered (once) first, so the returned command always
-/// targets a complete binary. Spawning `fix` this way runs the binary the test
-/// just built rather than whatever `fix` is on `PATH`, which a parallel
-/// worktree may be overwriting.
+/// targets a complete binary. The absolute path pins the run to the binary the
+/// test just built; the `fix` on `PATH` is one a parallel worktree may be
+/// overwriting.
 pub fn fix_command() -> Command {
     build_fix();
     let mut command = Command::new(fix_binary_path());
@@ -235,6 +235,9 @@ fn run_source(
     run(config, false)
 }
 
+/// Compiles `source` under `config` and runs it, failing the test unless it exits with code 0. The
+/// program's stdout and stderr are forwarded to the test's stderr, so a failing run shows what it
+/// printed.
 pub fn test_source(source: &str, config: Configuration) {
     let compile_result = run_source(source, config);
     let spawn_result = panic_if_err(compile_result);

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -158,16 +158,16 @@ pub fn emitted_llvm_ir(dir: &Path, which: EmittedIr) -> String {
 /// The bodies of the LLVM functions of `ir` whose names contain `name_part`, one string each.
 pub fn llvm_function_bodies(ir: &str, name_part: &str) -> Vec<String> {
     let mut bodies = vec![];
-    let mut current: Option<Vec<&str>> = None;
+    let mut current_body: Option<Vec<&str>> = None;
     for line in ir.lines() {
         if line.starts_with("define ") {
-            current = line.contains(name_part).then(Vec::new);
+            current_body = line.contains(name_part).then(Vec::new);
         }
-        if let Some(body) = current.as_mut() {
+        if let Some(body) = current_body.as_mut() {
             body.push(line);
         }
         if line == "}" {
-            if let Some(body) = current.take() {
+            if let Some(body) = current_body.take() {
                 bodies.push(body.join("\n"));
             }
         }

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -236,9 +236,9 @@ fn run_source(
 }
 
 pub fn test_source(source: &str, config: Configuration) {
-    let res = run_source(source, config);
-    let res = panic_if_err(res);
-    let output = res.unwrap();
+    let compile_result = run_source(source, config);
+    let spawn_result = panic_if_err(compile_result);
+    let output = spawn_result.unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stdout.is_empty() {
@@ -295,8 +295,8 @@ pub fn assert_grammar_accepts(source: &str) {
 ///     spawn;
 ///   - the captured stderr from the child process otherwise.
 pub fn run_source_assert_failed(source: &str, config: Configuration) -> String {
-    let res = run_source(source, config);
-    match res {
+    let compile_result = run_source(source, config);
+    match compile_result {
         Err(errs) => errs.to_string(),
         Ok(Err(e)) => e.to_string(),
         Ok(Ok(output)) => {
@@ -366,9 +366,9 @@ pub fn test_files_in_directory(dir: &Path) {
             config.add_user_source_file(path.clone());
         }
         println!("[{}]:", path.to_string_lossy().to_string());
-        let res = run(config, false);
-        let res = panic_if_err(res);
-        let output = res.unwrap();
+        let compile_result = run(config, false);
+        let spawn_result = panic_if_err(compile_result);
+        let output = spawn_result.unwrap();
         let code = output.status.code().unwrap();
         assert_eq!(code, 0);
         remove_file("test_process_text_file.txt").unwrap_or(());


### PR DESCRIPTION
The capacity check #178 added is emitted from `ObjectType::size_of`, and one of that function's callers is the clone an array write takes when the array is shared. So the check landed in every array write that carries a uniqueness test — `Array::set`, `mod`, and everything built on them.

On the speedtest corpus that costs `nbody` +26.60% and `fannkuch` +6.33% in executed instructions. Bisected over `383a7b5e..d55854af` with the settings `benchmark/speedtest` uses (`-O experimental`, `--disable-cpu-feature 'avx512.*'`, cachegrind):

| commit | `nbody` | `fannkuch` |
| --- | ---: | ---: |
| `383a7b5e` | 872,123,958 | 2,468,919,159 |
| `ab0635df` (#150, #154, #161, #165, #183, #177, #184 applied) | 872,123,958 | 2,468,919,145 |
| `81d687cd` (**#178**) | 1,104,124,006 | 2,729,304,433 |
| `ed02aa09` (#185) | 1,104,124,006 | 2,729,304,433 |
| `eccaa9d4` (#186) | 1,104,124,006 | 2,729,304,433 |

A check that never fires at run time is expensive there because of what it does to the code around it. `nbody` is inlined entirely into `main`, and the whole cost is 116 instructions per step of a loop whose array is unique every time. The two extra basic blocks per write grow the enclosing function past what LLVM's unroller will duplicate: in the optimized IR the 21-flop pair-interaction block goes from 4 copies to 1.

## The change

A capacity read back off an array is already within the bound, because the allocation that gave that array its capacity checked it. `CapacityCheck` says which of the two a capacity is, and the check moves out of `ObjectType::size_of` onto the two allocation entry points, `alloc_array_storage` and `realloc_array`. Every allocation asks for the answer, so a new allocation site states which of the two it is instead of inheriting one.

`CapacityCheck::Skip` has two callers:

- `make_array_unique_with_hole` clones a shared array's storage with the capacity that array holds.
- `set_capacity` chooses a new capacity, but both arms of its uniqueness branch allocate it, so it checks once ahead of the branch. That is a second, smaller instance of the same defect: before this, `reserve` on an array whose uniqueness is decided at run time emitted the check twice.

`ObjectType::size_of` goes back to computing a size, and `ObjectType::element_buffer_layout` gives it and the check the same header size and element stride.

## Evidence

- Full suite: **1177 passed, 0 failed**.
- `test_array_write_clones_without_rechecking_the_capacity` reads the emitted LLVM IR and asserts that the allocating path of `Std::Array::set` carries no capacity check, while the module still carries one where a capacity is chosen. Putting `CapacityCheck::Run` back on the clone path makes it fail, so it discriminates.
- Instruction counts (cachegrind, `-O experimental`, all 46 corpus cases) against `d55854af`'s row:

| case | `d55854af` | this branch | |
| --- | ---: | ---: | ---: |
| `nbody` | 1,104,123,988 | 872,123,940 | **-21.01%** |
| `fannkuch` | 2,625,198,292 | 2,352,398,352 | **-10.39%** |
| `cp_lib_lsegtree` | 884,985,341 | 854,311,732 | -3.47% |
| `nbody_fold` | 966,123,992 | 940,123,964 | -2.69% |
| `cp_lib_conv_zp` | 268,111,556 | 262,213,262 | -2.20% |
| `cp_lib_dijkstra` | 145,758,390 | 145,105,660 | -0.45% |
| `cp_lib_unionfind` | 134,693,620 | 134,135,792 | -0.41% |
| `fannkuch_scratch` | 1,310,391,511 | 1,308,577,111 | -0.14% |
| `cp_lib_scc` | 150,060,722 | 150,011,200 | -0.03% |
| `cp_lib_bipartite` | 236,805,161 | 237,074,939 | +0.11% |

The other 36 cases are unchanged. Hoisting `set_capacity`'s check is what turned `cp_lib_dijkstra` from +0.47% to -0.45% and moved `cp_lib_unionfind` and `cp_lib_scc`.

### Cycles

Instruction counts say nothing about how fast the machine gets through the instructions, so the
same binaries were read with the hardware counters as well, on an idle machine, alternating
between the two builds so that anything drifting reached both. Each figure is the lowest of five
runs, taken while other work held under 0.1 of a core.

| case | `origin/main` | this branch | | splits, main -> branch |
| --- | ---: | ---: | ---: | --- |
| `fannkuch` | 918,585,466 | 858,119,066 | **-6.58%** | unchanged |
| `nbody` | 392,616,374 | 369,322,107 | **-5.93%** | 18,000,029 -> 12,000,029 |
| `cp_lib_lsegtree` | 321,091,870 | 303,730,549 | -5.41% | unchanged |
| `cp_lib_dijkstra` | 85,164,794 | 81,182,072 | -4.68% | unchanged |
| `cp_lib_conv_zp` | 122,026,657 | 120,614,774 | -1.16% | unchanged |
| `nbody_fold` | 731,398,442 | 730,761,041 | -0.09% | unchanged |
| `fannkuch_scratch` | 674,429,617 | 694,834,105 | **+2.94%** | unchanged (23) |

`nbody` also stops splitting 6,000,000 of its accesses across a cache line, which no instruction
count shows.

**`fannkuch_scratch` costs 2.9% of its cycles**, and that is a real figure rather than noise:
three pairs put `origin/main` at 674.4M / 675.2M / 676.6M and this branch at 694.4M / 694.8M,
ranges that do not overlap. Its instruction count moves -0.14% and its split count is 23 either
way, so what changed is code layout. `cp_lib_scc` and `cp_lib_unionfind` move in both directions
across repeats and are noise.

## How it went unnoticed

`log.csv` has no row between `383a7b5e` and `d55854af`, so eleven PRs landed between two rows and the delta read as one change's. The twelve-case spot check #178 carried included neither `nbody` nor `fannkuch`, and could not have shown this in any case: the cost appears only where the check changes what the unroller does to the enclosing loop, which no single-case instruction count predicts.

## Left open by the review

- `ObjectFieldType::Array` is constructed nowhere. `element_buffer_layout`'s arm for it and `to_struct_type`'s are unreachable, and the comments around them describe a layout that no longer exists.
- `create_obj` still takes `Option<IntValue>` as a capacity and states no precondition, so a future caller reaching it without `alloc_array_storage` would allocate unchecked.
- The `#ArrayStorage` header size is computed in three places: `element_buffer_layout`, `realloc_array`, and `build_array_storage_shift`.
- `InlineLLVMArraySetCapacityBoundsUnchecked::force_unique` reads inverted beside its neighbour `assume_local`: `force_unique: false` means the array is known unique.
- The `CapacityCheck::Run` on `set_capacity`'s already-unique path is reached only when the suite runs at `-O max`, where the specialization that takes it exists.

