### PR TITLE
closure specialization のまわりの手入れ

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -235,7 +235,7 @@ impl ExprNode {
         }
     }
 
-    // The type constructor and fields of a struct construction, or `None` for anything else.
+    // The type constructor and fields of a struct construction.
     pub fn destructure_make_struct(
         &self,
     ) -> Option<(Arc<TyCon>, &Vec<(Name, Option<Span>, Arc<ExprNode>)>)> {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -277,9 +277,9 @@ impl ExprNode {
         let mut args = vec![];
         let mut body = self.clone();
         while body.is_lam() {
-            let (args_loc, body_loc) = body.destructure_lam();
-            args.push(args_loc);
-            body = body_loc;
+            let (lam_args, lam_body) = body.destructure_lam();
+            args.push(lam_args);
+            body = lam_body;
         }
         (args, body)
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -202,6 +202,7 @@ impl ExprNode {
         Arc::new(ret)
     }
 
+    // This application with its arguments replaced. Panics if the expression is not an application.
     pub fn set_app_args(&self, args: Vec<Arc<ExprNode>>) -> Arc<Self> {
         let mut ret = self.clone_except_fvs();
         match &*self.expr {
@@ -215,6 +216,7 @@ impl ExprNode {
         Arc::new(ret)
     }
 
+    // The function this application applies. Panics if the expression is not an application.
     #[allow(dead_code)]
     pub fn get_app_func(&self) -> Arc<ExprNode> {
         match &*self.expr {
@@ -225,6 +227,8 @@ impl ExprNode {
         }
     }
 
+    // The arguments this application applies its function to, at this single application node.
+    // Panics if the expression is not an application.
     #[allow(dead_code)]
     pub fn get_app_args(&self) -> Vec<Arc<ExprNode>> {
         match &*self.expr {
@@ -284,6 +288,7 @@ impl ExprNode {
         (args, body)
     }
 
+    // This lambda with its parameters replaced. Panics if the expression is not a lambda.
     #[allow(dead_code)]
     pub fn set_lam_params(&self, params: Vec<Arc<Var>>) -> Arc<Self> {
         let mut ret = self.clone_except_fvs();
@@ -298,6 +303,7 @@ impl ExprNode {
         Arc::new(ret)
     }
 
+    // This lambda with its body replaced. Panics if the expression is not a lambda.
     pub fn set_lam_body(&self, body: Arc<ExprNode>) -> Arc<Self> {
         let mut ret = self.clone_except_fvs();
         match &*self.expr {

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -2785,9 +2785,9 @@ impl Program {
         for sym in self.symbols.values() {
             let mut sym_text = Text::empty();
 
-            let type_sgn_str = format!("{} : {};", sym.name.to_string(), sym.ty.to_string());
-            let type_sgn = Text::from_str(&type_sgn_str);
-            sym_text = sym_text.append(type_sgn);
+            let type_signature = format!("{} : {};", sym.name.to_string(), sym.ty.to_string());
+            let type_signature_text = Text::from_str(&type_signature);
+            sym_text = sym_text.append(type_signature_text);
 
             let code = Text::from_str(&format!("{} = ", sym.name.to_string()))
                 .append_nobreak(
@@ -2801,7 +2801,7 @@ impl Program {
                 .append_to_last_line(";");
             sym_text = sym_text.append(code);
 
-            sym_texts.push((type_sgn_str, sym_text));
+            sym_texts.push((type_signature, sym_text));
         }
         sym_texts.sort_by(|(a, _), (b, _)| a.cmp(b));
 

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -2780,6 +2780,8 @@ impl Program {
         None
     }
 
+    // The symbols of this program rendered as Fix source, each as its type signature followed by its
+    // definition, ordered by signature.
     pub fn stringify_symbols(&self) -> Text {
         let mut sym_texts: Vec<(String, Text)> = vec![];
         for sym in self.symbols.values() {
@@ -2814,6 +2816,10 @@ impl Program {
         text
     }
 
+    // Write the symbols of this program, as Fix source, to `<DOT_FIXLANG>/<step_name>.symbols.fix`.
+    //
+    // # Arguments
+    // * `step_name` - names the compilation step the dump is taken at, and so the file it lands in.
     pub fn emit_symbols(&self, step_name: &str) {
         let file_name = format!("{}/{}.symbols.fix", DOT_FIXLANG, step_name);
         let file_path = PathBuf::from(file_name);
@@ -2823,6 +2829,8 @@ impl Program {
         file.write_all(text.as_bytes()).unwrap();
     }
 
+    // A type checker carrying this program's traits, types, kinds and imports, with the declared
+    // type of every global symbol already in scope.
     pub fn create_typechecker(&self, config: &Configuration) -> TypeCheckContext {
         // Error tolerance is opt-in via the diagnostics-mode config;
         // every other subcommand stays strict.
@@ -2852,9 +2860,13 @@ impl Program {
     }
 }
 
+// The innermost thing the cursor rests on at a source position, which is what the position-driven
+// LSP requests — hover, goto-definition, rename, references — answer about.
 #[derive(Serialize, Deserialize)]
 pub enum EndNode {
+    // A use of a value, carrying the type inferred for it where one was recorded.
     Expr(Var, Option<Arc<TypeNode>>),
+    // A name a pattern binds, carrying the type inferred for it where one was recorded.
     Pattern(Var, Option<Arc<TypeNode>>),
     Type(TyCon),
     Trait(TraitId),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -39,12 +39,12 @@ impl<T> Graph<T> {
         T: Clone + Eq + Hash,
     {
         let elems = elems.into_iter().collect::<Vec<_>>();
-        let inv_map = elems
+        let elem_to_idx = elems
             .iter()
             .enumerate()
             .map(|(idx, elem)| (elem.clone(), idx))
             .collect::<Map<_, _>>();
-        (Graph::new(elems), inv_map)
+        (Graph::new(elems), elem_to_idx)
     }
 
     // Get an element
@@ -115,12 +115,12 @@ impl<T> Graph<T> {
 
         let mut path_set: Set<usize> = Default::default();
         let mut path_vec: Vec<usize> = Default::default();
-        let mut visited: Set<usize> = Default::default();
+        let mut verified: Set<usize> = Default::default();
         path_set.reserve(self.elems.len());
-        visited.reserve(self.elems.len());
+        verified.reserve(self.elems.len());
 
         for pos in 0..self.elems.len() {
-            let maybe_loop = visit(pos, &mut path_set, &mut path_vec, &mut visited, self);
+            let maybe_loop = visit(pos, &mut path_set, &mut path_vec, &mut verified, self);
             if !maybe_loop.is_empty() {
                 return maybe_loop;
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,8 @@
 use crate::misc::{Map, Set};
 use std::{collections::VecDeque, hash::Hash};
 
+// A directed graph over a fixed set of elements, where a node is addressed by the position of its
+// element.
 pub struct Graph<T> {
     // Data stored in nodes;
     elems: Vec<T>,
@@ -19,6 +21,8 @@ impl<T> Graph<T> {
         }
     }
 
+    // Create a graph from a vector of elements and the nodes each node has an edge to, given as one
+    // list of node indices per element.
     #[allow(dead_code)]
     pub fn new_with_edges(elems: Vec<T>, edges: Vec<Vec<usize>>) -> Self {
         let len = elems.len();
@@ -152,7 +156,7 @@ impl<T> Graph<T> {
         let mut reversed_edges: Vec<Vec<usize>> = vec![vec![]; num_nodes];
         for u in 0..num_nodes {
             for &v in &self.edges[u] {
-                reversed_edges[v].push(u); // 辺 u -> v を v -> u に反転
+                reversed_edges[v].push(u); // Reverse the edge u -> v into v -> u
             }
         }
 
@@ -186,7 +190,7 @@ impl<T> Graph<T> {
                 self.scc_dfs1(v, visited, finish_order);
             }
         }
-        // DFSが完了したノードをスタックに積む
+        // Push the node onto the stack once its DFS has finished
         finish_order.push_back(u);
     }
 
@@ -200,7 +204,7 @@ impl<T> Graph<T> {
         scc_ids: &mut Vec<usize>,
     ) {
         visited[u] = true;
-        scc_ids[u] = current_scc_id; // 現在のSCCのIDを割り当てる
+        scc_ids[u] = current_scc_id; // Assign the ID of the SCC being collected
 
         for &v in &reversed_edges[u] {
             if !visited[v] {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,5 @@
-use std::{collections::VecDeque, hash::Hash};
-
 use crate::misc::{Map, Set};
+use std::{collections::VecDeque, hash::Hash};
 
 pub struct Graph<T> {
     // Data stored in nodes;
@@ -213,7 +212,7 @@ impl<T> Graph<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Graph;
 
     #[test]
     fn test_scc_empty_graph() {

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -167,6 +167,7 @@ struct Slot {
 }
 
 impl Slot {
+    // The way in through the argument itself, at the given position.
     fn arg(arg: usize) -> Self {
         Slot { arg, field: None }
     }
@@ -238,18 +239,22 @@ impl Tree {
 // An empty substitution names the function itself.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 struct UnitKey {
+    // The function the copy is made from.
     origin: FullName,
-    // Slots in ascending order, so that the name below is a function of the key alone.
+    // Slots in ascending order, so that `name` is a function of the key alone.
     subst: Vec<(Slot, Tree)>,
 }
 
 impl UnitKey {
+    // The key of the copy of `origin` whose ways in receive the given values.
     fn new(origin: FullName, subst: Map<Slot, Tree>) -> Self {
         let mut subst = subst.into_iter().collect::<Vec<_>>();
         subst.sort_by_key(|(slot, _)| *slot);
         UnitKey { origin, subst }
     }
 
+    // The name the copy carries: the origin's, with a hash of the substitution appended. The copy
+    // that substitutes nothing is the function itself and keeps the origin's name.
     fn name(&self) -> FullName {
         if self.subst.is_empty() {
             return self.origin.clone();
@@ -333,6 +338,7 @@ struct LiftedLambdas {
 }
 
 impl LiftedLambdas {
+    // Record a lambda just lifted, under the name of the global function it became.
     fn insert(&mut self, name: FullName, cap: CaptureStruct, func_ty: Arc<TypeNode>) {
         self.record_capture_list(&cap, &Tree::leaf(name.clone()));
         self.lambdas.insert(name, LiftedLambda { cap, func_ty });
@@ -367,12 +373,16 @@ impl LiftedLambdas {
         cap
     }
 
+    // Remember the value a capture list of `cap`'s type constructor carries, and hold that type
+    // constructor until it is registered.
     fn record_capture_list(&mut self, cap: &CaptureStruct, tree: &Tree) {
         self.trees.insert(cap.tycon.name.clone(), tree.clone());
         self.new_tycons
             .insert(cap.tycon.as_ref().clone(), cap.tycon_info.clone());
     }
 
+    // Take the type constructors minted so far, for the caller to register into the program's type
+    // environment.
     fn take_new_tycons(&mut self) -> Map<TyCon, TyConInfo> {
         mem::take(&mut self.new_tycons)
     }
@@ -884,6 +894,7 @@ struct ClosureSpecializationVisitor {
 // something to do again, and the two would take turns undoing each other.
 #[derive(Clone)]
 struct Known {
+    // Which lambda the value is, and which of its capture fields are themselves known.
     tree: Tree,
     // An expression yielding the bare capture list, evaluable wherever the value itself is.
     cap_list: Arc<ExprNode>,
@@ -893,6 +904,7 @@ struct Known {
 }
 
 impl Known {
+    // A known value carried by the bare capture list `cap_list`.
     fn bare(tree: Tree, cap_list: Arc<ExprNode>) -> Self {
         Known {
             tree,
@@ -945,7 +957,7 @@ impl ClosureSpecializationVisitor {
     }
 
     // The expression a known value is carried by: the bare capture list, or the closure wrapping it.
-    // A wrap names the copy of the lambda that receives the capture list as it now is (R3).
+    // A wrap names the copy of the lambda that receives the capture list as it now is.
     fn value_expr(&self, known: &Known) -> Arc<ExprNode> {
         if known.is_bare {
             return known.cap_list.clone();
@@ -1005,7 +1017,7 @@ impl ClosureSpecializationVisitor {
 
     // Narrow the capture list a known value is carried by, where it is built here: a field the table
     // is willing to specialize on takes the capture list of the value it holds, in place of the
-    // closure. R1.
+    // closure.
     //
     // Creating a narrowed value asks for the copy of the lambda that receives it, so that the value
     // can be wrapped back into a closure wherever one is called for.
@@ -1338,6 +1350,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         EndVisitResult::unchanged(expr)
     }
 
+    // Lift a lambda written among the arguments, name the copy of a lambda a call through a known
+    // value reaches, and specialize the called function on the arguments whose identity is known,
+    // where it is a specializable global.
     fn start_visit_app(
         &mut self,
         expr: &Arc<ExprNode>,
@@ -1360,9 +1375,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             return StartVisitResult::ReplaceAndRevisit(apply(func, lifted_args));
         }
 
-        // R3: a capture list reached through the lambda that consumes it names the copy of that
-        // lambda which receives the capture list as it now is. This covers the closure a capture
-        // list is wrapped into and a call made through such a closure alike.
+        // A capture list reached through the lambda that consumes it names the copy of that lambda
+        // which receives the capture list as it now is. This covers the closure a capture list is
+        // wrapped into and a call made through such a closure alike.
         if func.is_var() && !args.is_empty() {
             if let Some(known) = self.known_value(&args[0]) {
                 let called = func.get_var().name.clone();
@@ -1397,7 +1412,7 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             return StartVisitResult::VisitChildren;
         };
 
-        // R2: an argument whose identity is known is handed over as its bare capture list, where the
+        // An argument whose identity is known is handed over as its bare capture list, where the
         // table is willing to copy the function for that way in and the stopping rule allows it.
         let mut pinned = self.pinned.clone();
         let mut specialized_args = Map::default();
@@ -1419,7 +1434,7 @@ impl ExprVisitor for ClosureSpecializationVisitor {
                 continue;
             }
             // The value stays a closure here, but a narrowed capture list needs the copy that
-            // receives it named. R3.
+            // receives it named.
             if !known.is_bare && !self.is_up_to_date(arg, &known) {
                 new_args[i] = self.value_expr(&known);
                 changed = true;
@@ -1490,6 +1505,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         EndVisitResult::changed(expr)
     }
 
+    // Lift a lambda bound by this `let`, and record the bound name in `local_decap_lambdas` so that
+    // later uses of it are read as the value the binding now holds. A binding whose value already
+    // has a known identity passes that reading on to the new name.
     fn start_visit_let(
         &mut self,
         expr: &Arc<ExprNode>,

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -924,7 +924,8 @@ impl Known {
 }
 
 impl ClosureSpecializationVisitor {
-    // Create a new visitor
+    // A walk over the body of `current_symbol`, judging what to copy against `specializable_funcs`
+    // and carrying what the chain of requests reaching that symbol has already committed to.
     fn new(
         current_symbol: FullName,
         specializable_funcs: Rc<Map<FullName, SpecializableFunctionInfo>>,
@@ -1263,15 +1264,13 @@ fn apply(func: Arc<ExprNode>, args: Vec<Arc<ExprNode>>) -> Arc<ExprNode> {
 }
 
 impl ExprVisitor for ClosureSpecializationVisitor {
+    // A name holding the bare capture list of a lifted lambda, read where the closure is called for,
+    // is wrapped back into one: the lambda's global function applied to that capture list.
     fn start_visit_var(
         &mut self,
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // If `expr` refers to a decaptured lambda, and
-        // the type of this expression is T, and the lambda function type is C->T (C is the capture list type),
-        // replace it with an expression that applies the lambda function to the capture list.
-
         // Get the name
         let name = &expr.get_var().name;
 
@@ -1306,14 +1305,14 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         EndVisitResult::unchanged(expr)
     }
 
+    // Where an inline-LLVM expression reads a free variable holding the bare capture list of a
+    // lifted lambda, the closure wrapping that capture list is bound to a local in front of the
+    // expression, and the expression reads that local instead.
     fn start_visit_llvm(
         &mut self,
         llvm_expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // If any free variable in the LLVM expression refers to a decaptured lambda,
-        // replace it with an expression that applies the lambda function to the capture list.
-
         // The call of the lambda function, by the free variable holding the capture list it is
         // applied to.
         let mut call_lam_exprs = Map::default();
@@ -1478,12 +1477,13 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         EndVisitResult::unchanged(expr)
     }
 
+    // A parameter holding a bare capture list leaves the domain of the recorded lambda type stale,
+    // so that domain is set to the type of the capture list before the body is visited.
     fn start_visit_lam(
         &mut self,
         expr: &Arc<ExprNode>,
         _state: &mut VisitState,
     ) -> StartVisitResult {
-        // Before visiting children, if the argument refers to a decaptured lambda, fix the domain part of the lambda type since it is incorrect.
         let params = expr.get_lam_params();
         assert_eq!(params.len(), 1);
         let arg = &params[0];
@@ -1505,9 +1505,10 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         return StartVisitResult::ReplaceAndRevisit(expr);
     }
 
+    // Visiting the body can change its type, so the codomain of the lambda type is set to the type
+    // the body now has. In `|x| |y| (...)`, a `y` holding a capture list retypes `|y| (...)`, which
+    // is the codomain of the outer lambda.
     fn end_visit_lam(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        // After visiting children, the codomain type of this expression may have changed, so fix the type if necessary.
-        // Example: In `expr` is a lambda `|x| |y| (...)`, if `y` is a decaptured lambda, visiting `|y| (...)` may change its type, so the codomain of `|x| |y| (...)` may need to be fixed.
         let lam_ty = expr.type_.as_ref().unwrap();
         let dom_ty = lam_ty.get_lambda_srcs()[0].clone();
         let codom_ty = lam_ty.get_lambda_dst().clone();

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -453,7 +453,8 @@ fn lift_all(prg: &mut Program, lifted: &Rc<RefCell<LiftedLambdas>>, show_build_t
         }
     }
 
-    prg.type_env.add_tycons(lifted.borrow_mut().take_new_tycons());
+    prg.type_env
+        .add_tycons(lifted.borrow_mut().take_new_tycons());
 }
 
 // Make every copy the program asks for, starting from the functions themselves.
@@ -538,7 +539,8 @@ fn realize_all(
         queue.extend(visitor.required_specializations);
     }
 
-    prg.type_env.add_tycons(lifted.borrow_mut().take_new_tycons());
+    prg.type_env
+        .add_tycons(lifted.borrow_mut().take_new_tycons());
     prg.symbols = symbols;
 }
 
@@ -713,15 +715,15 @@ fn reaches_a_direct_call(
             // pass did not mint — one the program declares, or the capture list
             // `defunctionalize_fix` builds — carries no such way in, so the value is reached there
             // only by an indirect call.
-            UsageType::CapturedInto(tycon, position) => lifted
-                .tree_of_capture_list(&tycon)
-                .is_some_and(|tree| {
+            UsageType::CapturedInto(tycon, position) => {
+                lifted.tree_of_capture_list(&tycon).is_some_and(|tree| {
                     is_specializable(
                         specializable_funcs,
                         &tree.lambda,
                         Slot::capture_field(position),
                     )
-                }),
+                })
+            }
         })
 }
 
@@ -1532,10 +1534,7 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             let cap_list_ty = cap_list.type_.as_ref().unwrap().clone();
             self.local_decap_lambdas.insert(
                 var_name.clone(),
-                Known::bare(
-                    tree,
-                    expr_var(var_name, None).set_type(cap_list_ty.clone()),
-                ),
+                Known::bare(tree, expr_var(var_name, None).set_type(cap_list_ty.clone())),
             );
             let pat = pat
                 .set_var_tyanno(None) // Discard type annotation since it may become incorrect

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -458,16 +458,16 @@ fn realize_all(
 ) {
     let _sw = StopWatch::new("closure_specialization::realize_all", show_build_times);
 
-    let bodies = mem::take(&mut prg.symbols);
-    let mut global_names = bodies.keys().cloned().collect::<Set<_>>();
+    let originals = mem::take(&mut prg.symbols);
+    let mut global_names = originals.keys().cloned().collect::<Set<_>>();
     let mut symbols: Map<FullName, Symbol> = Map::default();
 
     // Every function stands for the copy of itself that substitutes nothing.
-    let mut queue = bodies
+    let mut queue = originals
         .keys()
         .map(|origin| SpecializationRequest {
             unit: UnitKey::new(origin.clone(), Map::default()),
-            org_func_ty: bodies[origin].ty.clone(),
+            org_func_ty: originals[origin].ty.clone(),
             pinned: Pinned::default(),
         })
         .collect::<VecDeque<_>>();
@@ -477,8 +477,8 @@ fn realize_all(
         if symbols.contains_key(&name) {
             continue;
         }
-        let org = &bodies[&request.unit.origin];
-        let expr = unique_local_names::run_on_expr(org.expr.as_ref().unwrap(), Set::default());
+        let original = &originals[&request.unit.origin];
+        let expr = unique_local_names::run_on_expr(original.expr.as_ref().unwrap(), Set::default());
 
         // A copy of a lifted lambda whose capture list is narrowed receives it through the same
         // parameter, at the narrowed type. The walk retypes the pattern destructuring it when it
@@ -815,7 +815,7 @@ fn capture_list_destructuring(
 // `symbols` is one about to be created and carries no edge yet.
 fn call_graph_of(symbols: &Map<FullName, Symbol>) -> (Graph<FullName>, Map<FullName, usize>) {
     let names = symbols.keys().cloned().collect::<Vec<_>>();
-    let idx_of = names
+    let name_to_idx = names
         .iter()
         .enumerate()
         .map(|(idx, name)| (name.clone(), idx))
@@ -823,12 +823,12 @@ fn call_graph_of(symbols: &Map<FullName, Symbol>) -> (Graph<FullName>, Map<FullN
     let mut graph = Graph::new(names);
     for (caller, sym) in symbols {
         for callee in sym.expr.as_ref().unwrap().free_vars() {
-            if let Some(callee_idx) = idx_of.get(&callee) {
-                graph.connect_idx(idx_of[caller], *callee_idx);
+            if let Some(callee_idx) = name_to_idx.get(&callee) {
+                graph.connect_idx(name_to_idx[caller], *callee_idx);
             }
         }
     }
-    (graph, idx_of)
+    (graph, name_to_idx)
 }
 
 // The capture list a copy of a lifted lambda receives in place of the one the lambda was built with.
@@ -1025,15 +1025,15 @@ impl ClosureSpecializationVisitor {
             if !info.specializable_slots.contains(&slot) {
                 continue;
             }
-            let field = match self.known_value(value) {
-                Some(field) => field,
+            let known_field = match self.known_value(value) {
+                Some(known_field) => known_field,
                 None => continue,
             };
-            if !commit(pinned, &known.tree.lambda, slot, &field.tree) {
+            if !commit(pinned, &known.tree.lambda, slot, &known_field.tree) {
                 continue;
             }
-            *value = field.cap_list;
-            narrowed_fields.push((position, field.tree));
+            *value = known_field.cap_list;
+            narrowed_fields.push((position, known_field.tree));
         }
         if narrowed_fields == known.tree.fields {
             return known;
@@ -1241,25 +1241,25 @@ impl ExprVisitor for ClosureSpecializationVisitor {
 
         // Check if this name holds the capture list of a lambda this walk knows. A name bound to
         // the closure wrapped around one already has the type its uses call for.
-        let decap_lambda = self.local_decap_lambdas.get(name).cloned();
-        if decap_lambda.is_none() {
+        let known = self.local_decap_lambdas.get(name).cloned();
+        if known.is_none() {
             return StartVisitResult::VisitChildren;
         }
-        let decap_lambda = decap_lambda.unwrap();
-        if !decap_lambda.is_bare {
+        let known = known.unwrap();
+        if !known.is_bare {
             return StartVisitResult::VisitChildren;
         }
-        let decap_lambda = decap_lambda.tree;
+        let tree = known.tree;
 
         // If the required type for this expression is already the capture list type, do nothing.
         let expr_ty = expr.type_.as_ref().unwrap().clone();
-        let cap_list_ty = self.cap_of(&decap_lambda).ty;
+        let cap_list_ty = self.cap_of(&tree).ty;
         if expr_ty.to_string() == cap_list_ty.to_string() {
             return StartVisitResult::VisitChildren;
         }
 
         // Check that the required type for this expression matches the codomain of the lambda function.
-        let lam = self.lambda_func_of(&decap_lambda);
+        let lam = self.lambda_func_of(&tree);
         let lambda_codom_ty = lam.type_.as_ref().unwrap().get_lambda_dst();
         assert_eq!(expr_ty.to_string(), lambda_codom_ty.to_string());
 
@@ -1282,20 +1282,19 @@ impl ExprVisitor for ClosureSpecializationVisitor {
 
         let mut replace = Map::default(); // Data for replacing free variables in the LLVM expression
         for free_name in llvm_expr.free_vars() {
-            let opt_decap_lambda = self.local_decap_lambdas.get(&free_name).cloned();
-            if opt_decap_lambda.is_none() {
+            let known = self.local_decap_lambdas.get(&free_name).cloned();
+            if known.is_none() {
                 continue;
             }
-            let decap_lambda = opt_decap_lambda.unwrap();
-            if !decap_lambda.is_bare {
+            let known = known.unwrap();
+            if !known.is_bare {
                 continue;
             }
-            let decap_lambda = decap_lambda.tree;
+            let tree = known.tree;
 
             // Create an expression that applies the lambda function to the capture list.
-            let lam = self.lambda_func_of(&decap_lambda);
-            let name_expr =
-                expr_var(free_name.clone(), None).set_type(self.cap_of(&decap_lambda).ty);
+            let lam = self.lambda_func_of(&tree);
+            let name_expr = expr_var(free_name.clone(), None).set_type(self.cap_of(&tree).ty);
             let expr = expr_app_typed(lam, vec![name_expr]);
 
             replace.insert(free_name.clone(), expr);

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -741,9 +741,9 @@ fn specializable_slots_of(
     let (params, body) = expr.destructure_lam_sequence();
     let params = params
         .iter()
-        .map(|may_multi_param| {
-            assert_eq!(may_multi_param.len(), 1);
-            may_multi_param[0].name.clone()
+        .map(|lam_params| {
+            assert_eq!(lam_params.len(), 1);
+            lam_params[0].name.clone()
         })
         .collect::<Vec<_>>();
     let param_tys = sym.ty.collect_app_src(usize::MAX).0;
@@ -1314,7 +1314,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         // If any free variable in the LLVM expression refers to a decaptured lambda,
         // replace it with an expression that applies the lambda function to the capture list.
 
-        let mut replace = Map::default(); // Data for replacing free variables in the LLVM expression
+        // The call of the lambda function, by the free variable holding the capture list it is
+        // applied to.
+        let mut call_lam_exprs = Map::default();
         for free_name in llvm_expr.free_vars() {
             let Some(tree) = self.bare_value_of(&free_name) else {
                 continue;
@@ -1325,11 +1327,11 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             let name_expr = expr_var(free_name.clone(), None).set_type(self.cap_of(&tree).ty);
             let expr = expr_app_typed(lam, vec![name_expr]);
 
-            replace.insert(free_name.clone(), expr);
+            call_lam_exprs.insert(free_name.clone(), expr);
         }
 
         // If none of the free variables in the LLVM expression refer to a decaptured lambda, do nothing.
-        if replace.is_empty() {
+        if call_lam_exprs.is_empty() {
             return StartVisitResult::VisitChildren;
         }
 
@@ -1342,14 +1344,14 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         // Rename free variables in the LLVM expression
         let mut llvm_expr = llvm_expr.clone();
         let mut rename: Map<FullName, FullName> = Default::default();
-        for (name, _) in replace.iter() {
+        for (name, _) in call_lam_exprs.iter() {
             rename.insert(name.clone(), make_new_name(name));
         }
         llvm_expr = rename_free_names(&llvm_expr, rename);
 
         // Insert `let (new name) = (lambda function call);` before the LLVM expression
         let mut expr = llvm_expr.clone();
-        for (name, call_lam_expr) in replace.iter() {
+        for (name, call_lam_expr) in call_lam_exprs.iter() {
             let new_name = make_new_name(name);
             expr = expr_let_typed(
                 PatternNode::make_var(var_var(new_name.clone()), None)
@@ -1482,9 +1484,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         _state: &mut VisitState,
     ) -> StartVisitResult {
         // Before visiting children, if the argument refers to a decaptured lambda, fix the domain part of the lambda type since it is incorrect.
-        let arg = expr.get_lam_params();
-        assert_eq!(arg.len(), 1);
-        let arg = &arg[0];
+        let params = expr.get_lam_params();
+        assert_eq!(params.len(), 1);
+        let arg = &params[0];
         let arg_name = &arg.name;
         // If the argument does not hold a capture list, do nothing.
         let Some(tree) = self.bare_value_of(arg_name) else {

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -770,18 +770,25 @@ fn specializable_slots_of(
     // The capture fields of a lifted lambda are ways into its body too, and narrowing one is what
     // lets a chain of copies continue past a lambda that only relays the closure it captured.
     if let Some(cap) = lifted.capture_struct(&sym.name) {
-        if let Some((field_names, cap_body)) = capture_list_destructuring(&body, &cap.tycon) {
-            for (position, (_, field_ty)) in cap.fields().iter().enumerate() {
-                if field_ty.is_closure()
-                    && reaches_a_direct_call(
-                        &field_names[position],
-                        &cap_body,
-                        specializable_funcs,
-                        lifted,
-                    )
-                {
-                    specializable_slots.insert(Slot::capture_field(position));
-                }
+        let (field_names, cap_body) =
+            capture_list_destructuring(&body, &cap.tycon).unwrap_or_else(|| {
+                panic!(
+                    "the body of the lifted lambda {} does not destructure the capture list {} it \
+                     receives",
+                    sym.name.to_string(),
+                    cap.tycon.name.to_string()
+                )
+            });
+        for (position, (_, field_ty)) in cap.fields().iter().enumerate() {
+            if field_ty.is_closure()
+                && reaches_a_direct_call(
+                    &field_names[position],
+                    &cap_body,
+                    specializable_funcs,
+                    lifted,
+                )
+            {
+                specializable_slots.insert(Slot::capture_field(position));
             }
         }
     }
@@ -939,6 +946,17 @@ impl ClosureSpecializationVisitor {
         }
     }
 
+    // The value a local name holds, where it holds the bare capture list of it. A name bound to the
+    // closure wrapped around a capture list already has the type its uses call for, so it answers
+    // nothing here.
+    fn bare_value_of(&self, name: &FullName) -> Option<Tree> {
+        let known = self.local_decap_lambdas.get(name)?;
+        if !known.is_bare {
+            return None;
+        }
+        Some(known.tree.clone())
+    }
+
     // The capture struct a value of `tree` is.
     fn cap_of(&self, tree: &Tree) -> CaptureStruct {
         self.lifted.borrow_mut().capture_struct_of(tree)
@@ -951,11 +969,7 @@ impl ClosureSpecializationVisitor {
         let base = self.lifted.borrow().func_ty(&tree.lambda);
         let (mut doms, codom) = base.collect_app_src(usize::MAX);
         doms[0] = self.cap_of(tree).ty;
-        let mut ty = codom;
-        for dom in doms.iter().rev() {
-            ty = type_fun(dom.clone(), ty);
-        }
-        expr_var(tree.unit().name(), None).set_type(ty)
+        expr_var(tree.unit().name(), None).set_type(curried_fun_ty(&doms, codom))
     }
 
     // The expression a known value is carried by: the bare capture list, or the closure wrapping it.
@@ -1069,6 +1083,15 @@ impl ClosureSpecializationVisitor {
             cap_list,
             is_bare: known.is_bare,
         }
+    }
+
+    // Narrow a known value against the chain the walk itself is on, and carry what the narrowing
+    // commits to back into that chain.
+    fn narrow_here(&mut self, known: Known) -> Known {
+        let mut pinned = self.pinned.clone();
+        let known = self.narrow(known, &mut pinned);
+        self.pinned = pinned;
+        known
     }
 
     // Ask for the copy of the lambda that receives a capture list of `tree`. Asking where the tree is
@@ -1196,13 +1219,7 @@ impl SpecializationRequest {
             doms[0] = lifted.capture_struct_of(&tree).ty;
         }
 
-        // Convert back to a function type
-        let mut func_ty = codom;
-        for dom in doms.iter().rev() {
-            func_ty = type_fun(dom.clone(), func_ty);
-        }
-
-        func_ty
+        curried_fun_ty(&doms, codom)
     }
 
     // Create an expression to refer to the specialized function.
@@ -1224,6 +1241,16 @@ fn lifted_lambda_func(cap: &CaptureStruct, lam: &Arc<ExprNode>) -> Arc<ExprNode>
     );
     let func = expr_abs_typed(var_local(CLOSURE_CAP_NAME), cap.ty.clone(), body);
     internalize_let_to_var_at_head(&func)
+}
+
+// The function type receiving `doms` one argument at a time and answering `codom`, which is the
+// inverse of `collect_app_src`.
+fn curried_fun_ty(doms: &[Arc<TypeNode>], codom: Arc<TypeNode>) -> Arc<TypeNode> {
+    let mut ty = codom;
+    for dom in doms.iter().rev() {
+        ty = type_fun(dom.clone(), ty);
+    }
+    ty
 }
 
 // `func` applied to `args`, one argument at a time.
@@ -1253,17 +1280,10 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             return StartVisitResult::VisitChildren;
         }
 
-        // Check if this name holds the capture list of a lambda this walk knows. A name bound to
-        // the closure wrapped around one already has the type its uses call for.
-        let known = self.local_decap_lambdas.get(name).cloned();
-        if known.is_none() {
+        // Check if this name holds the capture list of a lambda this walk knows.
+        let Some(tree) = self.bare_value_of(name) else {
             return StartVisitResult::VisitChildren;
-        }
-        let known = known.unwrap();
-        if !known.is_bare {
-            return StartVisitResult::VisitChildren;
-        }
-        let tree = known.tree;
+        };
 
         // If the required type for this expression is already the capture list type, do nothing.
         let expr_ty = expr.type_.as_ref().unwrap().clone();
@@ -1296,15 +1316,9 @@ impl ExprVisitor for ClosureSpecializationVisitor {
 
         let mut replace = Map::default(); // Data for replacing free variables in the LLVM expression
         for free_name in llvm_expr.free_vars() {
-            let known = self.local_decap_lambdas.get(&free_name).cloned();
-            if known.is_none() {
+            let Some(tree) = self.bare_value_of(&free_name) else {
                 continue;
-            }
-            let known = known.unwrap();
-            if !known.is_bare {
-                continue;
-            }
-            let tree = known.tree;
+            };
 
             // Create an expression that applies the lambda function to the capture list.
             let lam = self.lambda_func_of(&tree);
@@ -1384,9 +1398,7 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             if let Some(known) = self.known_value(&args[0]) {
                 let called = func.get_var().name.clone();
                 if called == known.tree.lambda || called == known.tree.unit().name() {
-                    let mut pinned = self.pinned.clone();
-                    let known = self.narrow(known, &mut pinned);
-                    self.pinned = pinned;
+                    let known = self.narrow_here(known);
                     let head = self.lambda_func_of(&known.tree);
                     let type_of = |expr: &Arc<ExprNode>| expr.type_.as_ref().unwrap().to_string();
                     if head.get_var().name != called
@@ -1474,11 +1486,11 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         assert_eq!(arg.len(), 1);
         let arg = &arg[0];
         let arg_name = &arg.name;
-        let cap_list_ty = match self.local_decap_lambdas.get(arg_name).cloned() {
-            Some(known) if known.is_bare => self.cap_of(&known.tree).ty,
-            // If the argument does not hold a capture list, do nothing.
-            _ => return StartVisitResult::VisitChildren,
+        // If the argument does not hold a capture list, do nothing.
+        let Some(tree) = self.bare_value_of(arg_name) else {
+            return StartVisitResult::VisitChildren;
         };
+        let cap_list_ty = self.cap_of(&tree).ty;
         let lam_ty = expr.type_.as_ref().unwrap();
         let arg_ty = lam_ty.get_lambda_srcs()[0].clone();
         // If the argument type is already correct, do nothing.
@@ -1550,9 +1562,7 @@ impl ExprVisitor for ClosureSpecializationVisitor {
             Some(known) => known,
             None => return StartVisitResult::VisitChildren,
         };
-        let mut pinned = self.pinned.clone();
-        let known = self.narrow(known, &mut pinned);
-        self.pinned = pinned;
+        let known = self.narrow_here(known);
 
         // A binding whose value has a known identity passes that identity to the name it binds. A
         // binding of a bare capture list lends the name the capture list itself, which later uses

--- a/src/optimization/closure_specialization.rs
+++ b/src/optimization/closure_specialization.rs
@@ -483,20 +483,7 @@ fn realize_all(
         // A copy of a lifted lambda whose capture list is narrowed receives it through the same
         // parameter, at the narrowed type. The walk retypes the pattern destructuring it when it
         // meets that pattern.
-        let narrowed = request.unit.capture_list_tree().map(|tree| {
-            let original = lifted
-                .borrow()
-                .capture_struct(&request.unit.origin)
-                .unwrap()
-                .tycon
-                .clone();
-            let cap = lifted.borrow_mut().capture_struct_of(&tree);
-            NarrowedCaptureList {
-                original,
-                cap,
-                fields: tree.fields,
-            }
-        });
+        let narrowed = narrowed_capture_list(&request.unit, lifted);
         let expr = match &narrowed {
             Some(narrowed) => {
                 let codom = expr.type_.as_ref().unwrap().get_lambda_dst();
@@ -504,23 +491,7 @@ fn realize_all(
             }
             None => expr,
         };
-
-        // Tell the walk what each substituted argument holds, by the local name it arrives under.
-        let mut local_decap_lambdas = Map::default();
-        let (args, _) = expr.destructure_lam_sequence();
-        for (slot, tree) in &request.unit.subst {
-            if slot.field.is_some() {
-                continue;
-            }
-            assert!(slot.arg < args.len());
-            assert_eq!(args[slot.arg].len(), 1);
-            let arg_name = args[slot.arg][0].name.clone();
-            let cap_list_ty = lifted.borrow_mut().capture_struct_of(tree).ty;
-            local_decap_lambdas.insert(
-                arg_name.clone(),
-                Known::bare(tree.clone(), expr_var(arg_name, None).set_type(cap_list_ty)),
-            );
-        }
+        let local_decap_lambdas = known_arguments(&request.unit, &expr, lifted);
 
         let mut visitor = ClosureSpecializationVisitor::new(
             name.clone(),
@@ -561,6 +532,59 @@ fn realize_all(
     prg.symbols = symbols;
 }
 
+// The capture list a unit receives in place of the one its origin was built with, where the unit
+// copies a lifted lambda and narrows one of its capture fields.
+fn narrowed_capture_list(
+    unit: &UnitKey,
+    lifted: &RefCell<LiftedLambdas>,
+) -> Option<NarrowedCaptureList> {
+    let tree = unit.capture_list_tree()?;
+    let original = lifted
+        .borrow()
+        .capture_struct(&unit.origin)
+        .unwrap()
+        .tycon
+        .clone();
+    let cap = lifted.borrow_mut().capture_struct_of(&tree);
+    Some(NarrowedCaptureList {
+        original,
+        cap,
+        fields: tree.fields,
+    })
+}
+
+// What each substituted argument of `unit` holds, by the local name it arrives under, which is what
+// the walk over `body` is told. A substituted capture field is left out: the walk learns that one
+// from the pattern destructuring the capture list.
+fn known_arguments(
+    unit: &UnitKey,
+    body: &Arc<ExprNode>,
+    lifted: &RefCell<LiftedLambdas>,
+) -> Map<FullName, Known> {
+    let mut known_args = Map::default();
+    let (args, _) = body.destructure_lam_sequence();
+    for (slot, tree) in &unit.subst {
+        if slot.field.is_some() {
+            continue;
+        }
+        assert!(
+            slot.arg < args.len(),
+            "{} is substituted at argument {}, but takes {} of them",
+            unit.origin.to_string(),
+            slot.arg,
+            args.len()
+        );
+        assert_eq!(args[slot.arg].len(), 1);
+        let arg_name = args[slot.arg][0].name.clone();
+        let cap_list_ty = lifted.borrow_mut().capture_struct_of(tree).ty;
+        known_args.insert(
+            arg_name.clone(),
+            Known::bare(tree.clone(), expr_var(arg_name, None).set_type(cap_list_ty)),
+        );
+    }
+    known_args
+}
+
 // Register the global function each lambda lifted by a walk became.
 fn register_lifted_lambdas(
     new_symbols: Vec<Symbol>,
@@ -587,11 +611,8 @@ fn specializable_functions(
     symbols: &Map<FullName, Symbol>,
     lifted: &LiftedLambdas,
 ) -> Map<FullName, SpecializableFunctionInfo> {
-    let call_graph = call_graph_of(symbols);
+    let (call_graph, name_to_idx) = call_graph_of(symbols);
     let call_graph_scc = call_graph.compute_sccs();
-    let name_to_idx = (0..call_graph.len())
-        .map(|idx| (call_graph.get(idx).clone(), idx))
-        .collect::<Map<FullName, usize>>();
 
     // Callers of each function, which is who has to be judged again once it enters the table. A
     // callee absent from `symbols` is a copy whose body is not made yet, and nothing reads its slots
@@ -678,7 +699,10 @@ fn reaches_a_direct_call(
                 is_specializable(specializable_funcs, &func, Slot::arg(idx))
             }
             // A value captured into a lifted lambda's capture list arrives in that lambda's body
-            // through the field it was stored in, which is a way in like an argument.
+            // through the field it was stored in, which is a way in like an argument. A struct this
+            // pass did not mint — one the program declares, or the capture list
+            // `defunctionalize_fix` builds — carries no such way in, so the value is reached there
+            // only by an indirect call.
             UsageType::CapturedInto(tycon, position) => lifted
                 .tree_of_capture_list(&tycon)
                 .is_some_and(|tree| {
@@ -766,9 +790,12 @@ fn capture_list_destructuring(
         let pat = expr.get_let_pat();
         if let Pattern::Struct(pat_tycon, field_to_pat) = &pat.pattern {
             if pat_tycon.as_ref() == tycon.as_ref() {
-                if !field_to_pat.iter().all(|(_, _, pat)| pat.is_var()) {
-                    return None;
-                }
+                assert!(
+                    field_to_pat.iter().all(|(_, _, pat)| pat.is_var()),
+                    "the capture list {} is destructured by a pattern that binds a field to \
+                     something other than a name",
+                    tycon.name.to_string()
+                );
                 let names = field_to_pat
                     .iter()
                     .map(|(_, _, pat)| pat.get_var().name.clone())
@@ -781,11 +808,12 @@ fn capture_list_destructuring(
     None
 }
 
-// The call graph of `symbols`: an edge from A to B means A calls B.
+// The call graph of `symbols` — an edge from A to B means A calls B — together with the node each
+// name is held at.
 //
 // A call site is rewritten to name a copy before that copy's body is made, so a callee absent from
 // `symbols` is one about to be created and carries no edge yet.
-fn call_graph_of(symbols: &Map<FullName, Symbol>) -> Graph<FullName> {
+fn call_graph_of(symbols: &Map<FullName, Symbol>) -> (Graph<FullName>, Map<FullName, usize>) {
     let names = symbols.keys().cloned().collect::<Vec<_>>();
     let idx_of = names
         .iter()
@@ -800,7 +828,7 @@ fn call_graph_of(symbols: &Map<FullName, Symbol>) -> Graph<FullName> {
             }
         }
     }
-    graph
+    (graph, idx_of)
 }
 
 // The capture list a copy of a lifted lambda receives in place of the one the lambda was built with.
@@ -986,9 +1014,10 @@ impl ClosureSpecializationVisitor {
             Some((_, fields)) => fields.clone(),
             None => return known,
         };
-        let info = match self.specializable_funcs.get(&known.tree.lambda) {
-            Some(info) => info.clone(),
-            None => return known,
+        // The table is held through the loop below, which takes `self` mutably.
+        let specializable_funcs = self.specializable_funcs.clone();
+        let Some(info) = specializable_funcs.get(&known.tree.lambda) else {
+            return known;
         };
         let mut narrowed_fields = Vec::new();
         for (position, (_, _, value)) in fields.iter_mut().enumerate() {
@@ -1363,9 +1392,10 @@ impl ExprVisitor for ClosureSpecializationVisitor {
         if !func_name.is_global() {
             return StartVisitResult::VisitChildren;
         }
-        let specialize_info = match self.specializable_funcs.get(&func_name) {
-            Some(info) => info.clone(),
-            None => return StartVisitResult::VisitChildren,
+        // The table is held through the loop below, which takes `self` mutably.
+        let specializable_funcs = self.specializable_funcs.clone();
+        let Some(specialize_info) = specializable_funcs.get(&func_name) else {
+            return StartVisitResult::VisitChildren;
         };
 
         // R2: an argument whose identity is known is handed over as its bare capture list, where the

--- a/src/optimization/defunctionalize_fix.rs
+++ b/src/optimization/defunctionalize_fix.rs
@@ -46,6 +46,7 @@ use crate::{
     tool::stopwatch::StopWatch,
 };
 use std::cell::RefCell;
+use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -103,7 +104,7 @@ fn run_one(
     // trivial variable-aliasing lets makes every self-reference name the parameter directly, so the
     // single substitution below reaches them all.
     let arity_map = let_elimination::create_global_lambda_to_arity_map(prg);
-    let symbols = std::mem::take(&mut prg.symbols);
+    let symbols = mem::take(&mut prg.symbols);
     let mut global_names: Set<FullName> = symbols.keys().cloned().collect();
     let mut new_symbols: Map<FullName, Symbol> = Map::default();
     let mut new_tycons: Map<TyCon, TyConInfo> = Map::default();

--- a/src/optimization/defunctionalize_fix.rs
+++ b/src/optimization/defunctionalize_fix.rs
@@ -176,6 +176,7 @@ struct LiftedFix {
 }
 
 impl LiftedFix {
+    // The program symbol defining `G`, typed by the type recorded on the lifted body.
     fn into_symbol(self) -> Symbol {
         Symbol {
             name: self.func_name.clone(),
@@ -186,6 +187,8 @@ impl LiftedFix {
     }
 }
 
+// The walk over one symbol that rewrites each `fix` application in it and collects the global
+// functions lifted out along the way.
 struct FixDefunctionalizer {
     // The symbol being processed; lifted-function names are derived from it.
     current_symbol: FullName,
@@ -206,6 +209,9 @@ struct FixDefunctionalizer {
 }
 
 impl FixDefunctionalizer {
+    // A walk over `current_symbol`, minting lifted-function names clear of `global_names` and sharing
+    // the global lambda definitions and the fixpoints built for them with the walks over the other
+    // symbols.
     fn new(
         current_symbol: FullName,
         global_names: Set<FullName>,
@@ -303,6 +309,8 @@ impl FixDefunctionalizer {
 }
 
 impl ExprVisitor for FixDefunctionalizer {
+    // An application of `Std::fix` becomes a call of the global function lifted from its recursion
+    // body, with any further arguments applied to the result.
     fn start_visit_app(
         &mut self,
         expr: &Arc<ExprNode>,
@@ -381,10 +389,10 @@ impl ExprVisitor for FixDefunctionalizer {
     fn end_visit_lam(&mut self, e: &Arc<ExprNode>, _s: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(e)
     }
+    // Record `let name = |..| ..` so a later `fix(name)` in this let's body resolves to the lambda.
+    // The `let` is an ancestor of any such use, so recording on the way down suffices; the binding
+    // stays even after a use is rewritten, since the lambda may be used elsewhere too.
     fn start_visit_let(&mut self, e: &Arc<ExprNode>, _s: &mut VisitState) -> StartVisitResult {
-        // Record `let name = |..| ..` so a later `fix(name)` in this let's body resolves to the
-        // lambda. The `let` is an ancestor of any such use, so recording on the way down suffices;
-        // the binding stays even after a use is rewritten, since the lambda may be used elsewhere too.
         if let Expr::Let(pat, bound, _) = &*e.expr {
             if bound.is_lam() {
                 let vars = pat.var_infos();

--- a/src/optimization/find_usage_of_name.rs
+++ b/src/optimization/find_usage_of_name.rs
@@ -1,12 +1,11 @@
 // This module provides functionality to find how a name is used in an expression.
 
-use std::sync::Arc;
-
 use crate::ast::{
     expr::ExprNode,
     name::FullName,
     traverse::{EndVisitResult, ExprVisitor, StartVisitResult, VisitState},
 };
+use std::sync::Arc;
 
 pub enum UsageType {
     // The name is passed as an argument to a function.
@@ -57,32 +56,24 @@ impl ExprVisitor for UsageFinder<'_> {
     fn start_visit_var(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_var(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_var(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_llvm(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_llvm(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_llvm(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
@@ -111,91 +102,71 @@ impl ExprVisitor for UsageFinder<'_> {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_app(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_app(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_lam(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_lam(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_lam(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_let(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_let(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_let(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_if(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_if(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_if(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_match(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_match(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+    fn end_visit_match(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_tyanno(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
     fn end_visit_tyanno(
         &mut self,
         expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+        _state: &mut VisitState,
+    ) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
@@ -219,56 +190,52 @@ impl ExprVisitor for UsageFinder<'_> {
     fn end_visit_make_struct(
         &mut self,
         expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+        _state: &mut VisitState,
+    ) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_array_lit(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
     fn end_visit_array_lit(
         &mut self,
         expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+        _state: &mut VisitState,
+    ) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_ffi_call(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        _state: &mut VisitState,
+    ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
     fn end_visit_ffi_call(
         &mut self,
         expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::EndVisitResult {
+        _state: &mut VisitState,
+    ) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 
     fn start_visit_eval(
         &mut self,
         _expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
+        _state: &mut VisitState,
     ) -> StartVisitResult {
         StartVisitResult::VisitChildren
     }
 
-    fn end_visit_eval(
-        &mut self,
-        expr: &Arc<ExprNode>,
-        _state: &mut crate::ast::traverse::VisitState,
-    ) -> EndVisitResult {
+    fn end_visit_eval(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         EndVisitResult::unchanged(expr)
     }
 }

--- a/src/optimization/find_usage_of_name.rs
+++ b/src/optimization/find_usage_of_name.rs
@@ -7,6 +7,7 @@ use crate::ast::{
 };
 use std::sync::Arc;
 
+// One way a name is used, at one occurrence of it.
 pub enum UsageType {
     // The name is passed as an argument to a function.
     // The first component is the name of the function called, and the second component is the index
@@ -20,6 +21,9 @@ pub enum UsageType {
     CapturedInto(FullName, usize),
 }
 
+// The uses of `name` within `expr`, one entry per occurrence that `UsageType` has a shape for, in
+// the order the walk meets them. An occurrence standing under an inner binding of the same name
+// belongs to that binding and is passed over.
 pub fn run(expr: &Arc<ExprNode>, name: &FullName) -> Vec<UsageType> {
     let mut usages = Vec::new();
     let mut finder = UsageFinder {
@@ -30,8 +34,11 @@ pub fn run(expr: &Arc<ExprNode>, name: &FullName) -> Vec<UsageType> {
     usages
 }
 
+// The walk collecting the uses of one name.
 struct UsageFinder<'a> {
+    // The name whose uses are being collected.
     name: &'a FullName,
+    // The uses met so far, which the walk appends to.
     usages: &'a mut Vec<UsageType>,
 }
 

--- a/src/optimization/find_usage_of_name.rs
+++ b/src/optimization/find_usage_of_name.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::ast::{
     expr::ExprNode,
     name::FullName,
-    traverse::{EndVisitResult, ExprVisitor, StartVisitResult},
+    traverse::{EndVisitResult, ExprVisitor, StartVisitResult, VisitState},
 };
 
 pub enum UsageType {
@@ -43,7 +43,7 @@ impl UsageFinder<'_> {
 
     // Whether an inner binding stands between here and the name being searched for, which makes an
     // occurrence here one about something else.
-    fn shadowed(&self, state: &crate::ast::traverse::VisitState) -> bool {
+    fn shadowed(&self, state: &VisitState) -> bool {
         self.name.is_local() && state.scope.has_value(&self.name.name)
     }
 }
@@ -84,8 +84,8 @@ impl ExprVisitor for UsageFinder<'_> {
     fn start_visit_app(
         &mut self,
         expr: &Arc<ExprNode>,
-        state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        state: &mut VisitState,
+    ) -> StartVisitResult {
         if self.shadowed(state) {
             return StartVisitResult::VisitChildren;
         }
@@ -197,8 +197,8 @@ impl ExprVisitor for UsageFinder<'_> {
     fn start_visit_make_struct(
         &mut self,
         expr: &Arc<ExprNode>,
-        state: &mut crate::ast::traverse::VisitState,
-    ) -> crate::ast::traverse::StartVisitResult {
+        state: &mut VisitState,
+    ) -> StartVisitResult {
         if self.shadowed(state) {
             return StartVisitResult::VisitChildren;
         }

--- a/src/optimization/find_usage_of_name.rs
+++ b/src/optimization/find_usage_of_name.rs
@@ -46,6 +46,11 @@ impl UsageFinder<'_> {
     fn shadowed(&self, state: &VisitState) -> bool {
         self.name.is_local() && state.scope.has_value(&self.name.name)
     }
+
+    // Whether `expr` is an occurrence of the name being searched for.
+    fn is_the_name(&self, expr: &Arc<ExprNode>) -> bool {
+        expr.is_var() && &expr.get_var().name == self.name
+    }
 }
 
 impl ExprVisitor for UsageFinder<'_> {
@@ -90,7 +95,7 @@ impl ExprVisitor for UsageFinder<'_> {
             return StartVisitResult::VisitChildren;
         }
         let (fun, args) = expr.destructure_app();
-        if fun.is_var() && &fun.get_var().name == self.name {
+        if self.is_the_name(&fun) {
             self.add_usage(UsageType::CalledAsFunction);
         }
         // A call whose callee is not a variable has no name to record the argument against, and the
@@ -98,7 +103,7 @@ impl ExprVisitor for UsageFinder<'_> {
         if fun.is_var() {
             let fun_name = fun.get_var().name.clone();
             for (i, arg) in args.iter().enumerate() {
-                if arg.is_var() && &arg.get_var().name == self.name {
+                if self.is_the_name(arg) {
                     self.add_usage(UsageType::FunctionArgument(fun_name.clone(), i));
                 }
             }
@@ -204,7 +209,7 @@ impl ExprVisitor for UsageFinder<'_> {
         }
         let (tycon, fields) = expr.destructure_make_struct().unwrap();
         for (position, (_, _, value)) in fields.iter().enumerate() {
-            if value.is_var() && &value.get_var().name == self.name {
+            if self.is_the_name(value) {
                 self.add_usage(UsageType::CapturedInto(tycon.name.clone(), position));
             }
         }


### PR DESCRIPTION
`closure-specialization-chain` のコードレビューが、変更のまわり (ring 2) で見つけた手入れをまとめたものです。変更そのものへの修正は元のブランチに入っており、こちらは**それが触れたファイルの、変更の外側**だけを扱います。分けてあるのは、`closure-specialization-chain` の差分を読むときに、名前直しとコメント追加が混ざらないようにするためです。

## 何が入っているか

### 1. パスの中で繰り返していた手順を、名前のある関数にした

`code-review: lift the repeated steps of the pass into named helpers`

`closure_specialization.rs` から 3 つ、`find_usage_of_name.rs` から 1 つ、同じ手順の 2 箇所以上の写しを関数にまとめました。規約は「2 つ目の写しが出た時点で関数化する」です。

- `curried_fun_ty` — 関数型を分解して 1 つの引数の型を差し替え、また組み直す手順。`lambda_func_of` と `specialized_func_ty` に同じものがあった。
- `narrow_here` — 固定表を複製し、狭めて、書き戻す手順。`start_visit_app` と `start_visit_let` に同じものがあった。
- `bare_value_of` — ローカル名が持つ素のキャプチャリストを引く手順。`start_visit_var` / `start_visit_llvm` / `start_visit_lam` の 3 箇所にあった。
- `is_the_name` (`find_usage_of_name.rs`) — 「この式は探している名前の変数か」を問う述語。3 箇所にあった。

同じコミットで 1 つだけ、**握りつぶしを止める修正**が入っています。持ち上げ済みラムダの本体がキャプチャリストを分解する `let` を持たない場合、これまでは黙って「キャプチャスロットは無い」と答えていました。この形は起こりえない (`lifted_lambda_func` が必ず置き、`internalize_let_to_var_at_head` はそれをラムダの内側へ動かすだけで消さない) ので、panic に変えてあります。到達しないことは、std を含む 12 プログラムを `-O max` でビルドして確かめました。

### 2. 中身を予告しないローカル名を直した

`code-review: rename local bindings the rewrite left behind` (元ブランチ側) と
`code-review: rename local bindings whose names hid what they hold — cleanup near the change`

書き換えで型や中身が変わったのに名前が残っていたもの、略語が何も表していないものを直しました。すべてローカル束縛で、有効範囲は 1 つの関数の中です。

- `args_loc` / `body_loc` -> `lam_args` / `lam_body` (`expr.rs`) — `_loc` が何の略でもなく、`get_lam_params` / `get_lam_body` の語に揃えた
- `may_multi_param` -> `lam_params` — 直下の `assert_eq!(len, 1)` と食い違っていた
- `replace` -> `call_lam_exprs` — 動詞が名詞の位置にあり、中身は「置換の対応」ではなく `let` に束縛する呼び出し式
- `inv_map` -> `elem_to_idx`、`visited` -> `verified` (`graph.rs`)
- `type_sgn_str` / `type_sgn` -> `type_signature` / `type_signature_text` (`program.rs`)

### 3. 修飾を短くし、use ブロックを 1 つに戻した

`code-review: shorten qualified paths — cleanup near the change`

- `find_usage_of_name.rs`: `crate::ast::traverse::` の修飾 42 箇所を落とした (3 つの型は既に import 済み)
- `graph.rs`: テストモジュールの `use super::*;` を `use super::Graph;` に
- `defunctionalize_fix.rs`: `std::mem::take` を `use std::mem;` + `mem::take` に
- 3 ファイルの use ブロックに入っていた空行を削除

`find_usage_of_name::run` や `pull_let::` のように、モジュール名のほうが「どれを呼んでいるか」を語る修飾はそのまま残してあります。

### 4. doc コメントの無かった項目に説明を足し、日本語のコメントを英語にした

`code-review: document the items around the change and put its comments in English — cleanup near the change`

規約は「Rust の項目には doc コメントを付ける」「プロジェクトが配る文章は英語で書く」です。1 ファイルあたり 5 件までという上限のもと、変更に近いものから順に入れました。

- `graph.rs` — 日本語コメント 3 件を英語に、`Graph` と `new_with_edges` に説明
- `find_usage_of_name.rs` — `UsageType` / `run` / `UsageFinder` とそのフィールド
- `closure_specialization.rs` — 本体のある `ExprVisitor` メソッド 4 つの先頭コメントを doc に昇格
- `defunctionalize_fix.rs` — `into_symbol` / `FixDefunctionalizer` / `new` / `start_visit_app` / `start_visit_let`
- `expr.rs` — `set_app_args` / `get_app_func` / `get_app_args` / `set_lam_params` / `set_lam_body` (どれも型に現れない panic 条件を持つ)
- `program.rs` — `stringify_symbols` / `emit_symbols` / `create_typechecker` / `EndNode` とその 2 つの variant

新しい doc は `///` ではなく、各ファイルが既に使っている `//` に揃えました。対象 5 ファイルのうち 3 つは `///` を 1 つも持たず、混ぜると読みにくくなるためです。

## 振る舞いが変わらない根拠

- **関数抽出**: 呼び出し側を新しい関数に載せ替えただけで、式は同じもの。
- **ローカル名の変更**: 有効範囲が 1 つの関数本体に閉じている。
- **修飾の短縮と import**: 名前の解決先が同じ。
- **コメント**: 実行されない。
- **握りつぶしを止めた 1 箇所**: 到達しないことを 12 プログラムのビルドで確かめてある。

確認したこと:

- `cargo test --release` が **1326 件 green** (`--lib` 121 + 本体 1205)
- `benchmark/speedtest/cases/sort` を cachegrind で測って **35,921,169 命令 / 45,565,240 メモリ参照** — 元ブランチと 1 命令も違わない
- `cargo fmt` は何も動かさなかった

## この後の畳み方

`closure-specialization-chain` が読まれたあとなら、どちらでも構いません。

1. この PR を `closure-specialization-chain` へマージし、そのブランチを `main` へマージする。`main` へのマージは 1 回。
2. `closure-specialization-chain` を先に `main` へマージし、head ブランチを削除する。削除すると GitHub がこの PR の宛先を `main` へ付け替えるので、単独の PR として残る。
