### PR TITLE
値の分割表現の不変条件を 3 本のテストで固定する

### DIFF
--- a/src/tests/test_value_splitting.rs
+++ b/src/tests/test_value_splitting.rs
@@ -201,3 +201,243 @@ fn test_wide_value_crosses_compilation_units() {
     config.max_cu_size = 1;
     test_source(CROSS_UNIT_PROGRAM, config);
 }
+
+// A type wider than the split limit, built by nesting an unbox struct of two fields eight levels
+// deep, so `L8` holds 256 scalars under the default limit. The program carries it every way the two
+// representations differ: it reads a field of a field, modifies a deep one, passes one across a
+// function boundary and returns it, merges two at an `if`, carries one around a loop, stores one in
+// an array, wraps one in a union variant, captures one in a closure, and reaches one through a
+// boxed owner.
+const WIDE_STRUCT_PROGRAM: &str = r#"
+module Main;
+
+type L0 = unbox struct { v : I64 };
+type L1 = unbox struct { a : L0, b : L0 };
+type L2 = unbox struct { a : L1, b : L1 };
+type L3 = unbox struct { a : L2, b : L2 };
+type L4 = unbox struct { a : L3, b : L3 };
+type L5 = unbox struct { a : L4, b : L4 };
+type L6 = unbox struct { a : L5, b : L5 };
+type L7 = unbox struct { a : L6, b : L6 };
+type L8 = unbox struct { a : L7, b : L7 };
+
+type Wrapped = unbox union { none : (), some : L8 };
+type Owner = box struct { w : L8 };
+
+sum0 : L0 -> I64;
+sum0 = |x| x.@v;
+sum1 : L1 -> I64;
+sum1 = |x| sum0(x.@a) + sum0(x.@b);
+sum2 : L2 -> I64;
+sum2 = |x| sum1(x.@a) + sum1(x.@b);
+sum3 : L3 -> I64;
+sum3 = |x| sum2(x.@a) + sum2(x.@b);
+sum4 : L4 -> I64;
+sum4 = |x| sum3(x.@a) + sum3(x.@b);
+sum5 : L5 -> I64;
+sum5 = |x| sum4(x.@a) + sum4(x.@b);
+sum6 : L6 -> I64;
+sum6 = |x| sum5(x.@a) + sum5(x.@b);
+sum7 : L7 -> I64;
+sum7 = |x| sum6(x.@a) + sum6(x.@b);
+sum8 : L8 -> I64;
+sum8 = |x| sum7(x.@a) + sum7(x.@b);
+
+mk0 : I64 -> L0;
+mk0 = |n| L0 { v : n };
+mk1 : I64 -> L1;
+mk1 = |n| L1 { a : mk0(n), b : mk0(n + 1) };
+mk2 : I64 -> L2;
+mk2 = |n| L2 { a : mk1(n), b : mk1(n + 2) };
+mk3 : I64 -> L3;
+mk3 = |n| L3 { a : mk2(n), b : mk2(n + 4) };
+mk4 : I64 -> L4;
+mk4 = |n| L4 { a : mk3(n), b : mk3(n + 8) };
+mk5 : I64 -> L5;
+mk5 = |n| L5 { a : mk4(n), b : mk4(n + 16) };
+mk6 : I64 -> L6;
+mk6 = |n| L6 { a : mk5(n), b : mk5(n + 32) };
+mk7 : I64 -> L7;
+mk7 = |n| L7 { a : mk6(n), b : mk6(n + 64) };
+mk8 : I64 -> L8;
+mk8 = |n| L8 { a : mk7(n), b : mk7(n + 128) };
+
+// Add one to the leftmost leaf, reaching it through eight nested modifications.
+bump : L8 -> L8;
+bump = |x| x.mod_a(|y| y.mod_a(|y| y.mod_a(|y| y.mod_a(|y| y.mod_a(
+    |y| y.mod_a(|y| y.mod_a(|y| y.mod_a(|z| z.set_v(z.@v + 1)))))))));
+
+pick : Bool -> L8 -> L8 -> L8;
+pick = |c, x, y| if c { x } else { y };
+
+unwrapped : Wrapped -> I64;
+unwrapped = |w| if w.is_none { -1 } else { sum8(w.as_some) };
+
+captured : L8 -> (I64 -> I64);
+captured = |x| |k| sum8(x) + k;
+
+main : IO ();
+main = (
+    let x = mk8(0);
+    let y = loop((0, x), |(i, v)|
+        if i == 5 { break $ v } else { continue $ (i + 1, bump(v)) }
+    );
+    let owner = Owner { w : y };
+    let arr = Array::fill(3, x).set(1, y);
+    let total = sum8(x)
+        + sum8(y)
+        + sum8(pick(true, x, y))
+        + sum8(pick(false, x, y))
+        + arr.to_iter.map(sum8).fold(0, |e, acc| acc + e)
+        + unwrapped(Wrapped::some(y))
+        + unwrapped(Wrapped::none())
+        + captured(y)(1000)
+        + sum8(owner.@w)
+        + y.@a.@a.@a.@a.@a.@a.@a.@a.@v
+        + y.@b.@b.@b.@b.@b.@b.@b.@b.@v;
+    println(total.to_string)
+);
+"#;
+
+/// Verifies that a value of a type wider than the split limit computes the same answers as the
+/// narrow types the rest of the suite uses.
+///
+/// The limit sits above every type the suite writes, so this is the only test that reaches the
+/// carried-whole representation as a released compiler selects it; the tests above reach it by
+/// lowering the limit instead.
+#[test]
+fn test_wide_value_under_the_default_limit() {
+    // The leaves of `mk8(0)` are `0` to `255`, so each unmodified value sums to 32640, and each
+    // value the loop bumped five times sums to 32645. `total` adds four unmodified values (`x`,
+    // `pick(true, ..)`, and two array elements) and six bumped ones (`y`, `pick(false, ..)`, one
+    // array element, the union payload, the closure's capture and the owner's field), then the
+    // closure's `1000`, the `-1` of the empty variant, and the two extreme leaves of `y`, which
+    // are `5` and `255`.
+    let expected = 4 * 32640 + 6 * 32645 + 1000 - 1 + 5 + 255;
+    let output = run_source_capture(WIDE_STRUCT_PROGRAM, Configuration::develop_mode());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        expected.to_string(),
+        "a value wider than the split limit computed the wrong answer"
+    );
+}
+
+// A program that merges values of one unbox struct across the arms of an `if` whose result the
+// continuation reads, so the arms meet at a phi rather than at a return, and that reads fields of
+// the merged value afterwards. The struct holds a boxed subobject as well, so reference counting
+// runs over the merged value.
+const BRANCH_MERGE_PROGRAM: &str = r#"
+module Main;
+
+type Pair = unbox struct { a : I64, b : I64 };
+type Quad = unbox struct { p : Pair, q : Pair, xs : Array I64 };
+
+pick : Bool -> Quad -> Quad -> Quad;
+pick = |c, x, y| (
+    let v = if c { x } else { y };
+    v.mod_p(|p| p.set_a(p.@a + 100))
+);
+
+total : Quad -> I64;
+total = |v| v.@p.@a + v.@p.@b * 3 + v.@q.@a * 5 + v.@q.@b * 7
+    + v.@xs.to_iter.fold(0, |e, acc| acc * 11 + e);
+
+main : IO ();
+main = (
+    let x = Quad { p : Pair { a : 1, b : 2 }, q : Pair { a : 3, b : 4 }, xs : [5, 6] };
+    let y = Quad { p : Pair { a : 10, b : 20 }, q : Pair { a : 30, b : 40 }, xs : [50, 60] };
+    println((total(pick(true, x, y)) * 13 + total(pick(false, x, y))).to_string)
+);
+"#;
+
+/// Verifies that a value merged across the arms of a branch computes the same answer whether it is
+/// carried whole -- where the merge is one phi of the aggregate -- or split, where it is one phi per
+/// scalar.
+#[test]
+fn test_carried_whole_value_merged_at_a_branch() {
+    let split_output = run_source_capture(BRANCH_MERGE_PROGRAM, Configuration::develop_mode());
+    let mut whole_config = Configuration::develop_mode();
+    whole_config.max_split_scalars = 0;
+    let whole_output = run_source_capture(BRANCH_MERGE_PROGRAM, whole_config);
+
+    assert_eq!(
+        String::from_utf8_lossy(&split_output.stdout).trim(),
+        "3953",
+        "the split representation computed the wrong answer"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&whole_output.stdout),
+        String::from_utf8_lossy(&split_output.stdout),
+        "carrying the merged value whole changed the answer"
+    );
+}
+
+/// Verifies that the parts of a struct are exactly its fields' parts laid end to end: `part_count`
+/// is the length of `type_parts`, and the ranges `field_part_range` gives the fields tile that list
+/// in order, without gap or overlap. Checked on both sides of the limit, so it covers the claim the
+/// descent rests on -- a field of a type within the limit is within it too, so a split struct has
+/// no field carried whole.
+#[test]
+fn test_field_part_ranges_tile_the_part_list() {
+    let config = panic_if_err(Configuration::check_mode());
+    let program = panic_if_err(elaborate_via_config(&config));
+    let type_env = program.type_env().clone();
+    let context = Context::create();
+    let target_machine = get_target_machine(config.get_llvm_opt_level(), &config);
+    let module = Generator::create_module("part_range_test", &context, &target_machine);
+    // The part lists below are read off the types alone, so this generator resolves no global and
+    // is given none.
+    let gc = Generator::new(
+        &context,
+        &module,
+        target_machine.get_target_data(),
+        config.clone(),
+        type_env,
+        Arc::new(Map::default()),
+    );
+
+    // A struct of `n` scalars of alternating class, led by a zero-sized member that yields no part.
+    let mixed = |n: usize| {
+        let mut fields: Vec<inkwell::types::BasicTypeEnum> =
+            vec![context.i8_type().array_type(0).into()];
+        for i in 0..n {
+            fields.push(if i % 2 == 0 {
+                context.i64_type().into()
+            } else {
+                context.f64_type().into()
+            });
+        }
+        context.struct_type(&fields, false)
+    };
+
+    let limit = MAX_SPLIT_SCALARS;
+    // `outer` holds `2 * n` scalars, so `n` around half the limit puts it on either side of it.
+    for n in [
+        0,
+        1,
+        2,
+        (limit / 2).saturating_sub(1),
+        limit / 2,
+        limit / 2 + 1,
+        limit,
+    ] {
+        let outer = context.struct_type(&[mixed(n).into(), mixed(n).into()], false);
+        let parts = gc.type_parts(outer.into());
+        assert_eq!(gc.part_count(outer.into()), parts.len());
+        if gc.is_carried_whole(outer.into()) {
+            assert_eq!(parts.len(), 1);
+            continue;
+        }
+        let mut offset = 0;
+        for i in 0..outer.count_fields() {
+            let field_ty = outer.get_field_type_at_index(i).unwrap();
+            assert!(!gc.is_carried_whole(field_ty));
+            let (off, cnt) = gc.field_part_range(outer, i);
+            assert_eq!(off, offset);
+            assert_eq!(cnt, gc.part_count(field_ty));
+            assert_eq!(&parts[off..off + cnt], gc.type_parts(field_ty).as_slice());
+            offset += cnt;
+        }
+        assert_eq!(offset, parts.len());
+    }
+}


