### PR TITLE
Require the head of a struct pattern to name a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 ### Fixed
 
+#### Language
+
+- A struct pattern now requires the type at its head to be a struct. `let MyUnion { a : x } = u;` read the union's variant list as a field list and bound `x` to the union's tag, which aborted the build inside LLVM; a pattern headed by an associated type name, such as `let Item { data : x } = 42;`, aborted the compiler.
+
 #### Std
 
 - Fixed a bug where `String::from_bytes` updated the length of a shared byte array in place instead of cloning it, truncating the caller's array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 #### Language
 
-- A struct pattern now requires the type at its head to be a struct. `let MyUnion { a : x } = u;` read the union's variant list as a field list and bound `x` to the union's tag, which aborted the build inside LLVM; a pattern headed by an associated type name, such as `let Item { data : x } = 42;`, aborted the compiler.
+- A struct pattern now requires the type at its head to be a struct, and reports an error otherwise. `let MyUnion { a : x } = u;` took the union's tag for the payload of `a`, and the build aborted; `let Item { data : x } = 42;`, whose head names an associated type, aborted the compiler.
 
 #### Std
 

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -133,17 +133,19 @@ impl PatternNode {
                 // `validate_pattern` requires the head to name a struct, so `None` arrives
                 // only in `error_tolerant` mode: the pattern then takes a fresh type
                 // variable, and its sub-patterns have no field type to match against.
-                let tycon_info = typechecker.resolve_struct_tycon(tc, &self.info.source, false)?;
-                let (ty, field_name_to_ty) = match tycon_info {
-                    Some(ti) => {
+                // The field names are taken by value because the steps below borrow the
+                // type checker mutably.
+                let field_names = typechecker
+                    .resolve_struct_tycon(tc, &self.info.source, false)?
+                    .map(|ti| ti.fields.iter().map(|f| f.name.clone()).collect::<Vec<_>>());
+                let (ty, field_name_to_ty) = match field_names {
+                    Some(field_names) => {
                         let ty = tc.get_struct_union_value_type(typechecker);
                         let field_tys = ty.field_types(&typechecker.type_env);
-                        assert_eq!(ti.fields.len(), field_tys.len());
-                        let field_name_to_ty = ti
-                            .fields
-                            .iter()
-                            .enumerate()
-                            .map(|(i, field)| (field.name.clone(), field_tys[i].clone()))
+                        assert_eq!(field_names.len(), field_tys.len());
+                        let field_name_to_ty = field_names
+                            .into_iter()
+                            .zip(field_tys)
                             .collect::<Map<_, _>>();
                         (ty, field_name_to_ty)
                     }

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -150,7 +150,11 @@ impl PatternNode {
                         (ty, field_name_to_ty)
                     }
                     None => {
-                        debug_assert!(typechcker.error_tolerant);
+                        assert!(
+                            typechcker.error_tolerant,
+                            "struct pattern head `{}` names no struct",
+                            tc.to_string()
+                        );
                         (
                             typechcker.fresh_ty_with_src(&self.info.source),
                             Map::default(),
@@ -173,7 +177,12 @@ impl PatternNode {
                     // struct has no such field. `validate_pattern` rejects both in strict
                     // mode and tolerates them in `error_tolerant` mode.
                     let Some(field_ty) = field_name_to_ty.get(field_name) else {
-                        debug_assert!(typechcker.error_tolerant);
+                        assert!(
+                            typechcker.error_tolerant,
+                            "struct `{}` has no field `{}`",
+                            tc.to_string(),
+                            field_name
+                        );
                         continue;
                     };
                     let unify_res = UnifOrOtherErr::extract_others(

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -130,8 +130,8 @@ impl PatternNode {
                 // `validate_pattern` requires the head to name a struct, so `None` arrives
                 // only in `error_tolerant` mode: the pattern then takes a fresh type
                 // variable, and its sub-patterns have no field type to match against.
-                let struct_info = typechcker.resolve_struct_tycon(tc, &self.info.source, false)?;
-                let (ty, field_name_to_ty) = match struct_info {
+                let tycon_info = typechcker.resolve_struct_tycon(tc, &self.info.source, false)?;
+                let (ty, field_name_to_ty) = match tycon_info {
                     Some(ti) => {
                         let ty = tc.get_struct_union_value_type(typechcker);
                         let field_tys = ty.field_types(&typechcker.type_env);

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -104,23 +104,23 @@ impl PatternNode {
     // Returns the pattern itself with a map which maps variable names to their types.
     pub fn get_typed(
         self: &Arc<PatternNode>,
-        typechcker: &mut TypeCheckContext,
+        typechecker: &mut TypeCheckContext,
     ) -> Result<(Arc<PatternNode>, Map<FullName, Arc<TypeNode>>), Errors> {
         match &self.pattern {
             Pattern::Var(v, ty) => {
                 let var_name = v.name.clone();
                 let ty = if ty.is_none() {
-                    typechcker.fresh_ty_with_src(&self.info.source)
+                    typechecker.fresh_ty_with_src(&self.info.source)
                 } else {
                     // If the annotation is ill-formed (e.g. references
                     // an unknown type), `error_tolerant` mode still
                     // wants this binder to participate in scope so the
                     // body can reference `var_name`; fall back to a
                     // fresh tyvar.
-                    let validated = typechcker.validate_type_annotation(ty.as_ref().unwrap());
-                    typechcker
+                    let validated = typechecker.validate_type_annotation(ty.as_ref().unwrap());
+                    typechecker
                         .tolerate(validated)?
-                        .unwrap_or_else(|| typechcker.fresh_ty_with_src(&self.info.source))
+                        .unwrap_or_else(|| typechecker.fresh_ty_with_src(&self.info.source))
                 };
                 let mut var_to_ty = Map::default();
                 var_to_ty.insert(var_name, ty.clone());
@@ -130,11 +130,11 @@ impl PatternNode {
                 // `validate_pattern` requires the head to name a struct, so `None` arrives
                 // only in `error_tolerant` mode: the pattern then takes a fresh type
                 // variable, and its sub-patterns have no field type to match against.
-                let tycon_info = typechcker.resolve_struct_tycon(tc, &self.info.source, false)?;
+                let tycon_info = typechecker.resolve_struct_tycon(tc, &self.info.source, false)?;
                 let (ty, field_name_to_ty) = match tycon_info {
                     Some(ti) => {
-                        let ty = tc.get_struct_union_value_type(typechcker);
-                        let field_tys = ty.field_types(&typechcker.type_env);
+                        let ty = tc.get_struct_union_value_type(typechecker);
+                        let field_tys = ty.field_types(&typechecker.type_env);
                         assert_eq!(ti.fields.len(), field_tys.len());
                         let field_name_to_ty = ti
                             .fields
@@ -146,12 +146,12 @@ impl PatternNode {
                     }
                     None => {
                         assert!(
-                            typechcker.error_tolerant,
+                            typechecker.error_tolerant,
                             "struct pattern head `{}` names no struct",
                             tc.to_string()
                         );
                         (
-                            typechcker.fresh_ty_with_src(&self.info.source),
+                            typechecker.fresh_ty_with_src(&self.info.source),
                             Map::default(),
                         )
                     }
@@ -164,8 +164,8 @@ impl PatternNode {
                     // type mismatch, …) substitutes a fresh-tyvar
                     // typed sub-pattern with no bindings, so the
                     // sibling fields are still walked.
-                    let typed = pat.get_typed(typechcker);
-                    let (typed_pat, var_ty) = typechcker.tolerate_pattern_typed(typed, pat)?;
+                    let typed = pat.get_typed(typechecker);
+                    let (typed_pat, var_ty) = typechecker.tolerate_pattern_typed(typed, pat)?;
                     *pat = typed_pat;
                     var_to_ty.extend(var_ty);
                     // No field type to unify against: the head names no struct, or the
@@ -173,7 +173,7 @@ impl PatternNode {
                     // mode and tolerates them in `error_tolerant` mode.
                     let Some(field_ty) = field_name_to_ty.get(field_name) else {
                         assert!(
-                            typechcker.error_tolerant,
+                            typechecker.error_tolerant,
                             "struct `{}` has no field `{}`",
                             tc.to_string(),
                             field_name
@@ -181,9 +181,9 @@ impl PatternNode {
                         continue;
                     };
                     let unify_res = UnifOrOtherErr::extract_others(
-                        typechcker.unify(&pat.info.type_.as_ref().unwrap(), field_ty),
+                        typechecker.unify(&pat.info.type_.as_ref().unwrap(), field_ty),
                     )?;
-                    if unify_res.is_err() && !typechcker.error_tolerant {
+                    if unify_res.is_err() && !typechecker.error_tolerant {
                         return Err(Errors::from_msg_srcs(
                             format!(
                                 "Inappropriate pattern `{}` for a value of field `{}` of struct `{}`.",
@@ -206,25 +206,25 @@ impl PatternNode {
             }
             Pattern::Union(variant_name, _, subpat) => {
                 let (variant_idx, tc, _ti) =
-                    Pattern::get_variant_info(&variant_name, &typechcker.type_env);
+                    Pattern::get_variant_info(&variant_name, &typechecker.type_env);
 
                 // Get the union type and variant type.
-                let union_ty = tc.get_struct_union_value_type(typechcker);
-                let variant_ty = union_ty.field_types(&typechcker.type_env)[variant_idx].clone();
+                let union_ty = tc.get_struct_union_value_type(typechecker);
+                let variant_ty = union_ty.field_types(&typechecker.type_env)[variant_idx].clone();
 
                 // Infer the type of the subpattern. In
                 // `error_tolerant` mode, a failure becomes a
                 // fresh-tyvar typed sub-pattern with no bindings — the
                 // surrounding union pattern still gets `union_ty`
                 // assigned, so the match arm can proceed.
-                let typed = subpat.get_typed(typechcker);
-                let (subpat, var_ty) = typechcker.tolerate_pattern_typed(typed, subpat)?;
+                let typed = subpat.get_typed(typechecker);
+                let (subpat, var_ty) = typechecker.tolerate_pattern_typed(typed, subpat)?;
 
                 // Unify the type of the subpattern with the type of the variant.
                 let unify_res = UnifOrOtherErr::extract_others(
-                    typechcker.unify(&subpat.info.type_.as_ref().unwrap(), &variant_ty),
+                    typechecker.unify(&subpat.info.type_.as_ref().unwrap(), &variant_ty),
                 )?;
-                if unify_res.is_err() && !typechcker.error_tolerant {
+                if unify_res.is_err() && !typechecker.error_tolerant {
                     return Err(Errors::from_msg_srcs(
                         format!(
                             "Inappropriate pattern `{}` for a value of variant `{}` of union `{}`.",
@@ -303,8 +303,8 @@ impl PatternNode {
             Pattern::Struct(tc, field_to_pat) => {
                 // Check if cursor is on any field-name span first.
                 for (name, name_src, pat) in field_to_pat {
-                    if let Some(ns) = name_src {
-                        if ns.includes_pos_lsp(pos) {
+                    if let Some(field_name_span) = name_src {
+                        if field_name_span.includes_pos_lsp(pos) {
                             return Some(EndNode::Field(tc.as_ref().clone(), name.clone()));
                         }
                     }
@@ -316,8 +316,10 @@ impl PatternNode {
                 Some(EndNode::Type(tc.as_ref().clone()))
             }
             Pattern::Union(variant, variant_src, subpat) => {
-                if let Some(vs) = variant_src {
-                    if vs.includes_pos_lsp(pos) && !variant.namespace.names.is_empty() {
+                if let Some(variant_name_span) = variant_src {
+                    if variant_name_span.includes_pos_lsp(pos)
+                        && !variant.namespace.names.is_empty()
+                    {
                         let tc = TyCon::new(variant.namespace.clone().to_fullname());
                         return Some(EndNode::Variant(tc, variant.name.clone()));
                     }
@@ -789,12 +791,12 @@ impl Pattern {
         match_src: &Option<Span>,
         pats: impl Iterator<Item = Arc<PatternNode>>,
     ) -> Result<(), Errors> {
-        let mut variants = cond_ti.fields.iter().map(|f| &f.name).collect::<Set<_>>();
+        let mut uncovered_variants = cond_ti.fields.iter().map(|f| &f.name).collect::<Set<_>>();
         let mut found_otherwise = false;
         for pat in pats {
             match &pat.pattern {
                 Pattern::Union(variant, _, _) => {
-                    if !variants.contains(&variant.name) {
+                    if !uncovered_variants.contains(&variant.name) {
                         return Err(Errors::from_msg_srcs(
                             format!(
                                 "`{}` is not a variant of union `{}`.",
@@ -804,24 +806,24 @@ impl Pattern {
                             &[&pat.info.source],
                         ));
                     }
-                    variants.remove(&variant.name);
+                    uncovered_variants.remove(&variant.name);
                 }
                 _ => {
                     found_otherwise = true;
                 }
             }
         }
-        if !found_otherwise && !variants.is_empty() {
-            let msg = if variants.len() == 1 {
+        if !found_otherwise && !uncovered_variants.is_empty() {
+            let msg = if uncovered_variants.len() == 1 {
                 format!(
                     "Variant `{}` of union `{}` is not covered.",
-                    variants.iter().next().unwrap(),
+                    uncovered_variants.iter().next().unwrap(),
                     cond_tc.to_string()
                 )
             } else {
                 format!(
                     "Variants {} of union `{}` are not covered.",
-                    variants
+                    uncovered_variants
                         .iter()
                         .map(|var| format!("`{}`", var))
                         .collect::<Vec<_>>()

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -100,8 +100,11 @@ impl PatternNode {
         }
     }
 
-    // Set `self.info.type_`.
-    // Returns the pattern itself with a map which maps variable names to their types.
+    /// Assign a type to the pattern and to each of its sub-patterns, taking a
+    /// fresh type variable wherever the source leaves the type open.
+    ///
+    /// # Returns
+    /// The typed pattern, and the type assigned to each variable name it binds.
     pub fn get_typed(
         self: &Arc<PatternNode>,
         typechecker: &mut TypeCheckContext,

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -425,6 +425,8 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// A copy of this variable pattern carrying `tyanno` as the type the user
+    /// wrote for the bound variable. Panics unless this is a variable pattern.
     pub fn set_var_tyanno(self: &PatternNode, tyanno: Option<Arc<TypeNode>>) -> Arc<PatternNode> {
         let mut node = self.clone();
         match &self.pattern {
@@ -439,6 +441,8 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// A copy of this struct pattern headed by `tc`, keeping its field
+    /// sub-patterns. Panics unless this is a struct pattern.
     pub fn set_struct_tycon(self: &PatternNode, tc: Arc<TyCon>) -> Arc<PatternNode> {
         let mut node = self.clone();
         match &self.pattern {
@@ -453,6 +457,10 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// A copy of this struct pattern matching the fields in `field_to_pat`,
+    /// keeping its head. Each entry is a field name, the span of that name in
+    /// the source, and the sub-pattern the field's value is matched against.
+    /// Panics unless this is a struct pattern.
     pub fn set_struct_field_to_pat(
         self: &PatternNode,
         field_to_pat: Vec<(Name, Option<Span>, Arc<PatternNode>)>,
@@ -470,6 +478,8 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// A copy of this union pattern matching the variant's payload against
+    /// `pat`, keeping its variant name. Panics unless this is a union pattern.
     pub fn set_union_pat(self: &PatternNode, pat: Arc<PatternNode>) -> Arc<PatternNode> {
         let mut node = self.clone();
         match &self.pattern {
@@ -492,6 +502,8 @@ impl PatternNode {
         matches!(&self.pattern, Pattern::Var(_, _))
     }
 
+    /// The variable this pattern binds. Panics unless this is a variable
+    /// pattern.
     pub fn get_var(&self) -> Arc<Var> {
         match &self.pattern {
             Pattern::Var(v, _) => v.clone(),

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -132,19 +132,32 @@ impl PatternNode {
                 Ok((self.set_type(ty), var_to_ty))
             }
             Pattern::Struct(tc, field_to_pat) => {
-                let ty = tc.get_struct_union_value_type(typechcker);
+                // `validate_pattern` requires the head to name a struct, so `None` arrives
+                // only in `error_tolerant` mode: the pattern then takes a fresh type
+                // variable, and its sub-patterns have no field type to match against.
+                let struct_info = typechcker.resolve_struct_tycon(tc, &self.info.source, false)?;
+                let (ty, field_name_to_ty) = match struct_info {
+                    Some(ti) => {
+                        let ty = tc.get_struct_union_value_type(typechcker);
+                        let field_tys = ty.field_types(&typechcker.type_env);
+                        assert_eq!(ti.fields.len(), field_tys.len());
+                        let field_name_to_ty = ti
+                            .fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, field)| (field.name.clone(), field_tys[i].clone()))
+                            .collect::<Map<_, _>>();
+                        (ty, field_name_to_ty)
+                    }
+                    None => {
+                        debug_assert!(typechcker.error_tolerant);
+                        (
+                            typechcker.fresh_ty_with_src(&self.info.source),
+                            Map::default(),
+                        )
+                    }
+                };
                 let mut var_to_ty = Map::default();
-                let field_tys = ty.field_types(&typechcker.type_env);
-                let fields = &typechcker.type_env.tycons.get(&tc).unwrap().fields;
-                assert_eq!(fields.len(), field_tys.len());
-                let field_name_to_ty = fields
-                    .iter()
-                    .enumerate()
-                    .map(|(i, field)| {
-                        let ty = field_tys[i].clone();
-                        (field.name.clone(), ty)
-                    })
-                    .collect::<Map<_, _>>();
                 let mut field_to_pat = field_to_pat.clone();
                 for (field_name, _, pat) in &mut field_to_pat {
                     // Type each sub-pattern. In `error_tolerant` mode
@@ -156,11 +169,9 @@ impl PatternNode {
                     let (typed_pat, var_ty) = typechcker.tolerate_pattern_typed(typed, pat)?;
                     *pat = typed_pat;
                     var_to_ty.extend(var_ty);
-                    // Unknown field name (filtered by
-                    // `validate_pattern` in strict mode, but tolerated
-                    // there in `error_tolerant` mode): skip the unify
-                    // — the struct definition has no field type to
-                    // match against.
+                    // No field type to unify against: the head names no struct, or the
+                    // struct has no such field. `validate_pattern` rejects both in strict
+                    // mode and tolerates them in `error_tolerant` mode.
                     let Some(field_ty) = field_name_to_ty.get(field_name) else {
                         debug_assert!(typechcker.error_tolerant);
                         continue;

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -36,11 +36,6 @@ impl PatternNode {
         match &self.pattern {
             Pattern::Var(_v, _ty) => {
                 // IGNORES user-provided type annotation!
-                // if let Some(ty) = ty {
-                //     if ty.to_string_normalize() != type_.to_string_normalize() {
-                //         return None;
-                //     }
-                // }
                 let pat = self.set_type(type_.clone());
                 Some(pat)
             }
@@ -431,7 +426,10 @@ impl PatternNode {
             Pattern::Var(v, _) => {
                 node.pattern = Pattern::Var(v.clone(), tyanno);
             }
-            _ => panic!(),
+            _ => panic!(
+                "`set_var_tyanno` requires a variable pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
         Arc::new(node)
     }
@@ -442,7 +440,10 @@ impl PatternNode {
             Pattern::Struct(_, field_to_pat) => {
                 node.pattern = Pattern::Struct(tc, field_to_pat.clone());
             }
-            _ => panic!(),
+            _ => panic!(
+                "`set_struct_tycon` requires a struct pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
         Arc::new(node)
     }
@@ -456,7 +457,10 @@ impl PatternNode {
             Pattern::Struct(tc, _) => {
                 node.pattern = Pattern::Struct(tc.clone(), field_to_pat);
             }
-            _ => panic!(),
+            _ => panic!(
+                "`set_struct_field_to_pat` requires a struct pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
         Arc::new(node)
     }
@@ -467,7 +471,10 @@ impl PatternNode {
             Pattern::Union(variant, variant_src, _) => {
                 node.pattern = Pattern::Union(variant.clone(), variant_src.clone(), pat);
             }
-            _ => panic!(),
+            _ => panic!(
+                "`set_union_pat` requires a union pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
         Arc::new(node)
     }
@@ -483,7 +490,10 @@ impl PatternNode {
     pub fn get_var(&self) -> Arc<Var> {
         match &self.pattern {
             Pattern::Var(v, _) => v.clone(),
-            _ => panic!(),
+            _ => panic!(
+                "`get_var` requires a variable pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
     }
 
@@ -520,10 +530,7 @@ impl PatternNode {
         fields: Vec<(Name, Arc<PatternNode>)>,
     ) -> Arc<PatternNode> {
         let fields = fields.into_iter().map(|(n, p)| (n, None, p)).collect();
-        Arc::new(PatternNode {
-            pattern: Pattern::Struct(tycon, fields),
-            info: PatternInfo::default(),
-        })
+        PatternNode::make_struct_with_spans(tycon, fields)
     }
 
     // Construct a struct destructuring pattern from `(field name,
@@ -593,7 +600,10 @@ impl PatternNode {
                     info: self.info.clone(),
                 }))
             }
-            _ => panic!(),
+            _ => panic!(
+                "`validate_variant_name` requires a union pattern, but got `{}`.",
+                self.to_string()
+            ),
         }
     }
 

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1532,7 +1532,7 @@ impl TypeCheckContext {
             Pattern::Struct(tc, pats) => {
                 // The head has to name a struct: the sub-patterns are matched against that
                 // struct's fields, and the value is destructured in its field order.
-                let struct_info = self.resolve_struct_tycon(tc, &pat.info.source, !tolerate)?;
+                let tycon_info = self.resolve_struct_tycon(tc, &pat.info.source, !tolerate)?;
                 let fields_pat = pats
                     .iter()
                     .map(|(name, _, _)| name.clone())
@@ -1543,10 +1543,11 @@ impl TypeCheckContext {
                         &[&pat.info.source],
                     ));
                 }
-                if let Some(ti) = struct_info {
-                    let fields_str = ti.fields.iter().map(|f| f.name.clone()).collect::<Set<_>>();
+                if let Some(ti) = tycon_info {
+                    let struct_field_names =
+                        ti.fields.iter().map(|f| f.name.clone()).collect::<Set<_>>();
                     for f in fields_pat {
-                        if !fields_str.contains(&f) && !tolerate {
+                        if !struct_field_names.contains(&f) && !tolerate {
                             return Err(Errors::from_msg_srcs(
                                 format!(
                                     "Unknown field `{}` for struct `{}`.",

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -620,9 +620,9 @@ impl TypeCheckContext {
         tc: &Arc<TyCon>,
         source: &Option<Span>,
         strict: bool,
-    ) -> Result<Option<TyConInfo>, Errors> {
+    ) -> Result<Option<&TyConInfo>, Errors> {
         match self.type_env.tycons.get(tc) {
-            Some(ti) if ti.variant == TyConVariant::Struct => Ok(Some(ti.clone())),
+            Some(ti) if ti.variant == TyConVariant::Struct => Ok(Some(ti)),
             Some(_) if strict => Err(Errors::from_msg_srcs(
                 format!("Type `{}` is not a struct.", tc.to_string()),
                 &[source],
@@ -1387,7 +1387,9 @@ impl TypeCheckContext {
                 // mode errors out on unknown / non-struct names;
                 // tolerant degrades to `None` so we can still type
                 // each field expression against a fresh tyvar.
-                let tycon_info = self.resolve_struct_tycon(tc, &ei.source, strict)?;
+                // The definition is taken by value because the steps below
+                // borrow the type checker mutably.
+                let tycon_info = self.resolve_struct_tycon(tc, &ei.source, strict)?.cloned();
 
                 // 2. Strict-only: reject missing or unknown fields
                 // with a rich diagnostic. Tolerant accepts the

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1060,6 +1060,10 @@ impl TypeCheckContext {
         })
     }
 
+    /// Elaborate `ei` against the expected type `ty`, one arm per `Expr`
+    /// variant, returning the expression annotated with its inferred type.
+    /// Each arm tolerates what it can in `error_tolerant` mode; what it
+    /// cannot is raised as an error.
     fn unify_type_of_expr_inner(
         &mut self,
         ei: &Arc<ExprNode>,
@@ -1399,8 +1403,8 @@ impl TypeCheckContext {
                 // 3. Compute the `name -> expected field type` map
                 // (after unifying the outer expected type with the
                 // constructed struct type). An empty map when the
-                // tycon didn't resolve, signalling step 4 to use
-                // fresh tyvars throughout.
+                // tycon didn't resolve, leaving every field
+                // expression to be typed against a fresh tyvar.
                 let known_field_tys =
                     self.compute_make_struct_field_tys(tc, tycon_info.as_ref(), &ty, &ei.source)?;
 
@@ -1511,7 +1515,10 @@ impl TypeCheckContext {
         }
     }
 
-    // Validate pattern and raise error if invalid,
+    /// Reject a pattern the elaboration cannot make sense of: a struct head
+    /// that names no struct, an unknown or duplicated field name, an
+    /// ill-formed type annotation, or a variable name bound twice. Recurses
+    /// into the sub-patterns.
     fn validate_pattern(&mut self, pat: &PatternNode) -> Result<(), Errors> {
         // In `error_tolerant` mode every gate below is downgraded to a
         // no-op so a single bad sub-check doesn't bail out of the whole
@@ -1584,6 +1591,14 @@ impl TypeCheckContext {
         Ok(())
     }
 
+    /// Say where each of `tvs` came from: for every type variable whose source
+    /// expression is known, a sentence naming it paired with that expression's
+    /// span, to hang off an error as extra source pointers.
+    ///
+    /// # Arguments
+    /// * `ref_no` — when the error text refers to several types by number, the
+    ///   number of the one these variables belong to; it is printed alongside
+    ///   each variable's name.
     pub fn create_tyvar_location_messages(
         &self,
         tvs: &[Arc<TyVar>],
@@ -1620,6 +1635,10 @@ impl TypeCheckContext {
         msg_srcs
     }
 
+    /// Build the "Type mismatch" error pointed at `source`: `expected_ty` and
+    /// `found_ty` with the current substitution applied, the constraint of
+    /// `unif_err` that could not be deduced, and a source pointer for every
+    /// type variable still free in them.
     fn create_type_mismatch_error(
         &self,
         expected_ty: &Arc<TypeNode>,

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1390,9 +1390,10 @@ impl TypeCheckContext {
                 // literal as-is so the user can keep typing inside a
                 // partially written struct literal.
                 if strict {
-                    if let Some(ti) = tycon_info.as_ref() {
-                        self.validate_make_struct_field_set(ti, tc, fields, &ei.source)?;
-                    }
+                    let ti = tycon_info
+                        .as_ref()
+                        .expect("strict mode resolves the head to a struct or reports an error");
+                    self.validate_make_struct_field_set(ti, tc, fields, &ei.source)?;
                 }
 
                 // 3. Compute the `name -> expected field type` map
@@ -1406,14 +1407,25 @@ impl TypeCheckContext {
                 // 4. Type each provided field expression in source
                 // order — matching the `Expr::App` convention that
                 // sub-expression side effects happen in the order
-                // the user wrote them. Unknown field names fall back
-                // to a fresh tyvar.
+                // the user wrote them.
                 let mut typed_fields = fields.clone();
                 for (name, _, field_expr) in typed_fields.iter_mut() {
-                    let field_ty = known_field_tys
-                        .get(name)
-                        .cloned()
-                        .unwrap_or_else(|| self.fresh_ty_with_src(&field_expr.source));
+                    let field_ty = match known_field_tys.get(name) {
+                        Some(field_ty) => field_ty.clone(),
+                        None => {
+                            // No expected type to check the field expression against: the head
+                            // names no struct, or the struct has no such field.
+                            // `validate_make_struct_field_set` rejects both in strict mode and
+                            // tolerates them in `error_tolerant` mode.
+                            assert!(
+                                self.error_tolerant,
+                                "struct `{}` has no field `{}`",
+                                tc.to_string(),
+                                name
+                            );
+                            self.fresh_ty_with_src(&field_expr.source)
+                        }
+                    };
                     *field_expr = self.unify_type_of_expr(field_expr, field_ty)?;
                 }
 
@@ -1423,9 +1435,10 @@ impl TypeCheckContext {
                 // tree may be structurally ill-formed for codegen,
                 // but tolerant elaborates aren't fed to codegen.
                 if strict {
-                    if let Some(ti) = tycon_info.as_ref() {
-                        typed_fields = reorder_make_struct_fields_to_def_order(ti, typed_fields);
-                    }
+                    let ti = tycon_info
+                        .as_ref()
+                        .expect("strict mode resolves the head to a struct or reports an error");
+                    typed_fields = reorder_make_struct_fields_to_def_order(ti, typed_fields);
                 }
 
                 Ok(ei.set_make_struct_fields(typed_fields))

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -610,11 +610,12 @@ impl TypeCheckContext {
         }))
     }
 
-    /// Resolve `tc` to its struct definition for `Expr::MakeStruct`
-    /// elaboration. In strict mode, an unknown or non-struct tycon
-    /// is an error; in tolerant mode it degrades to `None`, letting
-    /// the caller type each field expression against a fresh tyvar.
-    fn resolve_struct_tycon(
+    /// Resolve `tc`, the head of a struct literal or of a struct
+    /// pattern, to its struct definition. In strict mode, an unknown
+    /// or non-struct tycon is an error; in tolerant mode it degrades
+    /// to `None`, letting the caller fall back to fresh type
+    /// variables for the fields.
+    pub fn resolve_struct_tycon(
         &self,
         tc: &Arc<TyCon>,
         source: &Option<Span>,
@@ -1516,8 +1517,9 @@ impl TypeCheckContext {
                 }
             }
             Pattern::Struct(tc, pats) => {
-                let ti = self.type_env.tycons.get(&tc).unwrap();
-                let fields_str = ti.fields.iter().map(|f| f.name.clone()).collect::<Set<_>>();
+                // The head has to name a struct: the sub-patterns are matched against that
+                // struct's fields, and the value is destructured in its field order.
+                let struct_info = self.resolve_struct_tycon(tc, &pat.info.source, !tolerate)?;
                 let fields_pat = pats
                     .iter()
                     .map(|(name, _, _)| name.clone())
@@ -1528,16 +1530,19 @@ impl TypeCheckContext {
                         &[&pat.info.source],
                     ));
                 }
-                for f in fields_pat {
-                    if !fields_str.contains(&f) && !tolerate {
-                        return Err(Errors::from_msg_srcs(
-                            format!(
-                                "Unknown field `{}` for struct `{}`.",
-                                f,
-                                tc.name.to_string()
-                            ),
-                            &[&pat.info.source],
-                        ));
+                if let Some(ti) = struct_info {
+                    let fields_str = ti.fields.iter().map(|f| f.name.clone()).collect::<Set<_>>();
+                    for f in fields_pat {
+                        if !fields_str.contains(&f) && !tolerate {
+                            return Err(Errors::from_msg_srcs(
+                                format!(
+                                    "Unknown field `{}` for struct `{}`.",
+                                    f,
+                                    tc.name.to_string()
+                                ),
+                                &[&pat.info.source],
+                            ));
+                        }
                     }
                 }
                 for (_, _, p) in pats {

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1533,11 +1533,11 @@ impl TypeCheckContext {
                 // The head has to name a struct: the sub-patterns are matched against that
                 // struct's fields, and the value is destructured in its field order.
                 let tycon_info = self.resolve_struct_tycon(tc, &pat.info.source, !tolerate)?;
-                let fields_pat = pats
+                let pattern_field_names = pats
                     .iter()
                     .map(|(name, _, _)| name.clone())
                     .collect::<Set<_>>();
-                if fields_pat.len() < pats.len() && !tolerate {
+                if pattern_field_names.len() < pats.len() && !tolerate {
                     return Err(Errors::from_msg_srcs(
                         "Duplicate field in struct pattern.".to_string(),
                         &[&pat.info.source],
@@ -1546,12 +1546,12 @@ impl TypeCheckContext {
                 if let Some(ti) = tycon_info {
                     let struct_field_names =
                         ti.fields.iter().map(|f| f.name.clone()).collect::<Set<_>>();
-                    for f in fields_pat {
-                        if !struct_field_names.contains(&f) && !tolerate {
+                    for field_name in pattern_field_names {
+                        if !struct_field_names.contains(&field_name) && !tolerate {
                             return Err(Errors::from_msg_srcs(
                                 format!(
                                     "Unknown field `{}` for struct `{}`.",
-                                    f,
+                                    field_name,
                                     tc.name.to_string()
                                 ),
                                 &[&pat.info.source],

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7421,6 +7421,10 @@ pub fn test_tuple_functor() {
     "##;
     test_source(&source, Configuration::develop_mode());
 }
+
+/// Verifies that a struct declared with no fields can be constructed as
+/// `Empty {}` and given a trait implementation, in each of the plain, `box`
+/// and `unbox` forms.
 #[test]
 pub fn test_empty_struct() {
     let source = r##"
@@ -7455,6 +7459,8 @@ pub fn test_empty_struct() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Verifies that a struct literal whose head names a union is reported as an
+/// error.
 #[test]
 pub fn test_make_struct_to_union() {
     let source = r##"
@@ -7606,6 +7612,8 @@ pub fn test_struct_pattern_head_is_associated_type() {
     );
 }
 
+/// Verifies that `!` parses as negation whether or not a space separates it
+/// from its operand, so `if ! (1 == 2) { .. }` compiles like `if !(1 == 2)`.
 #[test]
 pub fn test_regression_issue_46() {
     let source = r##"
@@ -7626,6 +7634,8 @@ pub fn test_regression_issue_46() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Verifies that reading from a handle already given to `close_file` raises a
+/// catchable error naming the closed handle, rather than reading anything.
 #[test]
 pub fn test_read_file_after_close() {
     let source = r##"
@@ -7645,6 +7655,8 @@ pub fn test_read_file_after_close() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Verifies that a struct and a union may each name their own type inside a
+/// field, as long as the occurrence sits behind a function arrow.
 #[test]
 pub fn test_circular_type_definition() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7482,6 +7482,119 @@ pub fn test_make_struct_to_union() {
     );
 }
 
+// The head of a struct pattern has to name a struct: the sub-patterns are matched against that
+// struct's fields. Read as a field list, a union's variant list would make the pattern bind the
+// tag of the value in place of the payload it names.
+
+#[test]
+pub fn test_struct_pattern_head_is_union() {
+    let source = r##"
+        module Main;
+
+        type Foo = union {
+            foo: I64,
+            bar: Bool
+        };
+
+        main: IO ();
+        main = (
+            let Foo { foo: x } = Foo::foo(1);
+            println(x.to_string)
+        );
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Type `Main::Foo` is not a struct.",
+    );
+}
+
+#[test]
+pub fn test_struct_pattern_head_is_union_in_match_arm() {
+    let source = r##"
+        module Main;
+
+        type Foo = union {
+            foo: I64,
+            bar: Bool
+        };
+
+        main: IO ();
+        main = (
+            let x = match Foo::foo(1) {
+                Foo { foo: x } => x
+            };
+            println(x.to_string)
+        );
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Type `Main::Foo` is not a struct.",
+    );
+}
+
+#[test]
+pub fn test_struct_pattern_head_is_union_in_lambda_parameter() {
+    let source = r##"
+        module Main;
+
+        type Foo = union {
+            foo: I64,
+            bar: Bool
+        };
+
+        main: IO ();
+        main = (
+            let get_foo = |Foo { foo: x }| x;
+            println(get_foo(Foo::foo(1)).to_string)
+        );
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Type `Main::Foo` is not a struct.",
+    );
+}
+
+#[test]
+pub fn test_struct_pattern_head_is_primitive_type() {
+    let source = r##"
+        module Main;
+
+        main: IO ();
+        main = (
+            let I64 { foo: x } = 42;
+            println(x.to_string)
+        );
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Type `Std::I64` is not a struct.",
+    );
+}
+
+// An associated type name resolves like a type name, so it reaches the pattern as a type
+// constructor that no type declares.
+#[test]
+pub fn test_struct_pattern_head_is_associated_type() {
+    let source = r##"
+        module Main;
+
+        main: IO ();
+        main = (
+            let Item { foo: x } = 42;
+            println(x.to_string)
+        );
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Unknown type name `Std::Iterator::Item`.",
+    );
+}
+
 #[test]
 pub fn test_regression_issue_46() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7486,6 +7486,8 @@ pub fn test_make_struct_to_union() {
 // struct's fields. Read as a field list, a union's variant list would make the pattern bind the
 // tag of the value in place of the payload it names.
 
+/// Verifies that a struct pattern headed by a union type is reported as an
+/// error in a `let` binding.
 #[test]
 pub fn test_struct_pattern_head_is_union() {
     let source = r##"
@@ -7509,6 +7511,9 @@ pub fn test_struct_pattern_head_is_union() {
     );
 }
 
+/// Verifies that a struct pattern headed by a union type is reported as an
+/// error in a `match` arm, where the type of the matched value already agrees
+/// with the head.
 #[test]
 pub fn test_struct_pattern_head_is_union_in_match_arm() {
     let source = r##"
@@ -7534,6 +7539,9 @@ pub fn test_struct_pattern_head_is_union_in_match_arm() {
     );
 }
 
+/// Verifies that a struct pattern headed by a union type is reported as an
+/// error in a lambda parameter, where the pattern drives the inference of the
+/// parameter's type.
 #[test]
 pub fn test_struct_pattern_head_is_union_in_lambda_parameter() {
     let source = r##"
@@ -7557,6 +7565,8 @@ pub fn test_struct_pattern_head_is_union_in_lambda_parameter() {
     );
 }
 
+/// Verifies that a struct pattern headed by a primitive type, which carries no
+/// fields at all, is reported as an error.
 #[test]
 pub fn test_struct_pattern_head_is_primitive_type() {
     let source = r##"
@@ -7575,8 +7585,9 @@ pub fn test_struct_pattern_head_is_primitive_type() {
     );
 }
 
-// An associated type name resolves like a type name, so it reaches the pattern as a type
-// constructor that no type declares.
+/// Verifies that a struct pattern headed by an associated type name is reported
+/// as an error: such a name resolves like a type name, so it reaches the
+/// pattern as a type constructor that no type declares.
 #[test]
 pub fn test_struct_pattern_head_is_associated_type() {
     let source = r##"

--- a/src/tests/test_lsp/cases/completion-struct-pattern-head/fixproj.toml
+++ b/src/tests/test_lsp/cases/completion-struct-pattern-head/fixproj.toml
@@ -1,0 +1,6 @@
+[general]
+name = "completion-struct-pattern-head"
+version = "0.1.0"
+
+[build]
+files = ["main.fix"]

--- a/src/tests/test_lsp/cases/completion-struct-pattern-head/main.fix
+++ b/src/tests/test_lsp/cases/completion-struct-pattern-head/main.fix
@@ -1,0 +1,8 @@
+module Main;
+
+main : IO () = (
+    let Item { data : d } = 42;
+    let arr = [1, 2, 3];
+    let _ = arr.
+    pure()
+);

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::{Duration, Instant},
     };
@@ -543,8 +544,6 @@ mod tests {
     /// any fix lands; once it passes the regression is closed.
     #[test]
     fn test_completion_dot_sort_stale_snapshot_after_dot_added() {
-        use std::fs;
-
         let (temp_dir, project_dir) = setup_test_env("completion-dot-sort-stale");
         let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
         client
@@ -712,7 +711,7 @@ mod tests {
         // dot-context extractor actually observed as the receiver
         // type (it logs `dot-context receiver type: <ty>`).
         let log_path = ctx.project_dir.join(".fixlang/fix.log");
-        if let Ok(log_content) = std::fs::read_to_string(&log_path) {
+        if let Ok(log_content) = fs::read_to_string(&log_path) {
             let completion_log: String = log_content
                 .lines()
                 .filter(|l| l.contains("[completion]"))

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -14,12 +14,20 @@ mod tests {
     };
     use tempfile::TempDir;
 
+    /// The directory holding the LSP test projects, one subdirectory per
+    /// project, named as the tests name it.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_lsp/cases");
         path
     }
 
+    /// Copy the test project `project_name` into a temporary directory of its
+    /// own, so tests that build and edit it can run in parallel.
+    ///
+    /// # Returns
+    /// The guard whose drop deletes the copy, and the canonicalized path of
+    /// the copied project.
     fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let test_case_src = get_test_cases_dir().join(project_name);
@@ -74,13 +82,23 @@ mod tests {
         }
     }
 
+    /// A language server running over a private copy of one test project,
+    /// ready to answer completion requests against that copy's files.
     struct LspCompletionCtx {
+        /// The client end of the server's stdio connection.
         client: LspClient,
+        /// Absolute path of the project copy, the base of every file URI.
         project_dir: PathBuf,
+        /// Kept alive so the copy outlives the server; its drop deletes the
+        /// copy.
         _temp_dir: TempDir,
     }
 
     impl LspCompletionCtx {
+        /// Start a server over a fresh copy of `project_name` and open each of
+        /// `files`, paths relative to the project root, in the given order.
+        /// Returns once the server has published diagnostics for the last of
+        /// them, so the project has been type-checked.
         fn setup(project_name: &str, files: &[&str]) -> Self {
             let (temp_dir, project_dir) = setup_test_env(project_name);
             let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
@@ -101,6 +119,8 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path
+        /// relative to the project root.
         fn file_uri(&self, file: &str) -> String {
             format!("file://{}", self.project_dir.join(file).display())
         }

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -935,8 +935,8 @@ mod tests {
     /// associated type of `Std::Iterator` — is an error the strict
     /// typechecker reports. The completion pipeline runs
     /// `error_tolerant`, so it walks past that pattern and has to
-    /// keep serving the rest of the body: the `arr.` receiver two
-    /// lines below still earns its `Array I64` type, which puts
+    /// keep serving the rest of the body: the `arr.` receiver further
+    /// down the same body still earns its `Array I64` type, which puts
     /// `Std::Array::push_back` in Tier 0.
     #[test]
     fn test_completion_dot_sort_past_bad_struct_pattern() {

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -932,6 +932,43 @@ mod tests {
         ctx.shutdown();
     }
 
+    /// A struct pattern whose head names no struct — here `Item`, an
+    /// associated type of `Std::Iterator` — is an error the strict
+    /// typechecker reports. The completion pipeline runs
+    /// `error_tolerant`, so it walks past that pattern and has to
+    /// keep serving the rest of the body: the `arr.` receiver two
+    /// lines below still earns its `Array I64` type, which puts
+    /// `Std::Array::push_back` in Tier 0.
+    #[test]
+    fn test_completion_dot_sort_past_bad_struct_pattern() {
+        let mut ctx = LspCompletionCtx::setup("completion-struct-pattern-head", &["main.fix"]);
+
+        // main.fix layout (0-indexed):
+        //   0: module Main;
+        //   1: (blank)
+        //   2: main : IO () = (
+        //   3:     let Item { data : d } = 42;
+        //   4:     let arr = [1, 2, 3];
+        //   5:     let _ = arr.   <-- cursor right after the dot
+        //   6:     pure()
+        //   7: );
+        //
+        // Column 16 = byte just after `.` on `    let _ = arr.`.
+        let items = ctx.complete("main.fix", 5, 16);
+
+        let sort_push_back = find_sort_text(&items, "Std::Array::push_back")
+            .expect("Std::Array::push_back should be a candidate");
+        assert!(
+            sort_push_back.starts_with('0'),
+            "Std::Array::push_back should land in Tier 0 for an Array I64 \
+             receiver even though an earlier pattern in the same body has a \
+             bad head; got {:?}",
+            sort_push_back,
+        );
+
+        ctx.shutdown();
+    }
+
     /// When the user types a bare identifier (`mpq`) in a non-dot
     /// context after `import GMP.Q;`, the `GMP.Q::mpq` global must
     /// (a) appear in the completion response and (b) carry a


### PR DESCRIPTION
Fixes #168.

struct パターンは、先頭に書かれた型が struct であるかを検査していませんでした。union を書くとビルドが LLVM の verifier で落ち、関連型の名前を書くとコンパイラが panic します。この PR はその検査を入れます。

```fix
type MyU = union { a : I64, b : Bool };

main : IO () = (
    let u = MyU::a(1);
    let MyU { a : x } = u;      // union を struct パターンの先頭に書ける
    println(x.to_string)
);
```

```
Call parameter type does not match function signature!
LLVM ERROR: Broken module found, compilation aborted!
```

```fix
main : IO () = (
    let Item { data : x } = 42;  // `Item` は `Std::Iterator` の関連型
    println("done")
);
```

```
thread '<unnamed>' panicked at src/elaboration/typecheck.rs:1519:56:
called `Option::unwrap()` on a `None` value
```

以下、まず道具立て (コンパイラが型とパターンをどう持っているか) を述べ、次に何が起きていたか、最後に修正を述べます。

## 道具立て 1: 型構築子とその情報

Fix の型は、`type Point = struct { x : I64, y : I64 };` や `type MyU = union { a : I64, b : Bool };` のような宣言と、`I64` や `Ptr` のような組み込みの基本型からなります。どちらもコンパイラの中では**型構築子 (type constructor)** という 1 つの概念で扱われ、名前 (`TyCon`) から次の情報が引けます。

```rust
struct TyConInfo {
    variant: TyConVariant,   // Primitive / Struct / Union / Array / ...
    fields: Vec<Field>,      // 下記
    tyvars: Vec<Arc<TyVar>>, // 型引数
    is_unbox: bool,
    ...
}

struct Field {
    name: Name,              // フィールド名または variant 名
    ty: Arc<TypeNode>,       // フィールドの型または variant の payload 型
    ...
}
```

この設計の要点は **`fields` が 2 つの役を兼ねている**ことです。`variant` が `Struct` なら `fields` は宣言されたフィールドの一覧、`Union` なら variant の一覧です。`Primitive` なら空です。したがって `fields` を読む側は、それがどちらの意味なのかを `variant` を見て自分で決めなければなりません。

型構築子の一覧は型検査器が `TypeEnv.tycons: Map<TyCon, TyConInfo>` として持ちます。ここに載っているのは実際に宣言された型だけで、後で出てくる関連型の名前は載りません。

## 道具立て 2: パターンの表現

パターンの構文木は 3 種類です。

```rust
enum Pattern {
    Var(Arc<Var>, Option<Arc<TypeNode>>),                    // x, x : I64
    Struct(Arc<TyCon>, Vec<(Name, Option<Span>, PatternNode)>), // Point { x : a, y : b }
    Union(FullName, Option<Span>, Arc<PatternNode>),          // some(x)
}
```

`Struct` の第 1 引数が本 PR の主題である「先頭の型構築子」です。タプルのパターン `(a, b)` も、組み込みのタプル型を先頭に持つ `Struct` として表現されます。`Union` は `match` の腕でしか書けません (文法上そうなっていることは後で示します)。

## 道具立て 3: パターンが通る 2 つの関門

`let {pattern} = {expr};` や `match` の腕を型検査するとき、パターンは次の 2 つの関数をこの順で通ります。宣言は次のとおりです。

```rust
// パターンが型検査の理解できない形をしていれば診断を返す。部分パターンにも再帰する。
fn validate_pattern(&mut self, pat: &PatternNode) -> Result<(), Errors>;

// パターン自身と各部分パターンに型を与え、束縛される変数名とその型の対応を返す。
fn get_typed(self: &Arc<PatternNode>, typechecker: &mut TypeCheckContext)
    -> Result<(Arc<PatternNode>, Map<FullName, Arc<TypeNode>>), Errors>;
```

前者は「このパターンは意味を成すか」を、後者は「では各部分にどの型が付くか」を担当します。struct パターンの場合、後者が部分パターンに与える型は、先頭の型構築子の `fields` から取ってきたフィールドの型です。

もう 1 つ、この PR に関わるモードがあります。型検査器は `error_tolerant` というフラグを持ち、これが立っているとき、検査の失敗は診断を出して止まるのではなく、その場を適当な型で埋めて先に進みます。言語サーバの補完がこれを使います。ユーザが編集中のバッファは大抵どこかが壊れているので、壊れた箇所で止まってしまうとカーソル位置の型が分からず、補完候補を絞れないからです。

## 何が起きていたか

`validate_pattern` の struct パターンの腕は、先頭の型構築子を、その種別を見ずに引いていました。

```
Pattern::Struct(tc, pats):
    ti := tycons[tc]                      // 見つからなければ panic
    struct_field_names := ti.fields の名前の集合
    if パターン中に同じフィールド名が 2 回:  診断
    for f in パターン中のフィールド名:
        if f not in struct_field_names:   診断
    各部分パターンに再帰
```

`ti.fields` を「struct のフィールド一覧」として使っていますが、`ti` が struct であることは誰も確かめていません。ここから 3 つのことが通ります。

### union を先頭に書いた場合

union の `fields` は variant の一覧です。これをフィールド一覧として読むと、`MyU { a : x }` は「variant `a` の payload を取り出す」パターンとして型が付きます。タグが `a` であることの検査は付きません。

`get_typed` がパターンの型を組み立てるのに使う関数は、先頭が struct **または union** であることを表明します。union はここも通ります。

そしてコード生成は、struct の分解を**位置**で行います。「i 番目のフィールドを取り出す」という操作です。union の値の実行時表現は `{タグ, payload の入る領域}` で、タグが 0 番です。よって `MyU { a : x }` は `x` に**タグ**を読み込みます。

`a : I64` の payload が来るはずの場所に 1 バイトのタグが来るので、生成されたモジュールは LLVM の verifier に弾かれます。`-O` のどのレベルでも、`let` でも `match` の腕でも lambda の引数でも同じで、`Std::Option` のような標準ライブラリの union でも同じです。ビルドが落ちるのであって誤ったコードが出るわけではありませんが、それは verifier が型の食い違いを見つけられる間だけの話です。payload の実行時表現がタグと同じ型になる union なら、verifier は何も言いません。

### 関連型の名前を先頭に書いた場合

Fix には**関連型**があります。`trait a : Iterator { type Item a; ... }` のように、トレイトが型を 1 つ持ち、実装ごとに具体的な型が決まる仕組みです。`Item` はトレイトの中でだけ意味を持つ名前で、宣言された型ではありません。

パターンの先頭の名前を解決する処理は、型構築子の名前と関連型の名前の両方を受け付けます。よって `Item` は `Std::Iterator::Item` に解決され、`Pattern::Struct` の先頭としてそのまま型検査に届きます。ところが `Std::Iterator::Item` は宣言された型ではないので `tycons` に載っておらず、上の擬似コードの 1 行目が panic します。

`error_tolerant` モードもこの行を守っていませんでした。上に書いたとおり、このモードは言語サーバの補完が使います。したがって、編集中のファイルのどこかにこの形のパターンが 1 つあるだけで、そのファイル内のどこで補完を要求しても、補完のプロセスが落ちて応答が返りません。

どこにも存在しない名前は別の経路をたどります。名前解決の段階で先に弾かれ、`Unknown type or associated type name 'NoSuchType'.` になります。panic するのは「名前としては解決できるが型構築子ではない」場合だけです。

### 基本型を先頭に書いた場合

`Std::I64` の `fields` は空です。よって未知フィールドの検査が先に発火し、ビルドは失敗します。ただし診断はフィールドのせいにしていて、本当の間違いである先頭に触れません。

```
error: Unknown field `x` for struct `Std::I64`.
```

## なぜここだけ抜けていたのか

同じ問いは、型検査器の中で既に 2 回立てられています。

**struct リテラル** `Point { x : 1, y : 2 }` の型検査は `resolve_struct_tycon` を通ります。これは先頭の名前を型構築子の表で引き、宣言された struct であればその情報を返し、そうでなければ診断を返す関数です。

**`match` の被検査値**は `resolve_match_cond_tycon` を通ります。こちらは被検査値の型を確定させ、それが union であることを要求します。

struct パターンの腕だけが、どちらの検査もせずに表を直接引いていました。

## 修正

### 先頭の解決を struct リテラルと同じ関数に載せる

`validate_pattern` の struct パターンの腕が、リテラル側と同じ `resolve_struct_tycon` を通るようにしました。

```rust
fn resolve_struct_tycon(&self, tc: &Arc<TyCon>, source: &Option<Span>, strict: bool)
    -> Result<Option<&TyConInfo>, Errors>;
```

`strict` は「厳しく検査するか」で、`error_tolerant` モードでない通常のビルドでは真です。答えは 3 通りです。

| `tc` が指すもの | `strict` が真 | `strict` が偽 |
| --- | --- | --- |
| 宣言された struct | その情報 | その情報 |
| struct でない型構築子 | 診断 `Type '...' is not a struct.` | `None` |
| 表に無い名前 | 診断 `Unknown type name '...'.` | `None` |

表を直接引いていた行が消えるので、関連型を先頭に書いたときの panic もこれで無くなります。パターンとリテラルが同じ関数を通るので、同じ先頭に対して同じ診断が出るようになります。

### `error_tolerant` モードでは型変数で埋めて先に進む

`strict` が偽のとき `resolve_struct_tycon` は診断を出さずに `None` を返します。これを受けて `get_typed` は、パターン自身に新しい型変数を与え、各部分パターンをフィールドの型と突き合わせずにそれ自身で型付けします。部分パターンが束縛する変数はそのまま本体のスコープに入るので、補完は残りの本体を読み続けられます。

厳しい検査の側でこの `None` が来ることはありません。`validate_pattern` が先に診断を返して止まるからです。その不変条件は `assert!` で書いてあります。

### 診断の変化

| ソース | 修正前 | 修正後 |
| --- | --- | --- |
| `let MyU { a : x } = u;` | `LLVM ERROR: Broken module found` | error: Type `Main::MyU` is not a struct. |
| 同じものを `match` の腕で | 同上 | 同上 |
| 同じものを lambda の引数で | 同上 | 同上 |
| `let Option { some : x } = ...;` | 同上 | error: Type `Std::Option` is not a struct. |
| `let Pair { u : MyU { a : v }, n : m } = p;` | 同上 | error: Type `Main::MyU` is not a struct. |
| `let I64 { x : v } = 42;` | error: Unknown field `x` for struct `Std::I64`. | error: Type `Std::I64` is not a struct. |
| `let Item { data : x } = 42;` | `panicked at ... unwrap() on a None value` | error: Unknown type name `Std::Iterator::Item`. |
| `let NoSuchType { data : x } = 42;` | error: Unknown type or associated type name `NoSuchType`. | 変わらず |

最後の 2 行は並べて読んでください。関連型に対する `Unknown type name` は、名前解決が受理した名前を「知らない」と言っている点で不正確です。ただしこれは struct リテラル `Item { data : 42 }` が既に出している文言と一字一句同じで、パターンとリテラルは揃っています。正確にすると両方の診断が変わるので、この PR には入れていません (「残した課題」参照)。

## union パターンには同種の穴が無い

対になる問いは、union パターンの側にも同じ形の穴があるか、です。union パターンの variant 名を検証するのは `match` の腕の処理だけなので、もし union パターンが `match` 以外の場所に書けるなら、その検証を素通りして同じ panic に届きます。

書けません。文法が union パターンを `match` の腕に限っており、他の位置は構文エラーになります。

```
let MyU::a(x) = u;                       -> error: Expected capital_name.
let Pair { u : MyU::a(v), n : m } = p;   -> error: Expected capital_name.
```

## 先頭の解決で型の定義を複製しない

`resolve_struct_tycon` は元々、見つけた `TyConInfo` の**複製**を返していました。この複製は安くありません。`fields: Vec<Field>` が要素ごとに複製され、`Field` はフィールド名 (`String`) と、ソース上の位置を指す `Span` を 2 つ持ち、`Span` はファイルパス (`PathBuf`) を持つからです。

struct リテラル 1 個につき 1 回なら目立ちませんでした。しかしパターンの経路を同じ関数に載せると、**struct パターン 1 個につき 2 回** — `validate_pattern` と `get_typed` でそれぞれ 1 回 — 払うことになります。タプルの分解も struct パターンなので、これは普通の Fix プログラムで頻繁に起きます。付録 A のとおり、struct/タプルのパターンを 12,000 個含むプログラムの型検査で +0.31% でした。

そこで `resolve_struct_tycon` は借用を返すようにしました。`validate_pattern` はそこからフィールド名の集合を作るだけなので借用のままで足り、`get_typed` は型検査器を可変借用する呼び出しの前に必要なフィールド名を取り出します。所有が要るのは struct リテラルの側だけ — こちらは後続の手順が型検査器を可変借用しながら定義を持ち続けます — なので、そこだけが呼び出し箇所で複製を取ります。結果は `origin/main` と同等になりました。

## テスト

6 本追加しました。

- `test_basic.rs` に 5 本: union を先頭にした `let` / `match` の腕 / lambda の引数、基本型を先頭にしたもの、関連型を先頭にしたもの。いずれもコンパイルが指定の診断で失敗することを確認します。
- `test_completion.rs` に 1 本: 関連型を先頭にしたパターンを含む本体の中で補完を要求し、その 2 行下にある配列のレシーバがちゃんと `Array I64` と推論されていることを確認します。これが `error_tolerant` の経路を踏む唯一のテストです。

6 本とも、修正を戻すと落ちることを確認しています (付録 B)。

## コードレビュー

`code-review` スキルをこのブランチに適用しました。その修正はアスペクトごと・モードごとに分かれたコミットとして上に乗っているので、個別に判断・取り消しができます。

- `5a06e0f4` — 2 つの `debug_assert!` を、違反した値をメッセージに含む `assert!` に変更。このプロジェクトはテストを `cargo test --release` で走らせるので、`debug_assert!` はそれを働かせたい実行から消えていました。
- `86509d3b` — struct リテラルの厳しい経路で `if let Some(ti)` を `.expect(...)` に変更。厳しいモードでは `resolve_struct_tycon` は情報を返すか診断を返すかのどちらかなので、この分岐が黙って飛ばしていた場合は到達不能でした。しかも飛ばしていたのは**フィールドを宣言順に並べ替える処理**で、コード生成はフィールドを位置で読みます。到達した場合に飛ばすと、落ちるのではなく黙って誤ったコードが出ます。
- `a59ecb8f`, `6fc804af` — 名前: `struct_info` -> `tycon_info` (既存の呼び出し側が使っている語)、`fields_str` -> `struct_field_names`、および長く残っていた `typechcker` という綴り。
- `791ca51a`, `c624d6f1`, `106db58e` — import、doc コメント、changelog の文言。

`cargo fmt` は変更なし。上の借用化 (`12bf63bd`) もレビュー由来で、3 つのアスペクトが別々にこの複製に到達しました。

レビューは、この変更とは無関係な既存の不具合を 2 つ再現もしました。struct リテラルのフィールド重複でコンパイラが落ちる件 (issue #169)、および `match` の腕を重複させると `` `Main::Foo::a` is not a variant of union `Main::Foo` `` という誤った診断が出る件 — 後者は issue #175 の 6 件には含まれていません。

## 残した課題

- **関連型に対する診断の文言。** 正確にするには、`resolve_struct_tycon` の厳しい側の 2 つの答えを `Type '...' is not a struct.` にまとめるか、トレイトの情報を引いて「関連型であって struct ではない」と述べるかです。どちらも struct リテラル側の診断を変えるので、この PR には入れていません。
- **先頭を 2 回解決している。** struct リテラルは 1 回解決して両方の手順に渡します。パターン側も同じ形にできますが、未知フィールドの診断を検査側から型付け側へ移すことになり、複数の誤りがあるときにどれが先に出るかが変わります。
- **フィールド名から型への対応を作る処理が 2 か所にある。** struct リテラル側の既存の関数と同じものを `get_typed` が書き直しています。共通化すれば、`zip` を使っていて長さの食い違いを黙って切り捨てる既存側にも、長さの表明が付きます。
- **`resolve_struct_tycon` の `strict` 引数**は、3 つの呼び出し箇所すべてで `self.error_tolerant` から導出できます。
- **テストの穴が 3 つ。** union を先頭にしたものを `error_tolerant` モードで通す経路 (この変更で言語サーバの推論結果が変わる箇所)、`error_tolerant` の退避が部分パターンの束縛を残すこと、正しい先頭の下に入れ子になった誤った先頭 (上の表では手で確認しましたが、テストにはしていません)。

## 付録 A: 型検査の命令数

共有マシンでの計測なので、実時間ではなく命令数を見ます。300 個の関数に struct/タプルのパターンを合計 12,000 個含む Fix プログラムを生成し、`fix check` (型検査まで、コード生成なし) を `perf stat -e instructions:u` で 3 回ずつ計測しました。3 回のばらつきはいずれも 0.01% 未満です。

| | 命令数 |
| --- | --- |
| `origin/main` | 24.811 G |
| 本ブランチ、複製を返す版 | 24.887 G (+0.31%) |
| 本ブランチ、借用を返す版 | 24.809 G |

## 付録 B: テストが弁別することの確認

`src/ast/pattern.rs` と `src/elaboration/typecheck.rs` を `origin/main` の内容に戻し、テストは残したままビルドすると、追加した 6 本すべてが落ちます。5 本は LLVM の verifier または panic で、言語サーバのものは `Should receive a completion response` で落ちます。修正を戻すと 6 本とも通ります。

フルスイートはレビューの修正と借用化のそれぞれの後で 1213 passed / 0 failed です。
