### PR TITLE
一意性証明の開発モード検査を、証明を受け取る 18 の op すべてに出す (#198)

### DIFF
--- a/dev-docs/2026-08-05-unique-proof-assert/design.md
+++ b/dev-docs/2026-08-05-unique-proof-assert/design.md
@@ -1,0 +1,157 @@
+# 一意性証明の開発モード検査を全経路に出す (#198)
+
+## 目的
+
+一意性解析が「この値は unique なのでクローンを省いてよい」と判断した箇所で、その証明を
+開発モード時に参照カウントと突き合わせる。誤った証明は、他の保持者から見える値をその場で
+上書きすることを意味し、症状は実行時のサイレントな破壊になる。この検査は、破壊を書き込みの
+地点で止めるために置かれている。
+
+## 確認した事実
+
+issue の 3 つの指摘は、コードを読んで確認できた。
+
+### 1. 検査は 18 の op のうち 2 つにしか出ない
+
+証明を受け取る op、すなわち `assuming_unique` を実装する inline-LLVM op は 18 個ある。
+`force_unique` フィールドを持つ 16 個が証明を受けるとクローンを落とし、残る 2 個は
+検査の結果そのものを定数 `true` に畳む。
+
+| 群 | 数 | 証明を受けたときの形 | 検査 |
+|---|---|---|---|
+| 配列（`make_array_unique` 経由） | 9 | `if force_unique { make_array_unique(..) } else { array }` | なし |
+| 配列（hole 付き、`PunchedArrayPlugBody`） | 1 | `make_array_unique_with_hole` | なし |
+| 配列（`ArraySetCapacityBoundsUnchecked`） | 1 | `if !force_unique { realloc_array(..) }` の早期 return | なし |
+| 構造体（`StructPunch` / `StructPlugIn` / `StructSet`） | 3 | `if force_unique { make_struct_unique(..) }` | なし |
+| boxed（`_mutate_boxed_internal` / `_ios` 版） | 2 | `force_unique_boxed(..)` | **あり** |
+| 定数に畳む（`is_unique` / `Array::is_storage_unique`） | 2 | フラグを `true` にして返す | なし |
+
+RC IR の `specialize` が実際に一意性を証明するのは主に配列の書き込み経路なので、検査は
+それを最も必要とする 11 の配列 op すべてに届いていない。定数に畳む 2 つでは、誤った証明は
+「プログラムに嘘の答えを返す」形で出る。
+
+### 2. global の誤証明を素通しする
+
+本来の検査 `Generator::build_branch_by_is_unique` は、まず
+`build_branch_by_refcnt_state` で state を見て、**GLOBAL のオブジェクトをカウントに関わらず
+shared 側へ流す**。一方 `Generator::mark_global_one` は state を書き換えるだけでカウントに
+触らないので、global なオブジェクトのカウントは `create_obj` が入れた 1 のままである。
+
+現行の `assert_proven_unique` はカウントだけを `> 1` と比べるため、
+「プログラム全体で共有される値を unique と誤証明する」という最悪のケースを通す。
+
+### 3. threaded 状態でカウントを非アトミックに読む
+
+本来の検査は threaded 状態では acquire の atomic load を使う（TSan が standalone fence から
+happens-before を引かないため、acquire を load 自身に置くことが要る）。`assert_proven_unique`
+は素の load である。
+
+`Configuration::develop_mode()` は `threaded` を立てず、`develop_mode` を立てる経路は
+インプロセステストだけなので、この穴は現状どのビルドからも到達しない。ただし下の設計では、
+この穴は個別の対処ではなく「本来の検査と同じ機構を使う」ことの帰結として閉じる。
+
+### 4. 検査が発火しうることを固定するテストがない
+
+`UGT` を `ULT` に反転しても、`specialize` が `force_unique` をクリアしなくなっても、
+テストスイートは緑のままになる。
+
+
+## 終状態
+
+### A. `Generator::build_assert_unique`
+
+`build_assert_refcnt_state_local` の隣に置く。
+
+```rust
+fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>, state: RcState)
+```
+
+`build_branch_by_is_unique` と同じ骨格で、shared 側を abort にしたもの。
+
+- `develop_mode` でなければ何も出さない
+- `build_branch_by_refcnt_state(obj_ptr, state)` を再利用して local / threaded / global を得る
+- local: 素の load で `refcnt == 1` を検査
+- threaded: acquire の atomic load で同上。**state は書き換えない**（`build_branch_by_is_unique`
+  が unique 側で行う `mark_local_one` は、検査には属さない）
+- global: 無条件に abort
+
+`state.dispatches()` が false のときは `build_branch_by_refcnt_state` が
+`build_assert_refcnt_state_local` を出したうえで現在ブロックを返すので、local 相当の検査だけが
+残る。これは locality 注釈の検査と一意性証明の検査が同じ地点で重なる、正しい姿である。
+
+これで指摘 2 と 3 は、別々の対処ではなく設計の帰結として閉じる。
+
+### B. 証明でクローンを落とす判断を集める
+
+現在 16 の `generate` に散っている `if self.force_unique { ... } else { ... }` を、
+`force_unique` を引数に取る関数へ載せ替える。`builtin.rs` の `generate` から
+`if self.force_unique` を消し、判断が残るのは次の 3 箇所になる。
+
+1. `force_unique_or_assert(gc, val, force_unique, state) -> Object`
+   現在の `force_unique_boxed` を一般化する。unbox な値はカウントを持たないのでそのまま返し、
+   配列は storage を、それ以外の boxed は値そのものを対象にする。13 の op がここに載る。
+2. hole 付きの変種。`PunchedArrayPlugBody` 1 箇所のために残す。
+3. `ArraySetCapacityBoundsUnchecked`。unique 側が `realloc` の in-place 縮小・拡大で、
+   「unique にした値を返す」形をしていない。早期 return の先頭で `build_assert_unique` を直接呼ぶ。
+
+### C. 定数に畳む 2 つの op
+
+`is_unique` と `Array::is_storage_unique` は返す値を作らないので、上の関数には載らない。
+フラグを `true` にする地点で `build_assert_unique` を直接呼ぶ。
+
+## 実装手順
+
+1. `build_assert_unique` を追加する。
+2. `force_unique_or_assert` へ 13 の op を載せ替える。
+3. hole 付き変種と `ArraySetCapacityBoundsUnchecked` を処理する。
+4. 定数に畳む 2 つの op に検査を入れる。
+5. 現行の `assert_proven_unique` を削除する。
+6. スイートを `-O none` / `-O max` で回す。
+
+## 検証
+
+### global を即 abort にしてよいか
+
+よい。`rc_ir/provenance.rs` の `LeafOrigin::Unknown` は「boxed コンテナから読んだ値、
+**global**、`Retain` で複製された値」であり、`resolve_leaf` はこれを `Dynamic` に落とす。
+`leaf_is_unique` が `true` を返すのは `SharingVerdict::Unique` のときだけなので、
+**解析は global を unique と証明しない**。証明が global を指したならそれは解析の誤りである。
+
+### 発火の証明（1 回きり、テストには残さない）
+
+`unique_check_elim` の `leaf_is_unique` の結果を常に `true` に差し替え、共有された配列への
+`Array::set` を develop mode で走らせる。
+
+| | 結果 |
+|---|---|
+| 嘘の証明を注入 | `A value proven uniquely owned was reached while shared.` で abort |
+| 注入なし（対照） | プログラムは正常終了し、abort を期待するプローブが落ちる |
+
+対照側を測らないと「注入が原因で鳴った」とは言えないので、両方を走らせる。
+
+### 検査が経路に届いていることの確認
+
+比較 `EQ` を `NE` に反転させると、配列テストが軒並み落ちる
+（`test_array_bounds_check::test_set` は期待する "Index out of range" ではなく abort する）。
+issue が挙げた「反転してもスイートは緑のまま」は、検査が 2 経路から 18 経路に増えたことで
+解消している。**既存の 1207 件が、検査そのものの正しさを毎回検証する形になった。**
+
+### スイートとコスト
+
+`-O none` 1207 件、`-O max` 1207 件、いずれも 0 失敗。所要は none 468 秒 / max 402 秒で、
+これまでの範囲内にある。検査は develop mode だけなので released build には出ない。
+
+## 恒久テストを置かない理由
+
+「証明が通った経路に検査が出ている」ことを IR で固定する案は退けた。develop mode のビルドは
+インプロセスでしか起きず、オブジェクトキャッシュがカレントディレクトリ（全テスト共有）に載る。
+同じソースの 2 回目のビルドはコード生成ごと飛ぶので、IR ファイルが出ない。テスト側では直せず、
+develop mode を CLI から立てられるようにするのは公開仕様の変更になる。
+
+代わりの証拠は上の 2 つ、注入と対照の組、および反転が経路に届いていることの確認である。
+
+## 残る改善案（この変更には含めない）
+
+検査の呼び出しを op から取り上げ、inline-LLVM op のコード生成を行う唯一の地点で、
+`unique_check_operand` の鏡（証明が通ったときに操作対象を返す宣言）を読んで出す形にすれば、
+**新しい op が検査を書き忘れること自体が起きなくなる**。今回は各 op が検査を持つ形に留める。

--- a/dev-docs/2026-08-05-unique-proof-assert/design.md
+++ b/dev-docs/2026-08-05-unique-proof-assert/design.md
@@ -1,248 +1,354 @@
-# 一意性証明の開発モード検査 (#198)
+# 一意性証明を実行時に検査する
 
-## 1. この検査が捕まえるもの
+## 1. 何のための検査か
 
-RC IR の最適化は、ある値について「ここでは他に保持者がいない」と証明できたとき、その値を書き換える
-操作から**クローンを落とす**。落とすのは、実行時に参照カウントを読んで 1 かどうかを見る検査である。
+Fix の値は参照カウントで共有を管理する。ある値を書き換える操作は、その値を他の誰も保持していない
+ときに限って、その場で書き換えてよい。他に保持者がいるなら、先に複製を作ってそちらを書き換える。
+どちらであるかは、実行時に参照カウントを読んで決める。
 
-証明が誤っていた場合に起きることは、実行時エラーでもクラッシュでもない。他の保持者から見える値を
-その場で上書きし、プログラムはそのまま走り続ける。壊れた値が読まれるのは別の関数、別のフェーズ、
-別のスレッドかもしれない。**症状が原因から任意に離れる**という点で、このコンパイラが起こしうる
-最悪の壊れ方に属する。
+最適化はこの判断を静的に前倒しする。「ここに来る値には他の保持者がいない」と証明できたなら、
+実行時の検査も複製も丸ごと落としてよい。これは配列を 1 要素ずつ書き換えるようなループでは
+決定的に効く。落とさなければ、1 回の書き込みごとに参照カウントを読むことになる。
 
-落とした検査そのものが、その誤りを捕まえる唯一の観測である。だから開発モードでは同じ観測をもう一度
-行い、違反を**書き込みの地点で**止める。これがこの変更の対象である。
+問題は、証明が誤っていたときに何が起きるかである。**実行時エラーでもクラッシュでもない。**
+他の保持者から見える値をその場で上書きし、プログラムはそのまま走り続ける。壊れた値が読まれるのは
+別の関数、別のフェーズ、別のスレッドかもしれない。症状が原因から任意に離れるという点で、
+このコンパイラが起こしうる最悪の壊れ方に属する。
 
-## 2. 証明はどこから来るか
+そして、落とした検査そのものが、その誤りを捕まえる唯一の観測である。だからコンパイラの開発モード
+では、証明を受け入れた地点で同じ観測をもう一度行い、違反していれば**その書き込みの地点で**
+プログラムを止める。この文書はその検査の設計である。
 
-### 2.1 解析による証明
+## 2. 値の共有はどう表現されているか
 
-`src/rc_ir/unique_check_elim.rs` の `specialize` が、provenance 解析の結果を `leaf_is_unique` に
-問い、真なら `LLVMGen::assuming_unique()` を呼ぶ。`assuming_unique()` は op のフラグを書き換える。
-
-- クローンを出す 16 op: `force_unique` を **false** にする
-- 検査の結果を定数に畳む 2 op (`is_unique`, `Array::is_storage_unique`): `assume_unique` を
-  **true** にする
-
-同じ事実が逆極性の 2 つのフィールド名で保持されている。証明を受け取る op はこの 18 個で、
-issue が数えた 16 個は前者だけである。**後者では誤った証明が「プログラムに嘘の答えを返す」形で
-出る**ので、対象に含める。
-
-この pass が走るのは `Configuration::enable_borrow_optimization()` が真のとき、すなわち
-`-O max` 以上に限られる。
-
-### 2.2 解析が global を unique と証明しないこと
-
-`src/rc_ir/provenance.rs` の `LeafOrigin::Unknown` の定義は「boxed コンテナから読んだ値、
-**global**、`Retain` で複製された値」であり、`resolve_leaf` はこれを `SharingVerdict::Dynamic` に
-落とす。`leaf_is_unique` が真を返すのは `Unique` のときだけなので、**解析は global を unique と
-証明しない**。証明が global を指したなら、それは解析の誤りである。この不変条件は検査の global 腕
-（下記 4.2）が乗っているものなので、テストで固定する。
-
-### 2.3 登録による証明
-
-`force_unique == false` は解析以外からも来る。`src/ast/program.rs` は全 struct について
-`#punch_` / `#plug_in_` を `force_unique: false` で登録する。`act_x` はこれを使って、
-一意性を確かめたあとにフィールドを出し入れする。この経路の証明は解析とは無関係に立つ。
-
-検査はどちらの由来でも同じく立つ。ただし unboxed struct が到達しうるのはこの経路だけであり、
-そこには参照カウントが無いので検査の対象にならない（下記 5.3）。
-
-## 3. 参照カウントのモデル
-
-boxed オブジェクトの制御ブロックは 2 つのフィールドを持つ。
-
-| | 内容 |
-|---|---|
-| `CTRL_BLK_REFCNT_IDX` | 参照カウント |
-| `CTRL_BLK_REFCNT_STATE_IDX` | state バイト |
-
-state は `REFCNT_STATE_LOCAL` / `REFCNT_STATE_THREADED` / `REFCNT_STATE_GLOBAL` の 3 値である。
-**「unique か」はカウント単独では答えられない。**
-
-- **global**: `Generator::mark_global_one` は state を書くだけでカウントに触らない。global な
-  オブジェクトのカウントは `create_obj` が入れた 1 のままなので、カウントだけを見れば unique に
-  見える。実際にはプログラムが走る限り共有されている。
-- **threaded**: カウントは他スレッドが原子的に更新する。素の load はそれ自体がデータ競合になる。
-
-本来の検査 `Generator::build_branch_by_is_unique` はこの構造どおりに答える。まず
-`build_branch_by_refcnt_state` で state を読んで 3 分岐し、
-
-- **local**: 素の load でカウントを読み、1 と比較
-- **threaded**: **acquire の** atomic load で同上
-- **global**: カウントを読まず、無条件に shared 側へ
-
-acquire を load 自身に置くことには理由がある。ThreadSanitizer は standalone の `fence acquire`
-から happens-before を引かないので、acquire を fence に移すとコードは正しいまま**レース検出器が
-後続の書き込みを誤報する**。
-
-## 4. 変更前の検査が持っていた穴
-
-PR #196 が入れた `assert_proven_unique` は、**カウントだけを読んでいた**。issue が挙げた 3 点は、
-この 1 つの設計の誤りの帰結として並ぶ。
-
-1. **global の誤証明を素通しする**。global のカウントは 1 なので、カウントだけを見る検査は
-   「プログラム全体で共有される値を unique と誤証明する」という最悪のケースを通す。
-2. **threaded でカウントを非アトミックに読む**。検査自身がデータ競合になる。
-3. **18 の op のうち 2 つにしか出ない**。`force_unique_boxed` を通る `_mutate_boxed_internal` と
-   その `_ios` 版だけで、`specialize` が実際に証明する主戦場である配列の書き込み 11 op には
-   1 つも届いていない。
-
-したがって対処も 3 つ別々ではない。**本来の検査と同じ機構を使う**ことにすれば 1 と 2 は設計の
-帰結として閉じ、残るのは 3 の配線だけになる。
-
-## 5. 終状態
-
-### 5.1 `Generator::build_assert_unique`
-
-`build_assert_refcnt_state_local` の隣に置く。
+boxed な値は、ヒープ上のオブジェクトを指すポインタである。オブジェクトの先頭には制御ブロックが
+載っている。
 
 ```rust
-pub fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>)
+struct ControlBlock {
+    refcnt: i32,       // 参照カウント
+    refcnt_state: u8,  // 下記の 3 値
+    alloc_offset: u32, // 確保したブロックの先頭からの距離。この文書には関わらない
+}
 ```
 
-`build_branch_by_is_unique` と同じ骨格で、shared 側を abort にしたもの。
+`refcnt_state` は 3 値を取る。
 
-- `develop_mode` でなければ何も出さない
-- `build_branch_by_refcnt_state(obj_ptr, RcState::Unknown)` で local / threaded / global を得る
-- local: 素の load、threaded: acquire の atomic load、global: 無条件に abort
-- **state は書き換えない**。`build_branch_by_is_unique` は threaded かつ unique の側で
-  `mark_local_one` を呼ぶが、検査が守っている操作はその書き換えを持たない。開発モードのビルド
-  だけが実行時 state を変えれば、そこから先の RC の振る舞いが released build と分岐する。
+| 値 | 意味 |
+|---|---|
+| `REFCNT_STATE_LOCAL` | 単一スレッドからしか見えていない。カウントは非原子的に読み書きしてよい |
+| `REFCNT_STATE_THREADED` | 複数スレッドから見えている。カウントは原子的に扱う |
+| `REFCNT_STATE_GLOBAL` | プログラム全体で生きる値。retain も release もしない |
 
-カウントを読んで 1 と比べる列は、本来の検査と合わせて 4 箇所に現れる。これは
-`build_is_refcnt_one(obj_ptr, acquire, name_suffix)` に抽出し、acquire を load に置く理由も
+ここが以降の議論の要点である。**「この値には他の保持者がいないか」は、カウントだけでは答えられない。**
+
+- **GLOBAL の値のカウントは、確保したときに入れた 1 のまま動かない。** 値を global にする操作は
+  state バイトを書くだけで、カウントには触れない。カウントだけを見れば 1 なので他に保持者が
+  いないように見えるが、実際にはプログラムが走る限り共有されている。
+- **THREADED の値のカウントは他スレッドが原子的に更新する。** 素の load で読むこと自体が
+  データ競合になる。
+
+配列については、カウントは配列の値ではなく**要素バッファが持つ**。Fix の配列の値は
+（要素バッファへのポインタ, 長さ, 容量）の組で、ヒープに載っているのは要素バッファだけである。
+配列の一意性を問うとは、その要素バッファの一意性を問うことである。
+
+## 3. 実行時の一意性検査
+
+上の構造どおりに答える関数が `Generator::build_branch_by_is_unique` である。state を読んで
+3 分岐し、それぞれに合った読み方でカウントを 1 と比べ、unique 側と shared 側の 2 つの分岐先を
+呼び出し元に返す。
+
+```
+検査(obj):
+    state = load obj.refcnt_state
+    if state == GLOBAL:
+        -> shared                              // カウントは読まない
+    if state == THREADED:
+        c = atomic load acquire obj.refcnt
+        -> (c == 1) ? unique : shared
+    // LOCAL
+    c = load obj.refcnt
+    -> (c == 1) ? unique : shared
+```
+
+THREADED で **acquire を load 自身に置く**ことには理由がある。ThreadSanitizer は独立した
+`fence acquire` から happens-before の辺を引かない。acquire を fence に移すと、コードは正しい
+ままレース検出器が後続の書き込みを誤報する。
+
+## 4. 証明はどこで生まれ、何を落とすか
+
+### 4.1 組み込み操作とその宣言
+
+Fix の組み込み操作の多く（配列の `set`、構造体フィールドの更新、`unsafe_is_unique` など）は、
+LLVM IR を直接組み立てる「inline-LLVM op」として実装されている。各 op は `LLVMGen` トレイトを
+実装する。この文書に関わる宣言は次の 4 つである。
+
+```rust
+trait LLVMGen {
+    /// この操作の LLVM IR を組み立てる。
+    fn generate(&self, gc: &mut Generator, ty: &Arc<TypeNode>) -> Object;
+
+    /// この操作が実行時に一意性を検査する対象。検査を持たない操作は None を返す。
+    fn unique_check_operand(&self, arg_tys: &[Arc<TypeNode>], type_env: &TypeEnv)
+        -> Option<UniqueCheckOperand>;
+
+    /// 検査対象が unique だと証明できたときの、この操作の別版。
+    fn assuming_unique(&self) -> Box<dyn LLVMGen>;
+
+    /// 宣言した対象が LOCAL 状態だと証明できたときの、この操作の別版。
+    fn assuming_local(&self) -> Box<dyn LLVMGen>;
+}
+
+struct UniqueCheckOperand {
+    container_index: usize, // 何番目の引数か
+    path: FieldPath,        // その引数の値の中の、どの boxed な部分か
+}
+```
+
+`unique_check_operand` は「この操作は、この引数のこの位置にある boxed な値について、実行時に
+一意性を検査する」という**宣言**である。`assuming_unique` / `assuming_local` は、その宣言に
+対応する証明を受け取るための入口で、op は自分のフラグを書き換えた複製を返す。
+
+### 4.2 証明する pass
+
+RC IR の pass `unique_check_elim::specialize` が、後述の provenance 解析に「この操作の検査対象は
+unique か」を問い、真なら `assuming_unique()` を呼ぶ。この pass が走るのは `-O max` 以上に限られる。
+
+`assuming_unique()` が書き換えるフラグは、op の種類によって 2 通りある。
+
+| 種類 | 数 | フラグ | 証明を受けた側 | 証明を受けたときの振る舞い |
+|---|---|---|---|---|
+| クローンを出す op | 16 | `force_unique` | **false** | 複製を作らず、値をそのまま書き換える |
+| 検査結果を返す op | 2 | `assume_unique` | **true** | 検査を行わず、フラグを定数 `true` にする |
+
+同じ事実が逆極性の 2 つのフィールド名で保持されている。**証明を受け取る op は合計 18 個**である。
+後者は `unsafe_is_unique` と `Array::_unsafe_is_storage_unique` の 2 つで、ここでの誤った証明は
+「プログラムに嘘の答えを返す」形で出る。
+
+### 4.3 provenance 解析が言えること
+
+provenance 解析は、値の中の boxed な部分（boxed leaf）ごとに、それがどこから来たかを追う。
+
+```rust
+enum LeafOrigin {
+    /// 新しく確保した値、あるいは複製を作る操作の結果。
+    Fresh,
+    /// boxed コンテナから読み出した値、global な値、retain で複製された値。
+    Unknown,
+    /// 入力 i のその位置から、そのまま運ばれてきた値。
+    Arg(usize, FieldPath),
+}
+```
+
+`Unknown` は吸収状態で、`Fresh` や `Arg` がここへ落ちることはあっても戻ることはない。解析が
+「unique」と答えるのは、追った由来がすべて `Fresh`（あるいは unique と分かっている入力）に
+行き着いたときだけである。
+
+ここから 1 つの不変条件が出る。**global な値は `Unknown` に分類されるので、解析は global な値を
+unique と証明しない。** 証明が global を指したなら、それは解析の誤りである。この事実は、
+6.1 の検査が global を無条件に abort とすることの根拠になる。
+
+### 4.4 証明のもう 1 つの出どころ
+
+`force_unique == false` は解析だけから来るわけではない。
+
+構造体のフィールド更新（`rec.act_x(f)` のような形）は、フィールドを一旦取り出す操作（punch）と
+戻す操作（plug）の組で実装される。この 2 つは、**呼び出し側が直前に一意性を確かめている**という
+前提のもとに `force_unique: false` で登録される。解析とは無関係に、常にこの値である。
+
+この経路には unboxed な構造体も来る。unboxed な値は制御ブロックを持たないので、検査する
+カウントが存在しない。
+
+## 5. 変更前の検査が持っていた穴
+
+開発モードの検査は以前から 1 つだけ存在していた。それは**カウントだけを読み、1 より大きければ
+abort する**ものだった。ここから 3 つの穴が、1 つの設計の誤りの帰結として並ぶ。
+
+1. **global の誤証明を素通しする。** 2 節のとおり global な値のカウントは 1 のままなので、
+   カウントだけを見る検査は「プログラム全体で共有される値を unique と誤証明する」という最悪の
+   ケースを通す。
+2. **THREADED でカウントを非アトミックに読む。** 検査自身がデータ競合になる。
+3. **18 の op のうち 2 つにしか出ない。** 検査を持っていたのは boxed な値を書き換える 2 つの
+   操作だけで、証明の主戦場である配列の書き込み 11 op には 1 つも届いていなかった。
+
+したがって対処も 3 つ別々ではない。**3 節の検査と同じ機構を使う**ことにすれば 1 と 2 は設計の
+帰結として閉じ、残るのは 3 の配線だけになる。
+
+## 6. 終状態
+
+### 6.1 検査そのもの
+
+```rust
+impl Generator {
+    /// 開発モードのとき、`obj_ptr` の指すオブジェクトが共有されていれば abort する。
+    pub fn build_assert_unique(&mut self, obj_ptr: PointerValue);
+}
+```
+
+3 節の検査と同じ骨格で、shared 側を abort にしたものである。
+
+```
+検査を出す(obj):
+    if 開発モードでない: 何も出さない
+    state = load obj.refcnt_state
+    if state == GLOBAL:
+        -> abort                               // 4.3 より、証明が global を指したなら誤り
+    if state == THREADED:
+        c = atomic load acquire obj.refcnt
+        if c != 1: abort
+    else:                                      // LOCAL
+        c = load obj.refcnt
+        if c != 1: abort
+```
+
+3 節の検査との違いは 2 つある。shared 側が abort であること、そして **state を書き換えないこと**
+である。3 節の検査は THREADED かつ unique と分かった側で、その値を LOCAL に落とす（他スレッドが
+もう見ていないと分かったため）。検査が守っている操作はその書き換えを持たないので、ここで真似ては
+ならない。開発モードのビルドだけが実行時 state を変えれば、そこから先の参照カウントの振る舞いが
+通常のビルドと分岐する。
+
+カウントを読んで 1 と比べる列は、3 節の検査と合わせて 4 箇所に現れる。これは
+`build_is_refcnt_one(obj_ptr, acquire, name_suffix)` に切り出し、acquire を load 自身に置く理由も
 そこ 1 箇所に書く。
 
-### 5.2 state を実行時に読む（宣言の契約）
+### 6.2 state を引数に取らない理由
 
-`build_assert_unique` は `RcState` を引数に取らない。理由は locality 推論の契約にある。
+`build_assert_unique` は `RcState`（この地点の state について静的に分かっていること）を引数に
+取らない。理由は locality 推論の契約にある。
 
-op は自分が出す一意性検査を `LLVMGen::unique_check_operand` で宣言する。`assuming_local` の doc は
-この宣言について次を定めている。
+locality 推論は、op が扱うオブジェクトが LOCAL 状態だと証明できたとき `assuming_local()` を
+呼ぶ。証明を受けた op は state を読まずに済み、カウントを直接読める。この推論が何を対象と
+するかは `unique_check_operand`（4.1）が宣言した対象で決まる。`assuming_local` の doc は
+この関係を次のように定めている。
 
 > A `generate` that emits a check or a reference count it does not declare leaves that one
 > reading the state, so the declarations stay honest about what the annotation covers.
 
-すなわち **宣言していない検査は state を読み続ける**。ところが 18 op すべての
-`unique_check_operand` は
+すなわち**宣言していない検査は state を読み続ける**。これがあるから、宣言が locality 注釈の
+覆う範囲を正直に表していられる。
+
+ところが 18 op すべての `unique_check_operand` は、次の形で始まる。
 
 ```rust
-if !self.force_unique { return None; }   // あるいは if self.assume_unique { return None; }
+fn unique_check_operand(&self, ...) -> Option<UniqueCheckOperand> {
+    if !self.force_unique { return None; }   // 検査結果を返す op では if self.assume_unique
+    ...
+}
 ```
 
-で始まる。**証明が受理された瞬間に宣言が取り下げられる**。そして検査が立つのはまさにその地点である。
-よって、取り下げられた宣言に乗った locality 注釈は、この地点の対象について何も言っていない。
-`assumed_state(self.assume_local)` を渡すと、誰も証明していない locality を根拠に
-`build_assert_refcnt_state_local` が出て、正しい一意性証明に対して locality のメッセージで
-誤 abort しうる。
+**証明が受理された瞬間に、宣言が取り下げられる。** そして開発モードの検査が立つのは、まさに
+その地点である。取り下げられた宣言に乗った locality 注釈は、この地点の対象について何も言って
+いない。ここで「LOCAL と分かっている」を渡すと、誰も証明していない locality を根拠にした
+検査が出て、正しい一意性証明に対して locality の側のメッセージで誤って abort しうる。
 
-コストは開発モードでの state load 1 回である。なお threaded ビルドでは
-`locality::specialize` 自体が走らない（`build_object_files.rs` が `!config.threaded` で
-ガードしている）ので、そこでは `assume_local` はそもそも立たない。
+だから検査は state を実行時に読む。コストは開発モードでの state の load 1 回である。
 
-### 5.3 証明でクローンを落とす判断を集める
+### 6.3 証明でクローンを落とす判断を集める
 
-16 の `generate` に散っていた `if self.force_unique { make_X_unique(..) } else { .. }` を
-`force_unique_or_assert` に載せ替える。この関数は値の形で分岐する。
+変更前は、16 の op がそれぞれの `generate` の中で
 
-| 値の形 | `force_unique` | `!force_unique` |
+```rust
+let array = if self.force_unique {
+    make_array_unique(gc, array, ...)   // 共有されていれば複製する
+} else {
+    array                               // 証明を信じてそのまま使う
+};
+```
+
+と書いていた。この形を 1 つの関数 `force_unique_or_assert` に載せ替える。**証明を信じるかどうかの
+判断と、信じたときに立てる検査が、同じ場所で決まる**ようにするためである。
+
+| 値の形 | `force_unique` が真 | 偽（証明を受けた） |
 |---|---|---|
-| 配列 | `make_array_unique_with_hole` | storage を対象に検査（カウントは storage が持つ） |
-| boxed struct / union | `make_struct_union_unique` | 値そのものを対象に検査 |
-| unboxed struct / union | そのまま返す | そのまま返す（カウントが無い） |
+| 配列 | 共有されていれば要素バッファごと複製 | 要素バッファを対象に検査 |
+| boxed な構造体 / union | 共有されていれば複製 | 値そのものを対象に検査 |
+| unboxed な構造体 / union | そのまま返す | そのまま返す（カウントが無い） |
 
-unboxed が到達するのは 2.3 の登録経路だけである。ここに配列や `_mutate_boxed*` の値が来ることは
-無い（前者は先に分岐し、後者は `[a : Boxed]` 束縛を持つ）ので、unboxed 側では struct か union で
-あることを表明する。
+unboxed が到達するのは 4.4 の登録経路だけである。ここに配列や boxed 専用の操作の値が来ることは
+無いので、unboxed 側では構造体か union であることを表明する。
 
-### 5.4 一般の入口に載らない 3 つ
+### 6.4 一般の入口に載らない 3 つ
 
-- `ArraySetCapacityBoundsUnchecked`: unique 側が `realloc` による in-place の縮小・拡大で、
-  「unique にした値を返す」形をしていない。早期 return の先頭で検査を直接呼ぶ。
-- `PunchedArrayPlugBody`: クローンが穴を残す必要があるので、hole を取る変種を使う。
-- `is_unique` / `Array::is_storage_unique`: 値を作らずフラグを定数 `true` に畳むので、
-  その地点で検査を直接呼ぶ。
+- **配列の容量変更**: 一意な側が `realloc` による確保済み領域の伸縮で、「複製した値を返す」形を
+  していない。証明を受けた側の早期 return の先頭で検査を直接呼ぶ。
+- **穴あき配列への差し戻し（plug）**: 複製が 1 要素分の穴を残す必要があるので、穴の位置を取る
+  変種を使う。
+- **検査結果を返す 2 op**: 値を作らずフラグを定数 `true` に畳むので、その地点で検査を直接呼ぶ。
 
-## 6. 何が測れて何が測れないか
+## 7. テストで固定できること・できないこと
 
-### 6.1 測れないもの
+### 7.1 固定できないこと
 
 **18 箇所の検査をすべて削除しても、テストスイートは緑のままである。** これは違反を強制できない
-assertion 一般の性質であって、この検査に固有の弱さではない。テストで固定するには、誤った証明を
-作る口をコンパイラ側に用意するしかなく、それは production コードをテストのために歪めることになる。
+assertion 一般の性質であって、この検査に固有の弱さではない。テストで固定するには誤った証明を作る
+口をコンパイラ側に用意するしかなく、それは production コードをテストのために歪めることになる。
 
-IR を読んで「証明が通った経路に検査が出ている」ことを固定する案も検討したが、使えない。
-develop mode のビルドはインプロセスでしか起きず（`Configuration::develop_mode()` を呼ぶのは
-テストだけで、CLI から立てる手段が無い）、オブジェクトキャッシュがカレントディレクトリ
-（全テスト共有）に載る。**同じソースの 2 回目のビルドはコード生成ごと飛んで `.ll` が出ない。**
-`fix_build_source_command` を使う既存の IR テストは `current_dir(temp_dir)` でキャッシュごと
-隔離しているのでこの罠を踏まない。これは #197 と同じ土俵の問題である。
+出力された LLVM IR を読んで「証明が通った経路に検査が出ている」ことを固定する案も検討したが、
+使えない。開発モードのビルドはインプロセスでしか起こせず（開発モードの設定を作るのはテスト
+だけで、コマンドラインから立てる手段が無い）、そのときオブジェクトファイルのキャッシュが
+カレントディレクトリ（全テストで共有）に載る。**同じソースを 2 回目にビルドすると、コード生成
+ごと飛んで IR ファイルが出ない。** 外部プロセスとして `fix` を起動する既存の IR テストは、
+作業ディレクトリを一時ディレクトリに移してキャッシュごと隔離しているのでこの罠を踏まない。
 
-恒久的な歯止めにするなら 8 の構造化が要る。
+恒久的な歯止めにするなら 8 節の構造化が要る。
 
-### 6.2 測れるもの
+### 7.2 固定できること
 
-- **検査が誤った証明に反応すること**（注入と対照の組、7.1）
-- **検査が経路に届いていること**（比較の反転、7.2）
-- **証明が受理される地点が実在すること**。RC IR ダンプの `[unique]` マーカで固定する。
-  検査そのものではなく「検査が立つ地点」を固定するもので、将来 provenance/specialize の変更で
-  その op が証明を受けなくなれば落ちる。
+- **検査が誤った証明に反応すること。** 解析に嘘の証明をさせる細工を入れて確かめる（付録 A.1）。
+  これは 1 回きりの実験で、テストには残せない。
+- **検査が経路に届いていること。** 比較を反転させるとテストが落ちる（付録 A.2）。検査が
+  2 経路から 18 経路に増えたことで、既存のテストが検査そのものの正しさを毎回検証する形になった。
+- **証明が受理される地点が実在すること。** RC IR のダンプには、検査を落とした操作に `[unique]`
+  という印が付く。これを主張するテストは、検査そのものではなく「検査が立つ地点」を固定する。
+  将来の変更でその op が証明を受けなくなれば落ちる。この形のテストが無かった 5 つの op
+  （構造体の punch / plug、`unsafe_is_unique`、boxed な値を書き換える 2 操作）に追加した。
+- **4.3 の不変条件。** global から読んだ配列への書き込みが検査を保つことを、新しいテストケース
+  で固定する。これが崩れると 6.1 の global 腕が誤って発火する。
+- **THREADED 腕がコード生成されること。** 開発モードと `--threaded` が同時に立つ構成でのみ
+  この腕が出る。それを通すテストを追加した。実行が取るのは LOCAL 腕である。
 
-## 7. 検証
+## 8. 残る設計課題
 
-### 7.1 検査が発火することの証明
+- **19 個目の op が検査を書き忘れる余地。** 現状は 18 の op が自分で検査を呼ぶ。検査の呼び出しを
+  op から取り上げ、inline-LLVM op のコード生成を行う唯一の地点で、`unique_check_operand` の鏡
+  （証明が受理されたときに検査対象を返す宣言）を読んで出す形にすれば、書き忘れ自体が起きなく
+  なる。値の中の boxed leaf をパスで辿ってポインタを得るヘルパが要る（配列なら要素バッファ、
+  それ以外なら値そのもの、という 6.3 の表の区別）。
+- **`force_unique` と `assume_unique` が同じ事実を逆極性で持っている**（4.2）。読み手は op を
+  移るたびに極性を反転させる必要がある。
+- 配列から要素バッファのポインタを取り出す式が 3 箇所に手書きされている。既存の
+  `get_array_storage_buf` の隣に置くべきヘルパが欠けている。
+- boxed な値を書き換える 2 操作と、配列の要素をまとめて書き換える 2 操作の、計 4 つの本体が
+  同じ核を繰り返している。
+- 組み込み操作の実装ファイルが 8400 行で、配列 / 構造体・union / FFI の操作が同居している。
 
-`unique_check_elim` の `leaf_is_unique` の結果を常に `true` に差し替え、共有された配列への
-`Array::set` を develop mode で走らせる。
+## 付録 A 測定
+
+### A.1 検査が発火することの確認
+
+解析の答えを常に「unique」に差し替える細工を入れ、共有された配列への書き込みを開発モードで
+走らせた。
 
 | | 結果 |
 |---|---|
 | 嘘の証明を注入 | `A value proven uniquely owned was reached while shared.` で abort |
 | 注入なし（対照） | プログラムは正常終了し、abort を期待するプローブが落ちる |
 
-対照側を測らないと「注入が原因で鳴った」とは言えないので、両方を走らせる。
+対照側を測らないと「注入が原因で鳴った」とは言えないので、両方を走らせた。細工は戻してある。
 
-### 7.2 検査が経路に届いていることの確認
+### A.2 検査が経路に届いていることの確認
 
-比較 `EQ` を `NE` に反転させると、配列テストが軒並み落ちる
-（`test_array_bounds_check::test_set` は期待する "Index out of range" ではなく abort する）。
-issue が挙げた「反転してもスイートは緑のまま」は、検査が 2 経路から 18 経路に増えたことで解消した。
-既存の 1209 件が、検査そのものの正しさを毎回検証する形になっている。
+カウントとの比較 `EQ` を `NE` に反転させると、配列のテストが軒並み落ちる。境界検査のテストは
+期待する "Index out of range" ではなく abort する。
 
-### 7.3 追加したテスト
+### A.3 テストスイート
 
-- `test_unique_check_elim_local_fresh` に 5 つのマーカ。`struct_punch_0` / `struct_plug_in_0` /
-  `is_unique` / `mutate_boxed` / `mutate_boxed_ios` は、証明が受理されることを固定するものが
-  何も無かった。追加した Fix コードを外すとテストが落ちることを確認済み。
-- `test_global_value_keeps_its_check`（新ケース `unique_elim_global`）。2.2 の不変条件を固定する。
-- `test_threaded_build_checks_its_uniqueness_proofs`。develop mode と `--threaded` が同時に立つ
-  唯一の構成で、state 分岐の threaded 腕がコード生成され verifier を通る。実行が取るのは
-  local 腕である（threaded 腕だけを反転しても落ちないことで確認した）。
+`-O none` 1209 件 / `-O max` 1209 件、いずれも 0 失敗。所要は none 471 秒 / max 401 秒。
 
-### 7.4 スイートと影響範囲
+### A.4 通常のビルドへの影響
 
-`-O none` 1209 件 / `-O max` 1209 件、いずれも 0 失敗。所要は none 471 秒 / max 401 秒で、
-これまでの範囲内にある。
-
-**develop mode 以外への影響が無いことを実測した。** `origin/main` (`d41046e5`) のコンパイラと
-本ブランチのコンパイラで `examples/` の 17 プログラムを `-O none` / `-O basic` / `-O max` で
-コンパイルし、モジュールハッシュを正規化した LLVM IR を突き合わせて **51/51 が一致**
-（計 290 モジュール）。比較器が差を報告できることは、同一プログラムを 2 つの最適化レベルで
-ビルドして確かめた。51 対すべての IR に `is_unique` が現れるので、コーパスは 5.1 で抽出した
-`build_is_refcnt_one`（released build にも出る経路）に到達している。
-
-## 8. 残る設計課題
-
-- **19 個目の op が検査を書き忘れる余地**。検査の呼び出しを op から取り上げ、inline-LLVM op の
-  コード生成を行う唯一の地点で `unique_check_operand` の鏡（証明が受理されたときに検査対象を
-  返す宣言）を読んで出す形にすれば、書き忘れ自体が起きなくなる。boxed leaf を `FieldPath` で
-  辿ってポインタを得るヘルパが要る（配列は storage、それ以外は値そのもの、という
-  `force_unique_or_assert` が今は手で書いている区別）。
-- **`force_unique` と `assume_unique` が同じ事実を逆極性で持っている**（2.1）。読み手は op を
-  移るたびに極性を反転させる必要がある。
-- `get_array_storage(gc, x).value(gc).into_pointer_value()` が 3 箇所にある。`object.rs` の
-  `get_array_storage_buf` の隣に `get_array_storage_ptr` が要る。
-- `_mutate_boxed_internal` / `_ios` と `mutate_elements` / `_ios` の 4 つの op 本体が同じ核を
-  繰り返している。
-- `src/fixstd/builtin.rs` が 8400 行で、配列 / struct・union / FFI の builtin が同居している。
+`origin/main` (`d41046e5`) のコンパイラと本ブランチのコンパイラで `examples/` の 17 プログラムを
+`-O none` / `-O basic` / `-O max` でコンパイルし、モジュールハッシュを正規化した LLVM IR を
+突き合わせて **51/51 が一致**（計 290 モジュール）。比較器が差を報告できることは、同一プログラムを
+2 つの最適化レベルでビルドして確かめた。51 対すべての IR に `is_unique` が現れるので、コーパスは
+6.1 で切り出した `build_is_refcnt_one`（通常のビルドにも出る経路）に到達している。

--- a/dev-docs/2026-08-05-unique-proof-assert/design.md
+++ b/dev-docs/2026-08-05-unique-proof-assert/design.md
@@ -1,123 +1,197 @@
-# 一意性証明の開発モード検査を全経路に出す (#198)
+# 一意性証明の開発モード検査 (#198)
 
-## 目的
+## 1. この検査が捕まえるもの
 
-一意性解析が「この値は unique なのでクローンを省いてよい」と判断した箇所で、その証明を
-開発モード時に参照カウントと突き合わせる。誤った証明は、他の保持者から見える値をその場で
-上書きすることを意味し、症状は実行時のサイレントな破壊になる。この検査は、破壊を書き込みの
-地点で止めるために置かれている。
+RC IR の最適化は、ある値について「ここでは他に保持者がいない」と証明できたとき、その値を書き換える
+操作から**クローンを落とす**。落とすのは、実行時に参照カウントを読んで 1 かどうかを見る検査である。
 
-## 確認した事実
+証明が誤っていた場合に起きることは、実行時エラーでもクラッシュでもない。他の保持者から見える値を
+その場で上書きし、プログラムはそのまま走り続ける。壊れた値が読まれるのは別の関数、別のフェーズ、
+別のスレッドかもしれない。**症状が原因から任意に離れる**という点で、このコンパイラが起こしうる
+最悪の壊れ方に属する。
 
-issue の 3 つの指摘は、コードを読んで確認できた。
+落とした検査そのものが、その誤りを捕まえる唯一の観測である。だから開発モードでは同じ観測をもう一度
+行い、違反を**書き込みの地点で**止める。これがこの変更の対象である。
 
-### 1. 検査は 18 の op のうち 2 つにしか出ない
+## 2. 証明はどこから来るか
 
-証明を受け取る op、すなわち `assuming_unique` を実装する inline-LLVM op は 18 個ある。
-`force_unique` フィールドを持つ 16 個が証明を受けるとクローンを落とし、残る 2 個は
-検査の結果そのものを定数 `true` に畳む。
+### 2.1 解析による証明
 
-| 群 | 数 | 証明を受けたときの形 | 検査 |
-|---|---|---|---|
-| 配列（`make_array_unique` 経由） | 9 | `if force_unique { make_array_unique(..) } else { array }` | なし |
-| 配列（hole 付き、`PunchedArrayPlugBody`） | 1 | `make_array_unique_with_hole` | なし |
-| 配列（`ArraySetCapacityBoundsUnchecked`） | 1 | `if !force_unique { realloc_array(..) }` の早期 return | なし |
-| 構造体（`StructPunch` / `StructPlugIn` / `StructSet`） | 3 | `if force_unique { make_struct_unique(..) }` | なし |
-| boxed（`_mutate_boxed_internal` / `_ios` 版） | 2 | `force_unique_boxed(..)` | **あり** |
-| 定数に畳む（`is_unique` / `Array::is_storage_unique`） | 2 | フラグを `true` にして返す | なし |
+`src/rc_ir/unique_check_elim.rs` の `specialize` が、provenance 解析の結果を `leaf_is_unique` に
+問い、真なら `LLVMGen::assuming_unique()` を呼ぶ。`assuming_unique()` は op のフラグを書き換える。
 
-RC IR の `specialize` が実際に一意性を証明するのは主に配列の書き込み経路なので、検査は
-それを最も必要とする 11 の配列 op すべてに届いていない。定数に畳む 2 つでは、誤った証明は
-「プログラムに嘘の答えを返す」形で出る。
+- クローンを出す 16 op: `force_unique` を **false** にする
+- 検査の結果を定数に畳む 2 op (`is_unique`, `Array::is_storage_unique`): `assume_unique` を
+  **true** にする
 
-### 2. global の誤証明を素通しする
+同じ事実が逆極性の 2 つのフィールド名で保持されている。証明を受け取る op はこの 18 個で、
+issue が数えた 16 個は前者だけである。**後者では誤った証明が「プログラムに嘘の答えを返す」形で
+出る**ので、対象に含める。
 
-本来の検査 `Generator::build_branch_by_is_unique` は、まず
-`build_branch_by_refcnt_state` で state を見て、**GLOBAL のオブジェクトをカウントに関わらず
-shared 側へ流す**。一方 `Generator::mark_global_one` は state を書き換えるだけでカウントに
-触らないので、global なオブジェクトのカウントは `create_obj` が入れた 1 のままである。
+この pass が走るのは `Configuration::enable_borrow_optimization()` が真のとき、すなわち
+`-O max` 以上に限られる。
 
-現行の `assert_proven_unique` はカウントだけを `> 1` と比べるため、
-「プログラム全体で共有される値を unique と誤証明する」という最悪のケースを通す。
+### 2.2 解析が global を unique と証明しないこと
 
-### 3. threaded 状態でカウントを非アトミックに読む
+`src/rc_ir/provenance.rs` の `LeafOrigin::Unknown` の定義は「boxed コンテナから読んだ値、
+**global**、`Retain` で複製された値」であり、`resolve_leaf` はこれを `SharingVerdict::Dynamic` に
+落とす。`leaf_is_unique` が真を返すのは `Unique` のときだけなので、**解析は global を unique と
+証明しない**。証明が global を指したなら、それは解析の誤りである。この不変条件は検査の global 腕
+（下記 4.2）が乗っているものなので、テストで固定する。
 
-本来の検査は threaded 状態では acquire の atomic load を使う（TSan が standalone fence から
-happens-before を引かないため、acquire を load 自身に置くことが要る）。`assert_proven_unique`
-は素の load である。
+### 2.3 登録による証明
 
-`Configuration::develop_mode()` は `threaded` を立てず、`develop_mode` を立てる経路は
-インプロセステストだけなので、この穴は現状どのビルドからも到達しない。ただし下の設計では、
-この穴は個別の対処ではなく「本来の検査と同じ機構を使う」ことの帰結として閉じる。
+`force_unique == false` は解析以外からも来る。`src/ast/program.rs` は全 struct について
+`#punch_` / `#plug_in_` を `force_unique: false` で登録する。`act_x` はこれを使って、
+一意性を確かめたあとにフィールドを出し入れする。この経路の証明は解析とは無関係に立つ。
 
-### 4. 検査が発火しうることを固定するテストがない
+検査はどちらの由来でも同じく立つ。ただし unboxed struct が到達しうるのはこの経路だけであり、
+そこには参照カウントが無いので検査の対象にならない（下記 5.3）。
 
-`UGT` を `ULT` に反転しても、`specialize` が `force_unique` をクリアしなくなっても、
-テストスイートは緑のままになる。
+## 3. 参照カウントのモデル
 
+boxed オブジェクトの制御ブロックは 2 つのフィールドを持つ。
 
-## 終状態
+| | 内容 |
+|---|---|
+| `CTRL_BLK_REFCNT_IDX` | 参照カウント |
+| `CTRL_BLK_REFCNT_STATE_IDX` | state バイト |
 
-### A. `Generator::build_assert_unique`
+state は `REFCNT_STATE_LOCAL` / `REFCNT_STATE_THREADED` / `REFCNT_STATE_GLOBAL` の 3 値である。
+**「unique か」はカウント単独では答えられない。**
+
+- **global**: `Generator::mark_global_one` は state を書くだけでカウントに触らない。global な
+  オブジェクトのカウントは `create_obj` が入れた 1 のままなので、カウントだけを見れば unique に
+  見える。実際にはプログラムが走る限り共有されている。
+- **threaded**: カウントは他スレッドが原子的に更新する。素の load はそれ自体がデータ競合になる。
+
+本来の検査 `Generator::build_branch_by_is_unique` はこの構造どおりに答える。まず
+`build_branch_by_refcnt_state` で state を読んで 3 分岐し、
+
+- **local**: 素の load でカウントを読み、1 と比較
+- **threaded**: **acquire の** atomic load で同上
+- **global**: カウントを読まず、無条件に shared 側へ
+
+acquire を load 自身に置くことには理由がある。ThreadSanitizer は standalone の `fence acquire`
+から happens-before を引かないので、acquire を fence に移すとコードは正しいまま**レース検出器が
+後続の書き込みを誤報する**。
+
+## 4. 変更前の検査が持っていた穴
+
+PR #196 が入れた `assert_proven_unique` は、**カウントだけを読んでいた**。issue が挙げた 3 点は、
+この 1 つの設計の誤りの帰結として並ぶ。
+
+1. **global の誤証明を素通しする**。global のカウントは 1 なので、カウントだけを見る検査は
+   「プログラム全体で共有される値を unique と誤証明する」という最悪のケースを通す。
+2. **threaded でカウントを非アトミックに読む**。検査自身がデータ競合になる。
+3. **18 の op のうち 2 つにしか出ない**。`force_unique_boxed` を通る `_mutate_boxed_internal` と
+   その `_ios` 版だけで、`specialize` が実際に証明する主戦場である配列の書き込み 11 op には
+   1 つも届いていない。
+
+したがって対処も 3 つ別々ではない。**本来の検査と同じ機構を使う**ことにすれば 1 と 2 は設計の
+帰結として閉じ、残るのは 3 の配線だけになる。
+
+## 5. 終状態
+
+### 5.1 `Generator::build_assert_unique`
 
 `build_assert_refcnt_state_local` の隣に置く。
 
 ```rust
-fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>, state: RcState)
+pub fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>)
 ```
 
 `build_branch_by_is_unique` と同じ骨格で、shared 側を abort にしたもの。
 
 - `develop_mode` でなければ何も出さない
-- `build_branch_by_refcnt_state(obj_ptr, state)` を再利用して local / threaded / global を得る
-- local: 素の load で `refcnt == 1` を検査
-- threaded: acquire の atomic load で同上。**state は書き換えない**（`build_branch_by_is_unique`
-  が unique 側で行う `mark_local_one` は、検査には属さない）
-- global: 無条件に abort
+- `build_branch_by_refcnt_state(obj_ptr, RcState::Unknown)` で local / threaded / global を得る
+- local: 素の load、threaded: acquire の atomic load、global: 無条件に abort
+- **state は書き換えない**。`build_branch_by_is_unique` は threaded かつ unique の側で
+  `mark_local_one` を呼ぶが、検査が守っている操作はその書き換えを持たない。開発モードのビルド
+  だけが実行時 state を変えれば、そこから先の RC の振る舞いが released build と分岐する。
 
-`state.dispatches()` が false のときは `build_branch_by_refcnt_state` が
-`build_assert_refcnt_state_local` を出したうえで現在ブロックを返すので、local 相当の検査だけが
-残る。これは locality 注釈の検査と一意性証明の検査が同じ地点で重なる、正しい姿である。
+カウントを読んで 1 と比べる列は、本来の検査と合わせて 4 箇所に現れる。これは
+`build_is_refcnt_one(obj_ptr, acquire, name_suffix)` に抽出し、acquire を load に置く理由も
+そこ 1 箇所に書く。
 
-これで指摘 2 と 3 は、別々の対処ではなく設計の帰結として閉じる。
+### 5.2 state を実行時に読む（宣言の契約）
 
-### B. 証明でクローンを落とす判断を集める
+`build_assert_unique` は `RcState` を引数に取らない。理由は locality 推論の契約にある。
 
-現在 16 の `generate` に散っている `if self.force_unique { ... } else { ... }` を、
-`force_unique` を引数に取る関数へ載せ替える。`builtin.rs` の `generate` から
-`if self.force_unique` を消し、判断が残るのは次の 3 箇所になる。
+op は自分が出す一意性検査を `LLVMGen::unique_check_operand` で宣言する。`assuming_local` の doc は
+この宣言について次を定めている。
 
-1. `force_unique_or_assert(gc, val, force_unique, state) -> Object`
-   現在の `force_unique_boxed` を一般化する。unbox な値はカウントを持たないのでそのまま返し、
-   配列は storage を、それ以外の boxed は値そのものを対象にする。13 の op がここに載る。
-2. hole 付きの変種。`PunchedArrayPlugBody` 1 箇所のために残す。
-3. `ArraySetCapacityBoundsUnchecked`。unique 側が `realloc` の in-place 縮小・拡大で、
-   「unique にした値を返す」形をしていない。早期 return の先頭で `build_assert_unique` を直接呼ぶ。
+> A `generate` that emits a check or a reference count it does not declare leaves that one
+> reading the state, so the declarations stay honest about what the annotation covers.
 
-### C. 定数に畳む 2 つの op
+すなわち **宣言していない検査は state を読み続ける**。ところが 18 op すべての
+`unique_check_operand` は
 
-`is_unique` と `Array::is_storage_unique` は返す値を作らないので、上の関数には載らない。
-フラグを `true` にする地点で `build_assert_unique` を直接呼ぶ。
+```rust
+if !self.force_unique { return None; }   // あるいは if self.assume_unique { return None; }
+```
 
-## 実装手順
+で始まる。**証明が受理された瞬間に宣言が取り下げられる**。そして検査が立つのはまさにその地点である。
+よって、取り下げられた宣言に乗った locality 注釈は、この地点の対象について何も言っていない。
+`assumed_state(self.assume_local)` を渡すと、誰も証明していない locality を根拠に
+`build_assert_refcnt_state_local` が出て、正しい一意性証明に対して locality のメッセージで
+誤 abort しうる。
 
-1. `build_assert_unique` を追加する。
-2. `force_unique_or_assert` へ 13 の op を載せ替える。
-3. hole 付き変種と `ArraySetCapacityBoundsUnchecked` を処理する。
-4. 定数に畳む 2 つの op に検査を入れる。
-5. 現行の `assert_proven_unique` を削除する。
-6. スイートを `-O none` / `-O max` で回す。
+コストは開発モードでの state load 1 回である。なお threaded ビルドでは
+`locality::specialize` 自体が走らない（`build_object_files.rs` が `!config.threaded` で
+ガードしている）ので、そこでは `assume_local` はそもそも立たない。
 
-## 検証
+### 5.3 証明でクローンを落とす判断を集める
 
-### global を即 abort にしてよいか
+16 の `generate` に散っていた `if self.force_unique { make_X_unique(..) } else { .. }` を
+`force_unique_or_assert` に載せ替える。この関数は値の形で分岐する。
 
-よい。`rc_ir/provenance.rs` の `LeafOrigin::Unknown` は「boxed コンテナから読んだ値、
-**global**、`Retain` で複製された値」であり、`resolve_leaf` はこれを `Dynamic` に落とす。
-`leaf_is_unique` が `true` を返すのは `SharingVerdict::Unique` のときだけなので、
-**解析は global を unique と証明しない**。証明が global を指したならそれは解析の誤りである。
+| 値の形 | `force_unique` | `!force_unique` |
+|---|---|---|
+| 配列 | `make_array_unique_with_hole` | storage を対象に検査（カウントは storage が持つ） |
+| boxed struct / union | `make_struct_union_unique` | 値そのものを対象に検査 |
+| unboxed struct / union | そのまま返す | そのまま返す（カウントが無い） |
 
-### 発火の証明（1 回きり、テストには残さない）
+unboxed が到達するのは 2.3 の登録経路だけである。ここに配列や `_mutate_boxed*` の値が来ることは
+無い（前者は先に分岐し、後者は `[a : Boxed]` 束縛を持つ）ので、unboxed 側では struct か union で
+あることを表明する。
+
+### 5.4 一般の入口に載らない 3 つ
+
+- `ArraySetCapacityBoundsUnchecked`: unique 側が `realloc` による in-place の縮小・拡大で、
+  「unique にした値を返す」形をしていない。早期 return の先頭で検査を直接呼ぶ。
+- `PunchedArrayPlugBody`: クローンが穴を残す必要があるので、hole を取る変種を使う。
+- `is_unique` / `Array::is_storage_unique`: 値を作らずフラグを定数 `true` に畳むので、
+  その地点で検査を直接呼ぶ。
+
+## 6. 何が測れて何が測れないか
+
+### 6.1 測れないもの
+
+**18 箇所の検査をすべて削除しても、テストスイートは緑のままである。** これは違反を強制できない
+assertion 一般の性質であって、この検査に固有の弱さではない。テストで固定するには、誤った証明を
+作る口をコンパイラ側に用意するしかなく、それは production コードをテストのために歪めることになる。
+
+IR を読んで「証明が通った経路に検査が出ている」ことを固定する案も検討したが、使えない。
+develop mode のビルドはインプロセスでしか起きず（`Configuration::develop_mode()` を呼ぶのは
+テストだけで、CLI から立てる手段が無い）、オブジェクトキャッシュがカレントディレクトリ
+（全テスト共有）に載る。**同じソースの 2 回目のビルドはコード生成ごと飛んで `.ll` が出ない。**
+`fix_build_source_command` を使う既存の IR テストは `current_dir(temp_dir)` でキャッシュごと
+隔離しているのでこの罠を踏まない。これは #197 と同じ土俵の問題である。
+
+恒久的な歯止めにするなら 8 の構造化が要る。
+
+### 6.2 測れるもの
+
+- **検査が誤った証明に反応すること**（注入と対照の組、7.1）
+- **検査が経路に届いていること**（比較の反転、7.2）
+- **証明が受理される地点が実在すること**。RC IR ダンプの `[unique]` マーカで固定する。
+  検査そのものではなく「検査が立つ地点」を固定するもので、将来 provenance/specialize の変更で
+  その op が証明を受けなくなれば落ちる。
+
+## 7. 検証
+
+### 7.1 検査が発火することの証明
 
 `unique_check_elim` の `leaf_is_unique` の結果を常に `true` に差し替え、共有された配列への
 `Array::set` を develop mode で走らせる。
@@ -129,29 +203,46 @@ fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>, state: RcState)
 
 対照側を測らないと「注入が原因で鳴った」とは言えないので、両方を走らせる。
 