### PR DESCRIPTION
PR #194 で入った「値をパートに分割して運ぶ／閾値を超えたら 1 個の集約として運ぶ」表現について、成立していることを確認済みの不変条件を 3 本のテストで固定します。コンパイラ本体の変更はなく、差分は `src/tests/test_value_splitting.rs` への追加のみです。

## 追加するテスト

### `test_wide_value_under_the_default_limit`

幅 2 の `unbox struct` を 8 段重ねた 256 スカラーの型を、**既定の閾値 128 のまま**通します。フィールドのフィールドを読む、深いフィールドを更新する、関数境界を越えて渡して返す、`if` の両腕で合流させる、ループで持ち回る、配列の要素にする、union のバリアントに入れる、クロージャに捕捉させる、boxed な所有者を経由して届く、の 9 通りの運び方を 1 本のプログラムで通し、答えをリテラルと照合します。

閾値はスイートが書くどの型よりも上にあるため、**リリース構成のままで carried-whole 表現に入る唯一のテスト**です（既存の 2 本は `max_split_scalars` を下げて到達させています）。

### `test_carried_whole_value_merged_at_a_branch`

`if` の結果を `let` で受けてから読む形にして、両腕が return ではなく phi で合流する場合を作ります。carried-whole なら集約 1 個の phi、split ならパートごとの phi になる箇所です。`max_split_scalars` を 0 と既定値にした 2 通りで同じ答えになることを確認します。構造体は `Array` フィールドを持つので、合流した値の上を参照カウントも通ります。