-### 検査が経路に届いていることの確認
+### 7.2 検査が経路に届いていることの確認
 
 比較 `EQ` を `NE` に反転させると、配列テストが軒並み落ちる
 （`test_array_bounds_check::test_set` は期待する "Index out of range" ではなく abort する）。
-issue が挙げた「反転してもスイートは緑のまま」は、検査が 2 経路から 18 経路に増えたことで
-解消している。**既存の 1207 件が、検査そのものの正しさを毎回検証する形になった。**
+issue が挙げた「反転してもスイートは緑のまま」は、検査が 2 経路から 18 経路に増えたことで解消した。
+既存の 1209 件が、検査そのものの正しさを毎回検証する形になっている。
 
-### スイートとコスト
+### 7.3 追加したテスト
 
-`-O none` 1207 件、`-O max` 1207 件、いずれも 0 失敗。所要は none 468 秒 / max 402 秒で、
-これまでの範囲内にある。検査は develop mode だけなので released build には出ない。
+- `test_unique_check_elim_local_fresh` に 5 つのマーカ。`struct_punch_0` / `struct_plug_in_0` /
+  `is_unique` / `mutate_boxed` / `mutate_boxed_ios` は、証明が受理されることを固定するものが
+  何も無かった。追加した Fix コードを外すとテストが落ちることを確認済み。
+- `test_global_value_keeps_its_check`（新ケース `unique_elim_global`）。2.2 の不変条件を固定する。
+- `test_threaded_build_checks_its_uniqueness_proofs`。develop mode と `--threaded` が同時に立つ
+  唯一の構成で、state 分岐の threaded 腕がコード生成され verifier を通る。実行が取るのは
+  local 腕である（threaded 腕だけを反転しても落ちないことで確認した）。
 