### `test_field_part_ranges_tile_the_part_list`

`field_part_range` が返す区間が、`type_parts` の返すリストを隙間なく重複なく敷き詰めることを直接確かめる Rust 単体テストです。閾値の両側（`outer` が 0、2、126、128、130、256 スカラー）で見るので、パート列の降下が乗っている前提、すなわち「閾値以内の型のフィールドもまた閾値以内」も同時に覆います。

## 検証

- `-O none` / `-O max` の両方で `test_value_splitting` の 6 件すべて通過
- 追加分の実行時間は既定（`-O experimental`）でも合計 10.5 秒（6.37s + 3.90s + 0.18s）
- `test_field_part_ranges_tile_the_part_list` は速いため空振りを疑い、`field_part_range` の返す要素数を 1 減らす細工を入れて、実際に該当 assert が落ちることを確認した（細工は戻し済み）

## 限界

3 本とも、書いた時点で通ったテストです。バグを見つけたのではなく、疑って確かめた不変条件を固定するものです。とくに `test_wide_value_under_the_default_limit` については、分割は完全にコンパイル時の選択なので、分割を止めても同じ答えが出てしまい、注入によって既存の「閾値を下げる」テストと区別することはできませんでした。既定構成での被覆という点に価値があります。

https://claude.ai/code/session_01XFyf4t5HbFbzHyJHFLHQey