-## 恒久テストを置かない理由
+### 7.4 スイートと影響範囲
 
-「証明が通った経路に検査が出ている」ことを IR で固定する案は退けた。develop mode のビルドは
-インプロセスでしか起きず、オブジェクトキャッシュがカレントディレクトリ（全テスト共有）に載る。
-同じソースの 2 回目のビルドはコード生成ごと飛ぶので、IR ファイルが出ない。テスト側では直せず、
-develop mode を CLI から立てられるようにするのは公開仕様の変更になる。
+`-O none` 1209 件 / `-O max` 1209 件、いずれも 0 失敗。所要は none 471 秒 / max 401 秒で、
+これまでの範囲内にある。
 
-代わりの証拠は上の 2 つ、注入と対照の組、および反転が経路に届いていることの確認である。
+**develop mode 以外への影響が無いことを実測した。** `origin/main` (`d41046e5`) のコンパイラと
+本ブランチのコンパイラで `examples/` の 17 プログラムを `-O none` / `-O basic` / `-O max` で
+コンパイルし、モジュールハッシュを正規化した LLVM IR を突き合わせて **51/51 が一致**
+（計 290 モジュール）。比較器が差を報告できることは、同一プログラムを 2 つの最適化レベルで
+ビルドして確かめた。51 対すべての IR に `is_unique` が現れるので、コーパスは 5.1 で抽出した
+`build_is_refcnt_one`（released build にも出る経路）に到達している。
 
-## 残る改善案（この変更には含めない）
+## 8. 残る設計課題
 
-検査の呼び出しを op から取り上げ、inline-LLVM op のコード生成を行う唯一の地点で、
-`unique_check_operand` の鏡（証明が通ったときに操作対象を返す宣言）を読んで出す形にすれば、
-**新しい op が検査を書き忘れること自体が起きなくなる**。今回は各 op が検査を持つ形に留める。
+- **19 個目の op が検査を書き忘れる余地**。検査の呼び出しを op から取り上げ、inline-LLVM op の
+  コード生成を行う唯一の地点で `unique_check_operand` の鏡（証明が受理されたときに検査対象を
+  返す宣言）を読んで出す形にすれば、書き忘れ自体が起きなくなる。boxed leaf を `FieldPath` で
+  辿ってポインタを得るヘルパが要る（配列は storage、それ以外は値そのもの、という
+  `force_unique_or_assert` が今は手で書いている区別）。
+- **`force_unique` と `assume_unique` が同じ事実を逆極性で持っている**（2.1）。読み手は op を
+  移るたびに極性を反転させる必要がある。
+- `get_array_storage(gc, x).value(gc).into_pointer_value()` が 3 箇所にある。`object.rs` の
+  `get_array_storage_buf` の隣に `get_array_storage_ptr` が要る。
+- `_mutate_boxed_internal` / `_ios` と `mutate_elements` / `_ios` の 4 つの op 本体が同じ核を
+  繰り返している。
+- `src/fixstd/builtin.rs` が 8400 行で、配列 / struct・union / FFI の builtin が同居している。

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -1971,8 +1971,8 @@ pub fn array_unsafe_get_bounds_unchecked() -> (Arc<ExprNode>, Arc<Scheme>) {
 pub struct InlineLLVMArrayTruncateBoundsUnchecked {
     arr_name: FullName,
     len_name: FullName,
-    // When true, clone the array first if it is shared, so the shrink lands in a uniquely owned
-    // array. Set false only where the array is statically known to be unique.
+    /// When true, clone the array first if it is shared, so the shrink lands in a uniquely owned
+    /// array. Set false only where the array is statically known to be unique.
     pub(crate) force_unique: bool,
     /// Whether the object this op's declared uniqueness check tests is known to be in the local
     /// reference-counting state, so that the check reads the count without reading the state.
@@ -3443,6 +3443,9 @@ pub fn swap_bounds_unchecked_array() -> (Arc<ExprNode>, Arc<Scheme>) {
     swap_array_common(false)
 }
 
+/// The body of the array punch: the element at the index bound to `idx_name` is moved out of the
+/// array bound to `arr_name`, leaving that slot as the hole, and is returned together with the
+/// punched array.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMArrayPunchBody {
     pub(crate) force_unique: bool,
@@ -4529,6 +4532,8 @@ impl LLVMGen for InlineLLVMCaptureProjectBody {
     }
 }
 
+/// The body of a struct's `punch_x`: field `field_idx` is moved out of the struct bound to
+/// `var_name`, and is returned together with the punched struct, whose type records the hole.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructPunchBody {
     pub var_name: FullName,
@@ -5732,14 +5737,16 @@ fn make_struct_union_unique<'c, 'm>(
     obj
 }
 
+/// The body of a struct's `set_x`: the value bound to `value_name` takes the place of field
+/// `field_idx` of the struct bound to `struct_name`, and the value it displaces is released.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructSetBody {
     pub value_name: FullName,
     pub struct_name: FullName,
     field_count: u32,
     field_idx: u32,
-    // When true, clone the struct first if it is shared, so the write lands in a uniquely owned
-    // struct. Set false only where the struct is statically known to be unique.
+    /// When true, clone the struct first if it is shared, so the write lands in a uniquely owned
+    /// struct. Set false only where the struct is statically known to be unique.
     pub(crate) force_unique: bool,
     /// Whether the object this op's declared uniqueness check tests is known to be in the local
     /// reference-counting state, so that the check reads the count without reading the state.

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -6783,13 +6783,12 @@ impl LLVMGen for InlineLLVMIsUniqueFunctionBody {
         let ret = create_obj(ret_ty.clone(), &vec![], None, gc, Some("ret@is_unique"));
 
         // Get whether argument is unique.
+        let obj_ptr = obj.value(gc).into_pointer_value();
         let is_unique = if self.assume_unique {
             // The caller proved the argument unique, so the flag is the constant `true`.
-            let obj_ptr = obj.value(gc).into_pointer_value();
             gc.build_assert_unique(obj_ptr);
             bool_ty.const_int(1, false)
         } else {
-            let obj_ptr = obj.value(gc).into_pointer_value();
             let current_func = gc.current_function();
 
             let (unique_bb, shared_bb) =
@@ -6977,9 +6976,7 @@ impl LLVMGen for InlineLLVMArrayIsStorageUniqueBody {
 
         // Get whether the storage is uniquely referenced.
         let is_unique = if !self.assume_unique {
-            let storage_ptr = array
-                .extract_field(gc, ARRAY_STORAGE_IDX)
-                .into_pointer_value();
+            let storage_ptr = get_array_storage(gc, &array).value(gc).into_pointer_value();
             let current_func = gc.current_function();
 
             let (unique_bb, shared_bb) =
@@ -7846,12 +7843,18 @@ fn force_unique_or_assert_with_hole<'c, 'm>(
     if force_unique {
         return make_struct_union_unique(gc, val, state);
     }
-    // `act_x` punches and plugs with the check already dropped, so an unboxed struct reaches here.
-    // Such a value carries no reference count, and is unique by being held in registers.
-    if val.is_box(gc.type_env()) {
-        let obj_ptr = val.value(gc).into_pointer_value();
-        gc.build_assert_unique(obj_ptr);
+    if !val.is_box(gc.type_env()) {
+        // `act_x` punches and plugs with the check already dropped, so an unboxed struct reaches
+        // here. Such a value carries no reference count, and is unique by being held in registers.
+        assert!(
+            val.ty.is_struct(gc.type_env()) || val.ty.is_union(gc.type_env()),
+            "an unboxed value reaching here is a struct or a union, and `{}` is neither.",
+            val.ty.to_string()
+        );
+        return val;
     }
+    let obj_ptr = val.value(gc).into_pointer_value();
+    gc.build_assert_unique(obj_ptr);
     val
 }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -3457,12 +3457,12 @@ pub struct InlineLLVMArrayPunchBody {
 impl LLVMGen for InlineLLVMArrayPunchBody {
     fn generate<'c, 'm>(&self, gc: &mut Generator<'c, 'm>, ret_ty: &Arc<TypeNode>) -> Object<'c> {
         // ret_ty = (PunchedArray a, a)
-        let mut array = gc.get_scoped_obj(&self.arr_name);
+        let array = gc.get_scoped_obj(&self.arr_name);
         let idx_obj = gc.get_scoped_obj(&self.idx_name);
         let idx = idx_obj.extract_field(gc, 0).into_int_value();
 
         // The array has no hole yet, so this is an ordinary clone-if-shared.
-        array = force_unique_or_assert(
+        let array = force_unique_or_assert(
             gc,
             array,
             self.force_unique,
@@ -3642,12 +3642,12 @@ impl LLVMGen for InlineLLVMPunchedArrayPlugBody {
         let punched = gc.get_scoped_obj(&self.punched_name);
 
         // Deconstruct PunchedArray { _arr : array, _idx : idx }.
-        let mut array = ObjectFieldType::move_out_struct_field(gc, &punched, 0);
+        let array = ObjectFieldType::move_out_struct_field(gc, &punched, 0);
         let idx_obj = ObjectFieldType::move_out_struct_field(gc, &punched, 1);
         let idx = idx_obj.extract_field(gc, 0).into_int_value();
 
         // On a shared array, clone skipping the hole so this plug gets a private array.
-        array = force_unique_or_assert_with_hole(
+        let array = force_unique_or_assert_with_hole(
             gc,
             array,
             Some(idx),
@@ -4543,10 +4543,10 @@ pub struct InlineLLVMStructPunchBody {
 impl LLVMGen for InlineLLVMStructPunchBody {
     fn generate<'c, 'm>(&self, gc: &mut Generator<'c, 'm>, ret_ty: &Arc<TypeNode>) -> Object<'c> {
         // Get the argument object (the struct value).
-        let mut struct_obj = gc.get_scoped_obj(&self.var_name);
+        let struct_obj = gc.get_scoped_obj(&self.var_name);
 
         // Punching moves a field out of the struct, so the struct has to be uniquely owned.
-        struct_obj = force_unique_or_assert(
+        let struct_obj = force_unique_or_assert(
             gc,
             struct_obj,
             self.force_unique,
@@ -4753,11 +4753,11 @@ impl LLVMGen for InlineLLVMStructPlugInBody {
         struct_ty: &Arc<TypeNode>,
     ) -> Object<'c> {
         // Get the first argument, a punched struct value, and the second argument, a field value.
-        let mut punched_struct = gc.get_scoped_obj(&self.punched_struct_name);
+        let punched_struct = gc.get_scoped_obj(&self.punched_struct_name);
         let field = gc.get_scoped_obj(&self.field_name);
 
         // Make the punched struct unique before plugging-in the field value.
-        punched_struct = force_unique_or_assert(
+        let punched_struct = force_unique_or_assert(
             gc,
             punched_struct,
             self.force_unique,
@@ -6771,6 +6771,13 @@ impl LLVMGen for InlineLLVMIsUniqueFunctionBody {
 
         // Get argument
         let obj = gc.get_scoped_obj(&self.var_name);
+        // The `[a : Boxed]` bound of `is_unique` makes the argument boxed, so it carries a
+        // reference count to read.
+        assert!(
+            obj.is_box(gc.type_env()),
+            "is_unique is applied to a value of the unboxed type {}.",
+            obj.ty.to_string()
+        );
 
         // Prepare returned object.
         let ret = create_obj(ret_ty.clone(), &vec![], None, gc, Some("ret@is_unique"));
@@ -6782,13 +6789,6 @@ impl LLVMGen for InlineLLVMIsUniqueFunctionBody {
             gc.build_assert_unique(obj_ptr);
             bool_ty.const_int(1, false)
         } else {
-            // The `[a : Boxed]` bound of `is_unique` makes the argument boxed, so it carries a
-            // reference count to branch on.
-            assert!(
-                obj.is_box(gc.type_env()),
-                "is_unique is applied to a value of the unboxed type {}.",
-                obj.ty.to_string()
-            );
             let obj_ptr = obj.value(gc).into_pointer_value();
             let current_func = gc.current_function();
 
@@ -7808,9 +7808,10 @@ fn assumed_state(assume_local: bool) -> RcState {
 /// proof is trusted, and what checks the trust, are decided together.
 ///
 /// # Arguments
-/// * `force_unique` — false where the uniqueness analysis proved the value already unique; the value
-///   is then returned as it stands, and compiler development mode checks that proof against the
-///   value's reference count.
+/// * `force_unique` — false where the value is already known unique, either because the uniqueness
+///   analysis proved it or because the op is registered for a caller that guarantees it, as `act_x`
+///   registers the punch and the plug it carries its update out with. The value is then returned as
+///   it stands, and compiler development mode checks that against its reference count.
 /// * `state` — the reference-counting state the clone's uniqueness check reads the count under.
 fn force_unique_or_assert<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
@@ -7845,6 +7846,8 @@ fn force_unique_or_assert_with_hole<'c, 'm>(
     if force_unique {
         return make_struct_union_unique(gc, val, state);
     }
+    // `act_x` punches and plugs with the check already dropped, so an unboxed struct reaches here.
+    // Such a value carries no reference count, and is unique by being held in registers.
     if val.is_box(gc.type_env()) {
         let obj_ptr = val.value(gc).into_pointer_value();
         gc.build_assert_unique(obj_ptr);

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -36,8 +36,7 @@ use crate::misc::{make_map, Map, Set};
 use crate::object::{
     alloc_array_storage, build_array_storage_shift, build_capacity_check, build_elems_bytes,
     build_storage_is_aligned, create_obj, get_array_storage, get_array_storage_buf,
-    read_alloc_offset, refcnt_type, union_tag_type, write_alloc_offset, CapacityCheck,
-    ObjectFieldType,
+    read_alloc_offset, union_tag_type, write_alloc_offset, CapacityCheck, ObjectFieldType,
 };
 use crate::optimization::rename::generate_new_names;
 use crate::parse::sourcefile::Span;
@@ -1987,11 +1986,12 @@ impl LLVMGen for InlineLLVMArrayTruncateBoundsUnchecked {
         let new_len = gc.get_scoped_obj_field(&self.len_name, 0).into_int_value();
 
         // Force the array to be unique before shrinking it in place.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Release the dropped tail `[new_len, size)`, then lower the length to `new_len`. The caller
         // guarantees `0 <= new_len <= size`, so there is no size check.
@@ -2144,11 +2144,12 @@ impl LLVMGen for InlineLLVMArrayAppendValueCapacityUnchecked {
             .into_int_value();
 
         // Force the array to be unique before appending in place.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Write `value` into the `count` uninitialized slots at the end and grow the length. The
         // caller guarantees `count >= 0` and `size + count <= capacity`.
@@ -2480,6 +2481,9 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         let new_cap = gc.get_scoped_obj_field(&self.cap_name, 0).into_int_value();
 
         if !self.force_unique {
+            // `realloc` resizes the storage where it stands, so the proof that nobody else holds it
+            // is what makes the resize legal.
+            assert_array_storage_unique(gc, &array, assumed_state(self.assume_local));
             return realloc_array(gc, array, new_cap, CapacityCheck::Run);
         }
 
@@ -2670,11 +2674,8 @@ impl LLVMGen for InlineLLVMArrayAppendCapacityBoundsUnchecked {
         let n = gc.builder().build_int_sub(end, begin, "append_n").unwrap();
 
         // Clone `dst` if it is shared, so the append writes into a uniquely owned array.
-        let dst = if self.force_unique {
-            make_array_unique(gc, dst, assumed_state(self.assume_local))
-        } else {
-            dst
-        };
+        let dst =
+            force_unique_or_assert(gc, dst, self.force_unique, assumed_state(self.assume_local));
         let dst_len = dst.extract_field(gc, ARRAY_SIZE_IDX).into_int_value();
         let dst_buf = get_array_storage_buf(gc, &dst);
         let dst_write = unsafe {
@@ -2928,11 +2929,12 @@ impl LLVMGen for InlineLLVMArrayGrowSizeBody {
 
         // Force the array to be unique before growing it in place, so the length is written only on a
         // uniquely owned array.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
         array.insert_field(gc, ARRAY_SIZE_IDX, length)
     }
 
@@ -3044,16 +3046,6 @@ pub fn grow_size_array() -> (Arc<ExprNode>, Arc<Scheme>) {
 
 /// Force an array object to be unique: a unique array is returned as it is, and a shared one is
 /// cloned.
-fn make_array_unique<'c, 'm>(
-    gc: &mut Generator<'c, 'm>,
-    array: Object<'c>,
-    state: RcState,
-) -> Object<'c> {
-    make_array_unique_with_hole(gc, array, None, state)
-}
-
-/// Force an array object to be unique: a unique array is returned as it is, and a shared one is
-/// cloned.
 ///
 /// # Arguments
 /// * `hole` — `Some(idx)` makes the clone skip the element at `idx`, leaving that slot
@@ -3129,11 +3121,12 @@ impl LLVMGen for InlineLLVMArraySetBody {
         let value = gc.get_scoped_obj(&self.value_name);
 
         // Force array to be unique
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Perform write and return. `set` bounds-checks unless `--no-runtime-check` is set;
         // `unsafe_set_bounds_unchecked` never bounds-checks.
@@ -3308,11 +3301,12 @@ impl LLVMGen for InlineLLVMArraySwapBody {
         let j = gc.get_scoped_obj_field(&self.j_name, 0).into_int_value();
 
         // Force array to be unique.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         let elem_ty = array.ty.field_types(gc.type_env())[0].clone();
         // `swap` bounds-checks unless `--no-runtime-check` is set; `unsafe_swap_bounds_unchecked`
@@ -3468,9 +3462,12 @@ impl LLVMGen for InlineLLVMArrayPunchBody {
         let idx = idx_obj.extract_field(gc, 0).into_int_value();
 
         // The array has no hole yet, so this is an ordinary clone-if-shared.
-        if self.force_unique {
-            array = make_array_unique(gc, array, assumed_state(self.assume_local));
-        }
+        array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Move the element at `idx` out without retaining, leaving its slot as the hole; the
         // length is unchanged.
@@ -3650,10 +3647,13 @@ impl LLVMGen for InlineLLVMPunchedArrayPlugBody {
         let idx = idx_obj.extract_field(gc, 0).into_int_value();
 
         // On a shared array, clone skipping the hole so this plug gets a private array.
-        if self.force_unique {
-            array =
-                make_array_unique_with_hole(gc, array, Some(idx), assumed_state(self.assume_local));
-        }
+        array = force_unique_or_assert_with_hole(
+            gc,
+            array,
+            Some(idx),
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Write the element back into the hole (no bounds check, and no release of the hole slot).
         let buf = get_array_storage_buf(gc, &array);
@@ -4545,10 +4545,13 @@ impl LLVMGen for InlineLLVMStructPunchBody {
         // Get the argument object (the struct value).
         let mut struct_obj = gc.get_scoped_obj(&self.var_name);
 
-        if self.force_unique {
-            // If the struct is shared, we should clone it to make it unique.
-            struct_obj = make_struct_unique(gc, struct_obj, assumed_state(self.assume_local));
-        }
+        // Punching moves a field out of the struct, so the struct has to be uniquely owned.
+        struct_obj = force_unique_or_assert(
+            gc,
+            struct_obj,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Move out struct field value without releasing the struct itself.
         let field = ObjectFieldType::move_out_struct_field(gc, &struct_obj, self.field_idx as u32);
@@ -4754,10 +4757,12 @@ impl LLVMGen for InlineLLVMStructPlugInBody {
         let field = gc.get_scoped_obj(&self.field_name);
 
         // Make the punched struct unique before plugging-in the field value.
-        if self.force_unique {
-            punched_struct =
-                make_struct_unique(gc, punched_struct, assumed_state(self.assume_local));
-        }
+        punched_struct = force_unique_or_assert(
+            gc,
+            punched_struct,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Convert type of punched_struct into the struct type.
         let punched_value = punched_struct.value(gc);
@@ -5665,16 +5670,6 @@ pub fn struct_act_const(
     (expr, scm)
 }
 
-/// Force a struct object to be unique: an unboxed or unique struct is returned as it is, and a
-/// shared boxed one is cloned.
-fn make_struct_unique<'c, 'm>(
-    gc: &mut Generator<'c, 'm>,
-    struct_obj: Object<'c>,
-    state: RcState,
-) -> Object<'c> {
-    make_struct_union_unique(gc, struct_obj, state)
-}
-
 /// Force a struct or union object to be unique: an unboxed or unique object is returned as it is,
 /// and a shared boxed one is cloned.
 fn make_struct_union_unique<'c, 'm>(
@@ -5759,11 +5754,12 @@ impl LLVMGen for InlineLLVMStructSetBody {
         let struct_obj = gc.get_scoped_obj(&self.struct_name);
 
         // Make struct object unique.
-        let struct_obj = if self.force_unique {
-            make_struct_unique(gc, struct_obj, assumed_state(self.assume_local))
-        } else {
-            struct_obj
-        };
+        let struct_obj = force_unique_or_assert(
+            gc,
+            struct_obj,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Release old value
         let old_value =
@@ -6782,6 +6778,8 @@ impl LLVMGen for InlineLLVMIsUniqueFunctionBody {
         // Get whether argument is unique.
         let is_unique = if self.assume_unique {
             // The caller proved the argument unique, so the flag is the constant `true`.
+            let obj_ptr = obj.value(gc).into_pointer_value();
+            gc.build_assert_unique(obj_ptr, assumed_state(self.assume_local));
             bool_ty.const_int(1, false)
         } else {
             // The `[a : Boxed]` bound of `is_unique` makes the argument boxed, so it carries a
@@ -7005,6 +7003,7 @@ impl LLVMGen for InlineLLVMArrayIsStorageUniqueBody {
             flag.as_basic_value().into_int_value()
         } else {
             // Where the caller proved the array unique, the check is known to succeed.
+            assert_array_storage_unique(gc, &array, assumed_state(self.assume_local));
             bool_ty.const_int(1, false)
         };
         let bool_val = make_bool_ty().get_struct_type(gc).get_undef();
@@ -7655,7 +7654,8 @@ impl LLVMGen for InlineLLVMUnsafeMutateBoxedInternalFunctionBody {
         assert!(val.is_box(gc.type_env()));
 
         // Before mutating the value, force uniqueness of the value.
-        let val = force_unique_boxed(gc, val, self.force_unique, assumed_state(self.assume_local));
+        let val =
+            force_unique_or_assert(gc, val, self.force_unique, assumed_state(self.assume_local));
 
         // Get the data pointer.
         let data_ptr = get_data_pointer_from_boxed_value(gc, &val);
@@ -7801,78 +7801,73 @@ fn assumed_state(assume_local: bool) -> RcState {
     }
 }
 
-/// Clone a boxed value when it is shared, so that a write into it is not observed elsewhere.
+/// Clone `val` when it is shared, so that a write into it is not observed elsewhere, or check the
+/// proof that let the clone go.
+///
+/// Every operation that writes into a value it must own reaches this, so the decision to trust a
+/// uniqueness proof is taken in one place, and the check on that proof stands wherever it is taken.
 ///
 /// # Arguments
 /// * `force_unique` — false where the uniqueness analysis proved the value already unique; the value
 ///   is then returned as it stands, and compiler development mode checks that proof against the
 ///   value's reference count.
 /// * `state` — the reference-counting state the uniqueness check reads the count under.
-fn force_unique_boxed<'c, 'm>(
+fn force_unique_or_assert<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     val: Object<'c>,
     force_unique: bool,
     state: RcState,
 ) -> Object<'c> {
-    assert!(
-        val.is_box(gc.type_env()),
-        "force_unique_boxed on the unboxed type {}.",
-        val.ty.to_string()
-    );
-    if !force_unique {
-        assert_proven_unique(gc, &val);
-        return val;
-    }
-    make_struct_union_unique(gc, val, state)
+    force_unique_or_assert_with_hole(gc, val, None, force_unique, state)
 }
 
-/// Abort, in compiler development mode, if `val` is shared where the uniqueness analysis proved it
-/// unique.
-///
-/// Dropping the check that clones a shared container is what makes an in-place write legal, so a
-/// wrong proof turns a value another holder can see into one this code overwrites. Between threads
-/// that other holder may be running, which makes the mistake a data race that the write's own thread
-/// never sees. The check the analysis removed is exactly the observation that would have caught it,
-/// so it is made again here, where a violated proof stops at the write rather than at whatever reads
-/// the value later.
-///
-/// Development mode only: this restores the cost the analysis exists to remove.
-fn assert_proven_unique<'c, 'm>(gc: &mut Generator<'c, 'm>, val: &Object<'c>) {
+/// `force_unique_or_assert` where the value is an array and the clone leaves the element at `hole`
+/// uninitialized for the caller to fill.
+fn force_unique_or_assert_with_hole<'c, 'm>(
+    gc: &mut Generator<'c, 'm>,
+    val: Object<'c>,
+    hole: Option<IntValue<'c>>,
+    force_unique: bool,
+    state: RcState,
+) -> Object<'c> {
+    assert!(
+        hole.is_none() || val.ty.is_array(),
+        "a hole is left in an array, and `{}` is not one.",
+        val.ty.to_string()
+    );
+    if val.ty.is_array() {
+        if force_unique {
+            return make_array_unique_with_hole(gc, val, hole, state);
+        }
+        assert_array_storage_unique(gc, &val, state);
+        return val;
+    }
+    if !val.is_box(gc.type_env()) {
+        // An unboxed value holds no reference count: it has nothing to share, hence nothing to
+        // clone and nothing to check.
+        return val;
+    }
+    if force_unique {
+        return make_struct_union_unique(gc, val, state);
+    }
+    let obj_ptr = val.value(gc).into_pointer_value();
+    gc.build_assert_unique(obj_ptr, state);
+    val
+}
+
+/// Check the proof that an array is uniquely owned, which is a proof about its storage: that is
+/// where an array's reference count lives.
+fn assert_array_storage_unique<'c, 'm>(
+    gc: &mut Generator<'c, 'm>,
+    array: &Object<'c>,
+    state: RcState,
+) {
     if !gc.config.develop_mode {
         return;
     }
-    let obj_ptr = val.value(gc).into_pointer_value();
-    let refcnt_ptr = gc.get_refcnt_ptr(obj_ptr);
-    let refcnt = gc
-        .builder()
-        .build_load(refcnt_type(gc.context), refcnt_ptr, "refcnt@assert_unique")
-        .unwrap()
-        .into_int_value();
-    let is_shared = gc
-        .builder()
-        .build_int_compare(
-            IntPredicate::UGT,
-            refcnt,
-            refcnt_type(gc.context).const_int(1, false),
-            "is_shared@assert_unique",
-        )
-        .unwrap();
-    let current_func = gc.current_function();
-    let shared_bb = gc
-        .context
-        .append_basic_block(current_func, "shared_bb@assert_unique");
-    let unique_bb = gc
-        .context
-        .append_basic_block(current_func, "unique_bb@assert_unique");
-    gc.builder()
-        .build_conditional_branch(is_shared, shared_bb, unique_bb)
-        .unwrap();
-
-    gc.builder().position_at_end(shared_bb);
-    gc.panic("A write inferred to be into a unique object reached a shared one.\n");
-    gc.builder().build_unconditional_branch(unique_bb).unwrap();
-
-    gc.builder().position_at_end(unique_bb);
+    let storage = get_array_storage(gc, array);
+    let storage_ptr = storage.value(gc).into_pointer_value();
+    gc.build_assert_unique(storage_ptr, state);
 }
 
 /// The definition of `Std::FFI::_mutate_boxed_internal`, which makes the boxed value unique, applies
@@ -7944,7 +7939,8 @@ impl LLVMGen for InlineLLVMUnsafeMutateBoxedIOSInternalBody {
         assert!(val.is_box(gc.type_env()));
 
         // Before mutating the value, force uniqueness of the value.
-        let val = force_unique_boxed(gc, val, self.force_unique, assumed_state(self.assume_local));
+        let val =
+            force_unique_or_assert(gc, val, self.force_unique, assumed_state(self.assume_local));
 
         // Get the data pointer.
         let data_ptr = get_data_pointer_from_boxed_value(gc, &val);
@@ -8210,11 +8206,12 @@ impl LLVMGen for InlineLLVMArrayMutateElementsInternalBody {
         assert!(array.ty.is_array());
 
         // Clone the array first if it is shared, so the callback writes into a uniquely owned one.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Run the callback with a pointer to the first element.
         let data_ptr = get_array_storage_buf(gc, &array);
@@ -8351,11 +8348,12 @@ impl LLVMGen for InlineLLVMArrayMutateElementsIosInternalBody {
         assert!(array.ty.is_array());
 
         // Clone the array first if it is shared, so the callback writes into a uniquely owned one.
-        let array = if self.force_unique {
-            make_array_unique(gc, array, assumed_state(self.assume_local))
-        } else {
-            array
-        };
+        let array = force_unique_or_assert(
+            gc,
+            array,
+            self.force_unique,
+            assumed_state(self.assume_local),
+        );
 
         // Run the callback with a pointer to the first element, threading the real `ios`.
         let data_ptr = get_array_storage_buf(gc, &array);

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -5709,7 +5709,7 @@ fn make_struct_union_unique<'c, 'm>(
     // Release the old object.
     gc.release(obj.clone(), state);
 
-    let cloned_obj_ptr = cloned_obj.value(gc);
+    let cloned_obj_val = cloned_obj.value(gc);
     let succ_of_shared_bb = gc.builder().get_insert_block().unwrap();
     gc.builder().build_unconditional_branch(end_bb).unwrap();
 
@@ -5725,7 +5725,7 @@ fn make_struct_union_unique<'c, 'm>(
         .builder()
         .build_phi(obj_ptr.get_type(), "obj_phi")
         .unwrap();
-    obj_phi.add_incoming(&[(&obj_ptr, unique_bb), (&cloned_obj_ptr, succ_of_shared_bb)]);
+    obj_phi.add_incoming(&[(&obj_ptr, unique_bb), (&cloned_obj_val, succ_of_shared_bb)]);
 
     obj = Object::new(obj_phi.as_basic_value(), obj.ty.clone(), gc);
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -7819,8 +7819,8 @@ fn force_unique_or_assert<'c, 'm>(
     force_unique_or_assert_with_hole(gc, val, None, force_unique, state)
 }
 
-/// `force_unique_or_assert` where the value is an array and the clone leaves the element at `hole`
-/// uninitialized for the caller to fill.
+/// `force_unique_or_assert`, where `Some(hole)` makes a clone of the array `val` leave the element
+/// at that index uninitialized for the caller to fill.
 fn force_unique_or_assert_with_hole<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     val: Object<'c>,

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -2483,7 +2483,7 @@ impl LLVMGen for InlineLLVMArraySetCapacityBoundsUnchecked {
         if !self.force_unique {
             // `realloc` resizes the storage where it stands, so the proof that nobody else holds it
             // is what makes the resize legal.
-            assert_array_storage_unique(gc, &array, assumed_state(self.assume_local));
+            assert_array_storage_unique(gc, &array);
             return realloc_array(gc, array, new_cap, CapacityCheck::Run);
         }
 
@@ -6779,7 +6779,7 @@ impl LLVMGen for InlineLLVMIsUniqueFunctionBody {
         let is_unique = if self.assume_unique {
             // The caller proved the argument unique, so the flag is the constant `true`.
             let obj_ptr = obj.value(gc).into_pointer_value();
-            gc.build_assert_unique(obj_ptr, assumed_state(self.assume_local));
+            gc.build_assert_unique(obj_ptr);
             bool_ty.const_int(1, false)
         } else {
             // The `[a : Boxed]` bound of `is_unique` makes the argument boxed, so it carries a
@@ -7003,7 +7003,7 @@ impl LLVMGen for InlineLLVMArrayIsStorageUniqueBody {
             flag.as_basic_value().into_int_value()
         } else {
             // Where the caller proved the array unique, the check is known to succeed.
-            assert_array_storage_unique(gc, &array, assumed_state(self.assume_local));
+            assert_array_storage_unique(gc, &array);
             bool_ty.const_int(1, false)
         };
         let bool_val = make_bool_ty().get_struct_type(gc).get_undef();
@@ -7804,14 +7804,14 @@ fn assumed_state(assume_local: bool) -> RcState {
 /// Clone `val` when it is shared, so that a write into it is not observed elsewhere, or check the
 /// proof that let the clone go.
 ///
-/// Every operation that writes into a value it must own reaches this, so the decision to trust a
-/// uniqueness proof is taken in one place, and the check on that proof stands wherever it is taken.
+/// The operations that write into a value they must own reach this, so that whether a uniqueness
+/// proof is trusted, and what checks the trust, are decided together.
 ///
 /// # Arguments
 /// * `force_unique` — false where the uniqueness analysis proved the value already unique; the value
 ///   is then returned as it stands, and compiler development mode checks that proof against the
 ///   value's reference count.
-/// * `state` — the reference-counting state the uniqueness check reads the count under.
+/// * `state` — the reference-counting state the clone's uniqueness check reads the count under.
 fn force_unique_or_assert<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     val: Object<'c>,
@@ -7839,35 +7839,28 @@ fn force_unique_or_assert_with_hole<'c, 'm>(
         if force_unique {
             return make_array_unique_with_hole(gc, val, hole, state);
         }
-        assert_array_storage_unique(gc, &val, state);
-        return val;
-    }
-    if !val.is_box(gc.type_env()) {
-        // An unboxed value holds no reference count: it has nothing to share, hence nothing to
-        // clone and nothing to check.
+        assert_array_storage_unique(gc, &val);
         return val;
     }
     if force_unique {
         return make_struct_union_unique(gc, val, state);
     }
-    let obj_ptr = val.value(gc).into_pointer_value();
-    gc.build_assert_unique(obj_ptr, state);
+    if val.is_box(gc.type_env()) {
+        let obj_ptr = val.value(gc).into_pointer_value();
+        gc.build_assert_unique(obj_ptr);
+    }
     val
 }
 
 /// Check the proof that an array is uniquely owned, which is a proof about its storage: that is
 /// where an array's reference count lives.
-fn assert_array_storage_unique<'c, 'm>(
-    gc: &mut Generator<'c, 'm>,
-    array: &Object<'c>,
-    state: RcState,
-) {
+fn assert_array_storage_unique<'c, 'm>(gc: &mut Generator<'c, 'm>, array: &Object<'c>) {
     if !gc.config.develop_mode {
         return;
     }
     let storage = get_array_storage(gc, array);
     let storage_ptr = storage.value(gc).into_pointer_value();
-    gc.build_assert_unique(storage_ptr, state);
+    gc.build_assert_unique(storage_ptr);
 }
 
 /// The definition of `Std::FFI::_mutate_boxed_internal`, which makes the boxed value unique, applies

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1219,6 +1219,101 @@ impl<'c, 'm> Generator<'c, 'm> {
         self.builder().position_at_end(local_bb);
     }
 
+    /// Abort, in compiler development mode, when the object at `obj_ptr` is shared where the
+    /// uniqueness analysis proved it unique.
+    ///
+    /// Dropping the check that clones a shared container is what makes an in-place write legal, so
+    /// a wrong proof turns a value another holder can see into one this code overwrites. The check
+    /// the proof removed is the observation that would have caught it, so it is made again here,
+    /// where a violated proof stops at the write rather than at whatever reads the value later.
+    ///
+    /// It reads the count the way `build_branch_by_is_unique` does, so that it answers as the check
+    /// it stands in for would: a global object is shared whatever its count says, and a threaded
+    /// one is read by an acquire load, which is also what keeps this check from being a race of its
+    /// own. It leaves the state as it found it, the operation it guards having none of its own to
+    /// mark.
+    ///
+    /// Development mode only: this restores the cost the proof exists to remove.
+    pub fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>, state: RcState) {
+        if !self.config.develop_mode {
+            return;
+        }
+        let current_func = self.current_function();
+        let unique_bb = self
+            .context
+            .append_basic_block(current_func, "unique_bb@assert_unique");
+        let shared_bb = self
+            .context
+            .append_basic_block(current_func, "shared_bb@assert_unique");
+        let one = refcnt_type(self.context).const_int(1, false);
+
+        let (local_bb, threaded_bb, global_bb) = self.build_branch_by_refcnt_state(obj_ptr, state);
+
+        // Implement local_bb: read the count and compare it against one.
+        self.builder().position_at_end(local_bb);
+        let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
+        let refcnt = self
+            .builder()
+            .build_load(
+                refcnt_type(self.context),
+                ptr_to_refcnt,
+                "refcnt@assert_unique",
+            )
+            .unwrap()
+            .into_int_value();
+        let is_unique = self
+            .builder()
+            .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique@assert_unique")
+            .unwrap();
+        self.builder()
+            .build_conditional_branch(is_unique, unique_bb, shared_bb)
+            .unwrap();
+
+        // Implement threaded_bb: the same, reading the count atomically.
+        if let Some(threaded_bb) = threaded_bb {
+            self.builder().position_at_end(threaded_bb);
+            let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
+            let refcnt = self
+                .builder()
+                .build_load(
+                    refcnt_type(self.context),
+                    ptr_to_refcnt,
+                    "refcnt@assert_unique",
+                )
+                .unwrap()
+                .into_int_value();
+            refcnt
+                .as_instruction_value()
+                .unwrap()
+                .set_atomic_ordering(AtomicOrdering::Acquire)
+                .expect("Set atomic ordering failed");
+            let is_unique = self
+                .builder()
+                .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique@assert_unique")
+                .unwrap();
+            self.builder()
+                .build_conditional_branch(is_unique, unique_bb, shared_bb)
+                .unwrap();
+        }
+
+        // Implement global_bb: a global object is shared, so the proof is wrong wherever it names
+        // one.
+        if let Some(global_bb) = global_bb {
+            self.builder().position_at_end(global_bb);
+            self.builder()
+                .build_unconditional_branch(shared_bb)
+                .unwrap();
+        }
+
+        self.builder().position_at_end(shared_bb);
+        self.panic("A value proven uniquely owned was reached while shared.\n");
+        self.builder()
+            .build_unconditional_branch(unique_bb)
+            .unwrap();
+
+        self.builder().position_at_end(unique_bb);
+    }
+
     // Get pointer to state of reference counter of a given object.
     pub fn get_refcnt_state_ptr(&self, obj: PointerValue<'c>) -> PointerValue<'c> {
         self.builder()

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -982,6 +982,50 @@ impl<'c, 'm> Generator<'c, 'm> {
             .unwrap()
     }
 
+    /// Whether the object's reference count is one, read in the current block.
+    ///
+    /// `acquire` makes the load an acquire one, which is what an object in the threaded state needs:
+    /// the writes a unique answer licences must be ordered after the reads the other holders did
+    /// before releasing the object. Keep the acquire on the load itself: ThreadSanitizer draws no
+    /// happens-before edge from a standalone `fence acquire`, so an acquire moved into one leaves
+    /// the code correct while making the race detector report the writes that follow as racing.
+    ///
+    /// `name_suffix` distinguishes the emitted values from those of the other counts a function
+    /// reads.
+    fn build_is_refcnt_one(
+        &mut self,
+        obj_ptr: PointerValue<'c>,
+        acquire: bool,
+        name_suffix: &str,
+    ) -> IntValue<'c> {
+        let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
+        let refcnt = self
+            .builder()
+            .build_load(
+                refcnt_type(self.context),
+                ptr_to_refcnt,
+                &format!("refcnt{}", name_suffix),
+            )
+            .unwrap()
+            .into_int_value();
+        if acquire {
+            refcnt
+                .as_instruction_value()
+                .unwrap()
+                .set_atomic_ordering(AtomicOrdering::Acquire)
+                .expect("Set atomic ordering failed");
+        }
+        let one = refcnt_type(self.context).const_int(1, false);
+        self.builder()
+            .build_int_compare(
+                IntPredicate::EQ,
+                refcnt,
+                one,
+                &format!("is_unique{}", name_suffix),
+            )
+            .unwrap()
+    }
+
     /// Branch on whether the object's reference count is one, returning the block for each answer.
     ///
     /// A global object is never unique, so the count is read only after the state says the object
@@ -1002,53 +1046,21 @@ impl<'c, 'm> Generator<'c, 'm> {
 
         // Implement local_bb.
         self.builder().position_at_end(local_bb);
-        // Load refcnt.
-        let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
-        let refcnt = self
-            .builder()
-            .build_load(refcnt_type(self.context), ptr_to_refcnt, "refcnt")
-            .unwrap()
-            .into_int_value();
         // Jump to shared_bb if refcnt > 1.
-        let one = refcnt_type(self.context).const_int(1, false);
-        let is_unique: IntValue<'_> = self
-            .builder()
-            .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique")
-            .unwrap();
+        let is_unique = self.build_is_refcnt_one(obj_ptr, false, "");
         self.builder()
             .build_conditional_branch(is_unique, unique_bb, shared_bb)
             .unwrap();
 
         // Implement threaded_bb.
-        if threaded_bb.is_some() {
-            let threaded_bb = threaded_bb.clone().unwrap();
+        if let Some(threaded_bb) = threaded_bb {
             let unique_threaded_bb = self
                 .context
                 .append_basic_block(current_func, "unique_threaded_bb");
 
             self.builder().position_at_end(threaded_bb);
-            // Load refcnt atomically. The load acquires, so that the writes this thread is about to
-            // make are ordered after the reads another thread did before releasing this object.
-            // Keep the acquire on the load itself: ThreadSanitizer draws no happens-before edge
-            // from a standalone `fence acquire`, so an acquire moved into one on the unique path
-            // leaves the code correct while making the race detector report the writes that follow
-            // as racing.
-            let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
-            let refcnt = self
-                .builder()
-                .build_load(refcnt_type(self.context), ptr_to_refcnt, "refcnt")
-                .unwrap()
-                .into_int_value();
-            refcnt
-                .as_instruction_value()
-                .unwrap()
-                .set_atomic_ordering(AtomicOrdering::Acquire)
-                .expect("Set atomic ordering failed");
             // Jump to shared_bb if refcnt > 1.
-            let is_unique = self
-                .builder()
-                .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique")
-                .unwrap();
+            let is_unique = self.build_is_refcnt_one(obj_ptr, true, "");
             self.builder()
                 .build_conditional_branch(is_unique, unique_threaded_bb, shared_bb)
                 .unwrap();
@@ -1250,27 +1262,13 @@ impl<'c, 'm> Generator<'c, 'm> {
         let shared_bb = self
             .context
             .append_basic_block(current_func, "shared_bb@assert_unique");
-        let one = refcnt_type(self.context).const_int(1, false);
 
         let (local_bb, threaded_bb, global_bb) =
             self.build_branch_by_refcnt_state(obj_ptr, RcState::Unknown);
 
         // Implement local_bb: read the count and compare it against one.
         self.builder().position_at_end(local_bb);
-        let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
-        let refcnt = self
-            .builder()
-            .build_load(
-                refcnt_type(self.context),
-                ptr_to_refcnt,
-                "refcnt@assert_unique",
-            )
-            .unwrap()
-            .into_int_value();
-        let is_unique = self
-            .builder()
-            .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique@assert_unique")
-            .unwrap();
+        let is_unique = self.build_is_refcnt_one(obj_ptr, false, "@assert_unique");
         self.builder()
             .build_conditional_branch(is_unique, unique_bb, shared_bb)
             .unwrap();
@@ -1278,25 +1276,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         // Implement threaded_bb: the same, reading the count atomically.
         if let Some(threaded_bb) = threaded_bb {
             self.builder().position_at_end(threaded_bb);
-            let ptr_to_refcnt = self.get_refcnt_ptr(obj_ptr);
-            let refcnt = self
-                .builder()
-                .build_load(
-                    refcnt_type(self.context),
-                    ptr_to_refcnt,
-                    "refcnt@assert_unique",
-                )
-                .unwrap()
-                .into_int_value();
-            refcnt
-                .as_instruction_value()
-                .unwrap()
-                .set_atomic_ordering(AtomicOrdering::Acquire)
-                .expect("Set atomic ordering failed");
-            let is_unique = self
-                .builder()
-                .build_int_compare(IntPredicate::EQ, refcnt, one, "is_unique@assert_unique")
-                .unwrap();
+            let is_unique = self.build_is_refcnt_one(obj_ptr, true, "@assert_unique");
             self.builder()
                 .build_conditional_branch(is_unique, unique_bb, shared_bb)
                 .unwrap();

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -956,7 +956,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         obj.extract_field(self, field_idx)
     }
 
-    // Push scope.
+    /// Bind `var` to `obj` in the innermost scope, shadowing any binding `var` already has there.
     pub fn scope_push(self: &mut Self, var: &FullName, obj: &Object<'c>) {
         self.scope
             .borrow_mut()
@@ -965,12 +965,12 @@ impl<'c, 'm> Generator<'c, 'm> {
             .push_local(var, obj)
     }
 
-    // Pop scope.
+    /// Drop the innermost binding of `var`, revealing the binding it shadowed.
     pub fn scope_pop(self: &mut Self, var: &FullName) {
         self.scope.borrow_mut().last_mut().unwrap().pop_local(var);
     }
 
-    // Get pointer to reference counter of a given object.
+    /// The pointer to the reference count in the control block of the boxed object at `obj`.
     pub fn get_refcnt_ptr(&self, obj: PointerValue<'c>) -> PointerValue<'c> {
         self.builder()
             .build_struct_gep(
@@ -1299,7 +1299,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         self.builder().position_at_end(unique_bb);
     }
 
-    // Get pointer to state of reference counter of a given object.
+    /// The pointer to the reference-count state in the control block of the boxed object at `obj`.
     pub fn get_refcnt_state_ptr(&self, obj: PointerValue<'c>) -> PointerValue<'c> {
         self.builder()
             .build_struct_gep(
@@ -1311,7 +1311,8 @@ impl<'c, 'm> Generator<'c, 'm> {
             .unwrap()
     }
 
-    // Take a lambda object and return function pointer.
+    /// The code pointer to call a lambda through: the funcptr field of a closure, or the value
+    /// itself when the lambda is a bare function pointer.
     fn get_lambda_func_ptr(&mut self, obj: Object<'c>) -> PointerValue<'c> {
         // Get the pointer value.
         if obj.ty.is_closure() {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1304,12 +1304,12 @@ impl<'c, 'm> Generator<'c, 'm> {
 
         // Implement global_bb: a global object is shared, so the proof is wrong wherever it names
         // one.
-        if let Some(global_bb) = global_bb {
-            self.builder().position_at_end(global_bb);
-            self.builder()
-                .build_unconditional_branch(shared_bb)
-                .unwrap();
-        }
+        let global_bb =
+            global_bb.expect("the state is read under `RcState::Unknown`, so a global arm exists.");
+        self.builder().position_at_end(global_bb);
+        self.builder()
+            .build_unconditional_branch(shared_bb)
+            .unwrap();
 
         self.builder().position_at_end(shared_bb);
         self.panic("A value proven uniquely owned was reached while shared.\n");

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1142,9 +1142,8 @@ impl<'c, 'm> Generator<'c, 'm> {
                 .unwrap();
         } else {
             // In multi-threaded program,
-            let th_bb = self.context.append_basic_block(current_func, "threaded_bb");
-            threaded_bb = Some(th_bb);
-            let threaded_bb = threaded_bb.clone().unwrap();
+            threaded_bb = Some(self.context.append_basic_block(current_func, "threaded_bb"));
+            let threaded_bb = threaded_bb.unwrap();
 
             let nonlocal_bb = self.context.append_basic_block(current_func, "nonlocal_bb");
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1244,7 +1244,7 @@ impl<'c, 'm> Generator<'c, 'm> {
     /// own. It leaves the state as it found it, the operation it guards having none of its own to
     /// mark.
     ///
-    /// The state is read rather than assumed. An op declares the uniqueness check it emits through
+    /// The object's state is read at run time. An op declares the uniqueness check it emits through
     /// `LLVMGen::unique_check_operand`, and it withdraws that declaration exactly where the proof
     /// was accepted, which is where this check stands; a locality annotation resting on the
     /// withdrawn declaration therefore says nothing about the object here.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1233,8 +1233,13 @@ impl<'c, 'm> Generator<'c, 'm> {
     /// own. It leaves the state as it found it, the operation it guards having none of its own to
     /// mark.
     ///
+    /// The state is read rather than assumed. An op declares the uniqueness check it emits through
+    /// `LLVMGen::unique_check_operand`, and it withdraws that declaration exactly where the proof
+    /// was accepted, which is where this check stands; a locality annotation resting on the
+    /// withdrawn declaration therefore says nothing about the object here.
+    ///
     /// Development mode only: this restores the cost the proof exists to remove.
-    pub fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>, state: RcState) {
+    pub fn build_assert_unique(&mut self, obj_ptr: PointerValue<'c>) {
         if !self.config.develop_mode {
             return;
         }
@@ -1247,7 +1252,8 @@ impl<'c, 'm> Generator<'c, 'm> {
             .append_basic_block(current_func, "shared_bb@assert_unique");
         let one = refcnt_type(self.context).const_int(1, false);
 
-        let (local_bb, threaded_bb, global_bb) = self.build_branch_by_refcnt_state(obj_ptr, state);
+        let (local_bb, threaded_bb, global_bb) =
+            self.build_branch_by_refcnt_state(obj_ptr, RcState::Unknown);
 
         // Implement local_bb: read the count and compare it against one.
         self.builder().position_at_end(local_bb);

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -108,13 +108,14 @@ mod integration_tests {
         assert_binding_prov(&dump, "r", "[fresh]");
     }
 
-    /// Whether `line` is the signature of a function whose name starts with `fn <name_prefix>` and
-    /// whose name segment (up to the first space or parenthesis) satisfies `name_pred`.
+    /// Whether `line` is a function signature starting with `name_prefix` (which carries the `fn`
+    /// keyword) and whose name segment, up to the first space or parenthesis, satisfies `name_pred`.
     fn is_sig(line: &str, name_prefix: &str, name_pred: &impl Fn(&str) -> bool) -> bool {
         line.starts_with(name_prefix) && name_pred(line.split(['(', ' ']).nth(1).unwrap_or(""))
     }
 
-    /// The first signature line satisfying `is_sig`.
+    /// The first function signature in `dump` starting with `name_prefix` and whose name segment
+    /// satisfies `name_pred`.
     fn sig_line<'a>(dump: &'a str, name_prefix: &str, name_pred: impl Fn(&str) -> bool) -> &'a str {
         dump.lines()
             .find(|l| is_sig(l, name_prefix, &name_pred))
@@ -126,7 +127,8 @@ mod integration_tests {
             })
     }
 
-    /// Whether the dump has a signature line satisfying `is_sig`.
+    /// Whether `dump` has a function signature starting with `name_prefix` and whose name segment
+    /// satisfies `name_pred`.
     fn has_sig(dump: &str, name_prefix: &str, name_pred: impl Fn(&str) -> bool) -> bool {
         dump.lines().any(|l| is_sig(l, name_prefix, &name_pred))
     }
@@ -425,7 +427,7 @@ mod integration_tests {
             "struct_plug_in_0[unique]",
             // An `unsafe_is_unique`, whose flag folds to the constant `true`.
             "is_unique[unique]",
-            // The two `_mutate_boxed_internal` cores, on the value allocated a line earlier.
+            // The two `_mutate_boxed_internal` cores, on a freshly allocated value.
             "mutate_boxed[unique]",
             "mutate_boxed_ios[unique]",
         ] {

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -580,14 +580,14 @@ mod integration_tests {
         // iteration would re-check a value already proven unique.
         let mut checked = vec![];
         let mut elided = vec![];
-        let mut current = "";
+        let mut current_fn = "";
         for line in dump.lines() {
             if line.starts_with("fn ") {
-                current = line;
+                current_fn = line;
             } else if line.contains("array_set[unique]") {
-                elided.push(current);
+                elided.push(current_fn);
             } else if line.contains("array_set(") {
-                checked.push(current);
+                checked.push(current_fn);
             }
         }
         assert!(

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -108,13 +108,16 @@ mod integration_tests {
         assert_binding_prov(&dump, "r", "[fresh]");
     }
 
-    /// The first signature line of a function whose name starts with `fn <name_prefix>` and whose
-    /// name segment (up to the first space) satisfies `name_pred`.
+    /// Whether `line` is the signature of a function whose name starts with `fn <name_prefix>` and
+    /// whose name segment (up to the first space or parenthesis) satisfies `name_pred`.
+    fn is_sig(line: &str, name_prefix: &str, name_pred: &impl Fn(&str) -> bool) -> bool {
+        line.starts_with(name_prefix) && name_pred(line.split(['(', ' ']).nth(1).unwrap_or(""))
+    }
+
+    /// The first signature line satisfying `is_sig`.
     fn sig_line<'a>(dump: &'a str, name_prefix: &str, name_pred: impl Fn(&str) -> bool) -> &'a str {
         dump.lines()
-            .find(|l| {
-                l.starts_with(name_prefix) && name_pred(l.split(['(', ' ']).nth(1).unwrap_or(""))
-            })
+            .find(|l| is_sig(l, name_prefix, &name_pred))
             .unwrap_or_else(|| {
                 panic!(
                     "no matching `{}` function in the RC IR dump:\n{}",
@@ -123,12 +126,9 @@ mod integration_tests {
             })
     }
 
-    /// Whether the dump has a function whose name starts with `fn <name_prefix>` and satisfies
-    /// `name_pred` on its name segment.
+    /// Whether the dump has a signature line satisfying `is_sig`.
     fn has_sig(dump: &str, name_prefix: &str, name_pred: impl Fn(&str) -> bool) -> bool {
-        dump.lines().any(|l| {
-            l.starts_with(name_prefix) && name_pred(l.split(['(', ' ']).nth(1).unwrap_or(""))
-        })
+        dump.lines().any(|l| is_sig(l, name_prefix, &name_pred))
     }
 
     /// The body block of the first function whose signature satisfies the predicates: the lines from

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -11,14 +11,16 @@ mod integration_tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
+    /// The directory in the source tree holding the case projects these tests build.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_provenance/cases");
         path
     }
 
-    // Copy the test cases into a fresh temporary directory so parallel test runs do not conflict,
-    // and return the directory of the named case project.
+    /// Copy the test cases into a temporary directory of this test's own, so that parallel test
+    /// runs stay out of each other's way, and return that directory together with the directory of
+    /// the case project named by `case`.
     fn setup_test_env(case: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let dst = temp_dir.path().to_path_buf();
@@ -341,6 +343,9 @@ mod integration_tests {
         assert_binding_prov(&dump, "arr", "[fresh]");
     }
 
+    /// Verifies that the borrow version of a function that wraps its borrowed argument in a union
+    /// reference-counts nothing: the union lays the borrowed payload in place without owning it, so
+    /// releasing the union would free an array its caller still holds.
     #[test]
     fn test_borrow_union_no_double_release() {
         let (_temp_dir, project_dir) = setup_test_env("union");
@@ -374,6 +379,9 @@ mod integration_tests {
         );
     }
 
+    /// Verifies that a locally fresh value carries its provenance through a guard and through a
+    /// fill loop, so that every in-place operation reached with it drops its uniqueness check,
+    /// while an operation on a value read out of a boxed container keeps one.
     #[test]
     fn test_unique_check_elim_local_fresh() {
         let (_temp_dir, project_dir) = setup_test_env("unique_elim");
@@ -568,6 +576,12 @@ mod integration_tests {
         );
     }
 
+    /// Verifies that a loop entered with a shared array pays its uniqueness check on the first
+    /// iteration alone.
+    ///
+    /// Specialization clones the loop body per input uniqueness, so the source-level `set` appears
+    /// in two functions: a checked one, whose check clones the shared array, and one reached with
+    /// that fresh clone, which writes in place.
     #[test]
     fn test_unique_check_elim_shared_loop_entry() {
         let (_temp_dir, project_dir) = setup_test_env("unique_elim_shared_loop");

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -420,6 +420,14 @@ mod integration_tests {
             "array_grow_size[unique]",
             // An `unsafe_set_bounds_unchecked` on the fresh array folds its check.
             "array_set_unchecked[unique]",
+            // The punch and the plug that a boxed-struct field `act` carries the update out with.
+            "struct_punch_0[unique]",
+            "struct_plug_in_0[unique]",
+            // An `unsafe_is_unique`, whose flag folds to the constant `true`.
+            "is_unique[unique]",
+            // The two `_mutate_boxed_internal` cores, on the value allocated a line earlier.
+            "mutate_boxed[unique]",
+            "mutate_boxed_ios[unique]",
         ] {
             assert!(
                 dump.contains(elided),
@@ -514,6 +522,28 @@ mod integration_tests {
                 dump
             );
         }
+    }
+
+    /// Verifies that a write into an array read out of a global keeps its uniqueness check.
+    ///
+    /// A global object is shared whatever its reference count says, and the count is not raised to
+    /// record that, so proving one unique would licence a write everything else in the program can
+    /// see. The elimination is sound for globals only as long as this holds.
+    #[test]
+    fn test_global_value_keeps_its_check() {
+        let (_temp_dir, project_dir) = setup_test_env("unique_elim_global");
+        let dump = emit_main_rc_ir(&project_dir);
+
+        assert!(
+            dump.contains("array_set("),
+            "the set on an array read out of a global should keep its check:\n{}",
+            dump
+        );
+        assert!(
+            !dump.contains("array_set[unique]"),
+            "the set on an array read out of a global should not be proven unique:\n{}",
+            dump
+        );
     }
 
     /// Verifies that a value updated through a field of an unboxed struct keeps the provenance that

--- a/src/tests/test_provenance/cases/unique_elim/main.fix
+++ b/src/tests/test_provenance/cases/unique_elim/main.fix
@@ -21,6 +21,11 @@ module Main;
 //   to `array_append_range [unique]`.
 // - `_unsafe_grow_size` on a fresh array -> `array_grow_size [unique]`.
 // - `unsafe_set_bounds_unchecked` on a fresh array -> `array_set_unchecked [unique]`.
+// - a boxed-struct field `act` on a fresh struct -> the `struct_punch_0 [unique]` and
+//   `struct_plug_in_0 [unique]` it carries the update out with.
+// - `unsafe_is_unique` on a fresh boxed value -> `is_unique [unique]`, the flag folded to `true`.
+// - `mutate_boxed` and `mutate_boxed_io` on a fresh boxed value -> `mutate_boxed [unique]` and
+//   `mutate_boxed_ios [unique]`.
 type Rec = box struct { x : I64, y : I64 };
 
 namespace Array {
@@ -41,6 +46,11 @@ main = (
 
     let rec = Rec { x : 1, y : 2 };
     let rec = rec.set_x(10);
+
+    let acted_rec = Rec { x : 3, y : 4 }.act_x(|v| Option::some(v + 1)).as_some;
+    let (rec_unique, checked_rec) = Rec { x : 5, y : 6 }.unsafe_is_unique;
+    let (mutated, _) = Rec { x : 7, y : 8 }.mutate_boxed(|_| pure());
+    let (mutated_io, _) = *Rec { x : 9, y : 10 }.mutate_boxed_io(|_| pure());
 
     let guarded = Array::fill(4, 0).assert_unique(|_|"the array is shared");
     let guarded = guarded.set(0, 7);
@@ -66,5 +76,6 @@ main = (
     let inner = boxes.@(0);
     let inner = inner.set(0, 99);
 
-    println $ (acted.@(2) + rec.@x + inner.@(0) + guarded.@(0) + built.@(0) + trunc.@(0) + reserved.@(0) + appended.@(0) + grown.@size + unsafe_set.@(1)).to_string
+    let rec_fields = acted_rec.@x + checked_rec.@x + mutated.@x + mutated_io.@x + (if rec_unique { 1 } else { 0 });
+    println $ (acted.@(2) + rec.@x + inner.@(0) + guarded.@(0) + built.@(0) + trunc.@(0) + reserved.@(0) + appended.@(0) + grown.@size + unsafe_set.@(1) + rec_fields).to_string
 );

--- a/src/tests/test_provenance/cases/unique_elim_global/fixproj.toml
+++ b/src/tests/test_provenance/cases/unique_elim_global/fixproj.toml
@@ -1,0 +1,6 @@
+[general]
+name = "prov-unique-elim-global"
+version = "0.1.0"
+
+[build]
+files = ["main.fix"]

--- a/src/tests/test_provenance/cases/unique_elim_global/main.fix
+++ b/src/tests/test_provenance/cases/unique_elim_global/main.fix
@@ -1,0 +1,14 @@
+module Main;
+
+// A write into an array read out of a global. A global object is shared for as long as the program
+// runs and its reference count is never raised to say so, so the count alone cannot answer whether
+// the array is uniquely owned. The write therefore keeps its check, and the check reads the state
+// before the count.
+shared : Array I64;
+shared = Array::fill(4, 0);
+
+main : IO ();
+main = (
+    let written = shared.set(0, 1);
+    println $ (written.@(0) + shared.@(1)).to_string
+);

--- a/src/tests/test_threaded_rc.rs
+++ b/src/tests/test_threaded_rc.rs
@@ -5,7 +5,10 @@
 //! fence is reported as racing even where it is correct. The orderings are read off the emitted
 //! LLVM IR, since that is where the choice is made and where a change to it is visible.
 
-use crate::tests::test_util::{emitted_llvm_ir, fix_build_source_command, EmittedIr};
+use crate::configuration::Configuration;
+use crate::tests::test_util::{
+    emitted_llvm_ir, fix_build_source_command, run_source_capture, EmittedIr,
+};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -153,4 +156,23 @@ fn test_threaded_orderings_are_checkable_unoptimized() {
 #[test]
 fn test_threaded_orderings_are_checkable_optimized() {
     assert_orderings_are_checkable("max");
+}
+
+/// Verifies that a build with multi-threading and compiler development mode both on computes the
+/// same answers.
+///
+/// The checks development mode makes on the uniqueness proofs read the object's state, and that
+/// dispatch grows a threaded arm only where the two settings meet, so this is what puts the arm
+/// through code generation and the verifier. Execution takes the local arm: the writes whose proofs
+/// are checked here reach values still in the local state.
+#[test]
+fn test_threaded_build_checks_its_uniqueness_proofs() {
+    let mut config = Configuration::develop_mode();
+    config.set_threaded();
+    let output = run_source_capture(SOURCE, config);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        EXPECTED_OUTPUT,
+        "a threaded development-mode build should compute what every other build does"
+    );
 }


### PR DESCRIPTION
Fixes #198。

本文は `dev-docs/2026-08-05-unique-proof-assert/design.md` と同じものです。

## 1. 何のための検査か

Fix の値は参照カウントで共有を管理する。ある値を書き換える操作は、その値を他の誰も保持していない
ときに限って、その場で書き換えてよい。他に保持者がいるなら、先に複製を作ってそちらを書き換える。
どちらであるかは、実行時に参照カウントを読んで決める。

最適化はこの判断を静的に前倒しする。「ここに来る値には他の保持者がいない」と証明できたなら、
実行時の検査も複製も丸ごと落としてよい。これは配列を 1 要素ずつ書き換えるようなループでは
決定的に効く。落とさなければ、1 回の書き込みごとに参照カウントを読むことになる。

問題は、証明が誤っていたときに何が起きるかである。**実行時エラーでもクラッシュでもない。**
他の保持者から見える値をその場で上書きし、プログラムはそのまま走り続ける。壊れた値が読まれるのは
別の関数、別のフェーズ、別のスレッドかもしれない。症状が原因から任意に離れるという点で、
このコンパイラが起こしうる最悪の壊れ方に属する。

そして、落とした検査そのものが、その誤りを捕まえる唯一の観測である。だからコンパイラの開発モード
では、証明を受け入れた地点で同じ観測をもう一度行い、違反していれば**その書き込みの地点で**
プログラムを止める。この文書はその検査の設計である。

## 2. 値の共有はどう表現されているか

boxed な値は、ヒープ上のオブジェクトを指すポインタである。オブジェクトの先頭には制御ブロックが
載っている。

```rust
struct ControlBlock {
    refcnt: i32,       // 参照カウント
    refcnt_state: u8,  // 下記の 3 値
    alloc_offset: u32, // 確保したブロックの先頭からの距離。この文書には関わらない
}
```

`refcnt_state` は 3 値を取る。

| 値 | 意味 |
|---|---|
| `REFCNT_STATE_LOCAL` | 単一スレッドからしか見えていない。カウントは非原子的に読み書きしてよい |
| `REFCNT_STATE_THREADED` | 複数スレッドから見えている。カウントは原子的に扱う |
| `REFCNT_STATE_GLOBAL` | プログラム全体で生きる値。retain も release もしない |

ここが以降の議論の要点である。**「この値には他の保持者がいないか」は、カウントだけでは答えられない。**

- **GLOBAL の値のカウントは、確保したときに入れた 1 のまま動かない。** 値を global にする操作は
  state バイトを書くだけで、カウントには触れない。カウントだけを見れば 1 なので他に保持者が
  いないように見えるが、実際にはプログラムが走る限り共有されている。
- **THREADED の値のカウントは他スレッドが原子的に更新する。** 素の load で読むこと自体が
  データ競合になる。

配列については、カウントは配列の値ではなく**要素バッファが持つ**。Fix の配列の値は
（要素バッファへのポインタ, 長さ, 容量）の組で、ヒープに載っているのは要素バッファだけである。
配列の一意性を問うとは、その要素バッファの一意性を問うことである。

## 3. 実行時の一意性検査

上の構造どおりに答える関数が `Generator::build_branch_by_is_unique` である。state を読んで
3 分岐し、それぞれに合った読み方でカウントを 1 と比べ、unique 側と shared 側の 2 つの分岐先を
呼び出し元に返す。

```
検査(obj):
    state = load obj.refcnt_state
    if state == GLOBAL:
        -> shared                              // カウントは読まない
    if state == THREADED:
        c = atomic load acquire obj.refcnt
        -> (c == 1) ? unique : shared
    // LOCAL
    c = load obj.refcnt
    -> (c == 1) ? unique : shared
```

THREADED で **acquire を load 自身に置く**ことには理由がある。ThreadSanitizer は独立した
`fence acquire` から happens-before の辺を引かない。acquire を fence に移すと、コードは正しい
ままレース検出器が後続の書き込みを誤報する。

## 4. 証明はどこで生まれ、何を落とすか

### 4.1 組み込み操作とその宣言

Fix の組み込み操作の多く（配列の `set`、構造体フィールドの更新、`unsafe_is_unique` など）は、
LLVM IR を直接組み立てる「inline-LLVM op」として実装されている。各 op は `LLVMGen` トレイトを
実装する。この文書に関わる宣言は次の 4 つである。

```rust
trait LLVMGen {
    /// この操作の LLVM IR を組み立てる。
    fn generate(&self, gc: &mut Generator, ty: &Arc<TypeNode>) -> Object;

    /// この操作が実行時に一意性を検査する対象。検査を持たない操作は None を返す。
    fn unique_check_operand(&self, arg_tys: &[Arc<TypeNode>], type_env: &TypeEnv)
        -> Option<UniqueCheckOperand>;

    /// 検査対象が unique だと証明できたときの、この操作の別版。
    fn assuming_unique(&self) -> Box<dyn LLVMGen>;

    /// 宣言した対象が LOCAL 状態だと証明できたときの、この操作の別版。
    fn assuming_local(&self) -> Box<dyn LLVMGen>;
}

struct UniqueCheckOperand {
    container_index: usize, // 何番目の引数か
    path: FieldPath,        // その引数の値の中の、どの boxed な部分か
}
```

`unique_check_operand` は「この操作は、この引数のこの位置にある boxed な値について、実行時に
一意性を検査する」という**宣言**である。`assuming_unique` / `assuming_local` は、その宣言に
対応する証明を受け取るための入口で、op は自分のフラグを書き換えた複製を返す。

### 4.2 証明する pass

RC IR の pass `unique_check_elim::specialize` が、後述の provenance 解析に「この操作の検査対象は
unique か」を問い、真なら `assuming_unique()` を呼ぶ。この pass が走るのは `-O max` 以上に限られる。

`assuming_unique()` が書き換えるフラグは、op の種類によって 2 通りある。

| 種類 | 数 | フラグ | 証明を受けた側 | 証明を受けたときの振る舞い |
|---|---|---|---|---|
| クローンを出す op | 16 | `force_unique` | **false** | 複製を作らず、値をそのまま書き換える |
| 検査結果を返す op | 2 | `assume_unique` | **true** | 検査を行わず、フラグを定数 `true` にする |

同じ事実が逆極性の 2 つのフィールド名で保持されている。**証明を受け取る op は合計 18 個**である。
後者は `unsafe_is_unique` と `Array::_unsafe_is_storage_unique` の 2 つで、ここでの誤った証明は
「プログラムに嘘の答えを返す」形で出る。

### 4.3 provenance 解析が言えること

provenance 解析は、値の中の boxed な部分（boxed leaf）ごとに、それがどこから来たかを追う。

```rust
enum LeafOrigin {
    /// 新しく確保した値、あるいは複製を作る操作の結果。
    Fresh,
    /// boxed コンテナから読み出した値、global な値、retain で複製された値。
    Unknown,
    /// 入力 i のその位置から、そのまま運ばれてきた値。
    Arg(usize, FieldPath),
}
```

`Unknown` は吸収状態で、`Fresh` や `Arg` がここへ落ちることはあっても戻ることはない。解析が
「unique」と答えるのは、追った由来がすべて `Fresh`（あるいは unique と分かっている入力）に
行き着いたときだけである。

ここから 1 つの不変条件が出る。**global な値は `Unknown` に分類されるので、解析は global な値を
unique と証明しない。** 証明が global を指したなら、それは解析の誤りである。この事実は、
6.1 の検査が global を無条件に abort とすることの根拠になる。

### 4.4 証明のもう 1 つの出どころ

`force_unique == false` は解析だけから来るわけではない。

構造体のフィールド更新（`rec.act_x(f)` のような形）は、フィールドを一旦取り出す操作（punch）と
戻す操作（plug）の組で実装される。この 2 つは、**呼び出し側が直前に一意性を確かめている**という
前提のもとに `force_unique: false` で登録される。解析とは無関係に、常にこの値である。

この経路には unboxed な構造体も来る。unboxed な値は制御ブロックを持たないので、検査する
カウントが存在しない。

## 5. 変更前の検査が持っていた穴

開発モードの検査は以前から 1 つだけ存在していた。それは**カウントだけを読み、1 より大きければ
abort する**ものだった。ここから 3 つの穴が、1 つの設計の誤りの帰結として並ぶ。

1. **global の誤証明を素通しする。** 2 節のとおり global な値のカウントは 1 のままなので、
   カウントだけを見る検査は「プログラム全体で共有される値を unique と誤証明する」という最悪の
   ケースを通す。
2. **THREADED でカウントを非アトミックに読む。** 検査自身がデータ競合になる。
3. **18 の op のうち 2 つにしか出ない。** 検査を持っていたのは boxed な値を書き換える 2 つの
   操作だけで、証明の主戦場である配列の書き込み 11 op には 1 つも届いていなかった。

したがって対処も 3 つ別々ではない。**3 節の検査と同じ機構を使う**ことにすれば 1 と 2 は設計の
帰結として閉じ、残るのは 3 の配線だけになる。

## 6. 終状態

### 6.1 検査そのもの

```rust
impl Generator {
    /// 開発モードのとき、`obj_ptr` の指すオブジェクトが共有されていれば abort する。
    pub fn build_assert_unique(&mut self, obj_ptr: PointerValue);
}
```

3 節の検査と同じ骨格で、shared 側を abort にしたものである。

```
検査を出す(obj):
    if 開発モードでない: 何も出さない
    state = load obj.refcnt_state
    if state == GLOBAL:
        -> abort                               // 4.3 より、証明が global を指したなら誤り
    if state == THREADED:
        c = atomic load acquire obj.refcnt
        if c != 1: abort
    else:                                      // LOCAL
        c = load obj.refcnt
        if c != 1: abort
```

3 節の検査との違いは 2 つある。shared 側が abort であること、そして **state を書き換えないこと**
である。3 節の検査は THREADED かつ unique と分かった側で、その値を LOCAL に落とす（他スレッドが
もう見ていないと分かったため）。検査が守っている操作はその書き換えを持たないので、ここで真似ては
ならない。開発モードのビルドだけが実行時 state を変えれば、そこから先の参照カウントの振る舞いが
通常のビルドと分岐する。

カウントを読んで 1 と比べる列は、3 節の検査と合わせて 4 箇所に現れる。これは
`build_is_refcnt_one(obj_ptr, acquire, name_suffix)` に切り出し、acquire を load 自身に置く理由も
そこ 1 箇所に書く。

### 6.2 state を引数に取らない理由

`build_assert_unique` は `RcState`（この地点の state について静的に分かっていること）を引数に
取らない。理由は locality 推論の契約にある。

locality 推論は、op が扱うオブジェクトが LOCAL 状態だと証明できたとき `assuming_local()` を
呼ぶ。証明を受けた op は state を読まずに済み、カウントを直接読める。この推論が何を対象と
するかは `unique_check_operand`（4.1）が宣言した対象で決まる。`assuming_local` の doc は
この関係を次のように定めている。

> A `generate` that emits a check or a reference count it does not declare leaves that one
> reading the state, so the declarations stay honest about what the annotation covers.

すなわち**宣言していない検査は state を読み続ける**。これがあるから、宣言が locality 注釈の
覆う範囲を正直に表していられる。

ところが 18 op すべての `unique_check_operand` は、次の形で始まる。

```rust
fn unique_check_operand(&self, ...) -> Option<UniqueCheckOperand> {
    if !self.force_unique { return None; }   // 検査結果を返す op では if self.assume_unique
    ...
}
```

**証明が受理された瞬間に、宣言が取り下げられる。** そして開発モードの検査が立つのは、まさに
その地点である。取り下げられた宣言に乗った locality 注釈は、この地点の対象について何も言って
いない。ここで「LOCAL と分かっている」を渡すと、誰も証明していない locality を根拠にした
検査が出て、正しい一意性証明に対して locality の側のメッセージで誤って abort しうる。

だから検査は state を実行時に読む。コストは開発モードでの state の load 1 回である。

### 6.3 証明でクローンを落とす判断を集める

変更前は、16 の op がそれぞれの `generate` の中で

```rust
let array = if self.force_unique {
    make_array_unique(gc, array, ...)   // 共有されていれば複製する
} else {
    array                               // 証明を信じてそのまま使う
};
```

と書いていた。この形を 1 つの関数 `force_unique_or_assert` に載せ替える。**証明を信じるかどうかの
判断と、信じたときに立てる検査が、同じ場所で決まる**ようにするためである。

| 値の形 | `force_unique` が真 | 偽（証明を受けた） |
|---|---|---|
| 配列 | 共有されていれば要素バッファごと複製 | 要素バッファを対象に検査 |
| boxed な構造体 / union | 共有されていれば複製 | 値そのものを対象に検査 |
| unboxed な構造体 / union | そのまま返す | そのまま返す（カウントが無い） |

unboxed が到達するのは 4.4 の登録経路だけである。ここに配列や boxed 専用の操作の値が来ることは
無いので、unboxed 側では構造体か union であることを表明する。

### 6.4 一般の入口に載らない 3 つ

- **配列の容量変更**: 一意な側が `realloc` による確保済み領域の伸縮で、「複製した値を返す」形を
  していない。証明を受けた側の早期 return の先頭で検査を直接呼ぶ。
- **穴あき配列への差し戻し（plug）**: 複製が 1 要素分の穴を残す必要があるので、穴の位置を取る
  変種を使う。
- **検査結果を返す 2 op**: 値を作らずフラグを定数 `true` に畳むので、その地点で検査を直接呼ぶ。

## 7. テストで固定できること・できないこと

### 7.1 固定できないこと

**18 箇所の検査をすべて削除しても、テストスイートは緑のままである。** これは違反を強制できない
assertion 一般の性質であって、この検査に固有の弱さではない。テストで固定するには誤った証明を作る
口をコンパイラ側に用意するしかなく、それは production コードをテストのために歪めることになる。

出力された LLVM IR を読んで「証明が通った経路に検査が出ている」ことを固定する案も検討したが、
使えない。開発モードのビルドはインプロセスでしか起こせず（開発モードの設定を作るのはテスト
だけで、コマンドラインから立てる手段が無い）、そのときオブジェクトファイルのキャッシュが
カレントディレクトリ（全テストで共有）に載る。**同じソースを 2 回目にビルドすると、コード生成
ごと飛んで IR ファイルが出ない。** 外部プロセスとして `fix` を起動する既存の IR テストは、
作業ディレクトリを一時ディレクトリに移してキャッシュごと隔離しているのでこの罠を踏まない。

恒久的な歯止めにするなら 8 節の構造化が要る。

### 7.2 固定できること

- **検査が誤った証明に反応すること。** 解析に嘘の証明をさせる細工を入れて確かめる（付録 A.1）。
  これは 1 回きりの実験で、テストには残せない。
- **検査が経路に届いていること。** 比較を反転させるとテストが落ちる（付録 A.2）。検査が
  2 経路から 18 経路に増えたことで、既存のテストが検査そのものの正しさを毎回検証する形になった。
- **証明が受理される地点が実在すること。** RC IR のダンプには、検査を落とした操作に `[unique]`
  という印が付く。これを主張するテストは、検査そのものではなく「検査が立つ地点」を固定する。
  将来の変更でその op が証明を受けなくなれば落ちる。この形のテストが無かった 5 つの op
  （構造体の punch / plug、`unsafe_is_unique`、boxed な値を書き換える 2 操作）に追加した。
- **4.3 の不変条件。** global から読んだ配列への書き込みが検査を保つことを、新しいテストケース
  で固定する。これが崩れると 6.1 の global 腕が誤って発火する。
- **THREADED 腕がコード生成されること。** 開発モードと `--threaded` が同時に立つ構成でのみ
  この腕が出る。それを通すテストを追加した。実行が取るのは LOCAL 腕である。

## 8. 残る設計課題

- **19 個目の op が検査を書き忘れる余地。** 現状は 18 の op が自分で検査を呼ぶ。検査の呼び出しを
  op から取り上げ、inline-LLVM op のコード生成を行う唯一の地点で、`unique_check_operand` の鏡
  （証明が受理されたときに検査対象を返す宣言）を読んで出す形にすれば、書き忘れ自体が起きなく
  なる。値の中の boxed leaf をパスで辿ってポインタを得るヘルパが要る（配列なら要素バッファ、
  それ以外なら値そのもの、という 6.3 の表の区別）。
- **`force_unique` と `assume_unique` が同じ事実を逆極性で持っている**（4.2）。読み手は op を
  移るたびに極性を反転させる必要がある。
- 配列から要素バッファのポインタを取り出す式が 3 箇所に手書きされている。既存の
  `get_array_storage_buf` の隣に置くべきヘルパが欠けている。
- boxed な値を書き換える 2 操作と、配列の要素をまとめて書き換える 2 操作の、計 4 つの本体が
  同じ核を繰り返している。
- 組み込み操作の実装ファイルが 8400 行で、配列 / 構造体・union / FFI の操作が同居している。

## 付録 A 測定

### A.1 検査が発火することの確認

解析の答えを常に「unique」に差し替える細工を入れ、共有された配列への書き込みを開発モードで
走らせた。

| | 結果 |
|---|---|
| 嘘の証明を注入 | `A value proven uniquely owned was reached while shared.` で abort |
| 注入なし（対照） | プログラムは正常終了し、abort を期待するプローブが落ちる |

対照側を測らないと「注入が原因で鳴った」とは言えないので、両方を走らせた。細工は戻してある。

### A.2 検査が経路に届いていることの確認

カウントとの比較 `EQ` を `NE` に反転させると、配列のテストが軒並み落ちる。境界検査のテストは
期待する "Index out of range" ではなく abort する。

### A.3 テストスイート

`-O none` 1209 件 / `-O max` 1209 件、いずれも 0 失敗。所要は none 471 秒 / max 401 秒。

### A.4 通常のビルドへの影響

`origin/main` (`d41046e5`) のコンパイラと本ブランチのコンパイラで `examples/` の 17 プログラムを
`-O none` / `-O basic` / `-O max` でコンパイルし、モジュールハッシュを正規化した LLVM IR を
突き合わせて **51/51 が一致**（計 290 モジュール）。比較器が差を報告できることは、同一プログラムを
2 つの最適化レベルでビルドして確かめた。51 対すべての IR に `is_unique` が現れるので、コーパスは
6.1 で切り出した `build_is_refcnt_one`（通常のビルドにも出る経路）に到達している。

https://claude.ai/code/session_01XFyf4t5HbFbzHyJHFLHQey
