### PR TITLE
レビューが変更のまわりで見つけた手入れ (#216 へ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 #### Std
 
-- `Array` no longer implements `Boxed`. An array used to keep its size and capacity on the heap alongside its elements, so an `Array a` value was a pointer to that heap object and the type was `Boxed`. An array now keeps its size and capacity in the value itself and puts only the elements on the heap, so the type is unboxed: its embedded representation is `{ptr, i64, i64}` — the pointer to the element storage, the size, and the capacity. Consequently an array's element data pointer for FFI now comes from `Array::borrow_elements` / `mutate_elements` instead of the generic `Boxed` pointer helpers (`FFI::borrow_boxed` / `mutate_boxed` / `_get_boxed_ptr`); code that called those on an array uses the array helpers instead. To pass a whole array to C as an opaque retained pointer, wrap it in a boxed struct such as `Box`.
+- `Array` no longer implements `Boxed`. An array now keeps its size and capacity in the value itself and only its elements on the heap, so the type is unboxed and its embedded representation is `{ptr, i64, i64}` — the pointer to the element storage, the size, and the capacity. For FFI, take an array's element pointer from `Array::borrow_elements` / `mutate_elements` in place of `FFI::borrow_boxed` / `mutate_boxed` / `_get_boxed_ptr`, and wrap an array in a boxed struct such as `Box` to pass it to C as an opaque retained pointer.
 - `Std::unsafe_is_unique` and `Debug::assert_unique` now require their argument to be `Boxed`.
 - The counting iterators produced by `Iterator::range`, `Iterator::range_step`, and `Array::to_iter` hold different fields. They yield the same elements as before, so only code that reads their fields directly is affected; see their definitions in the standard library.
 

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -348,8 +348,8 @@ impl TraitDefn {
                 }
             }
         }
-        for mi in &self.members {
-            let node = mi.find_node_at(pos);
+        for member in &self.members {
+            let node = member.find_node_at(pos);
             if node.is_some() {
                 return node;
             }
@@ -372,8 +372,8 @@ impl TraitDefn {
     // Resolve namespace.
     pub fn resolve_namespace(&mut self, ctx: &mut NameResolutionContext) -> Result<(), Errors> {
         let mut errors = Errors::empty();
-        for mi in &mut self.members {
-            errors.eat_err(mi.resolve_namespace(ctx));
+        for member in &mut self.members {
+            errors.eat_err(member.resolve_namespace(ctx));
         }
         errors.to_result()
     }
@@ -381,8 +381,8 @@ impl TraitDefn {
     // Resolve type aliases
     pub fn resolve_type_aliases(&mut self, type_env: &TypeEnv) -> Result<(), Errors> {
         let mut errors = Errors::empty();
-        for mi in &mut self.members {
-            errors.eat_err(mi.resolve_type_aliases(type_env));
+        for member in &mut self.members {
+            errors.eat_err(member.resolve_type_aliases(type_env));
         }
         errors.to_result()
     }
@@ -391,7 +391,11 @@ impl TraitDefn {
     // Here, for example, in case "trait a: ToString { to_string : a -> String }",
     // this function returns "[a: ToString] a -> String" as type of "to_string" member.
     pub fn member_scheme(&self, name: &Name, syntactic: bool) -> Arc<Scheme> {
-        let member = self.members.iter().find(|mi| mi.name == *name).unwrap();
+        let member = self
+            .members
+            .iter()
+            .find(|member| member.name == *name)
+            .unwrap();
         let mut qual_ty = if syntactic {
             member.syn_qual_ty.as_ref().unwrap().clone()
         } else {
@@ -413,7 +417,7 @@ impl TraitDefn {
     pub fn member_ty(&self, name: &Name) -> QualType {
         self.members
             .iter()
-            .find(|mi| mi.name == *name)
+            .find(|member| member.name == *name)
             .unwrap()
             .qual_ty
             .clone()
@@ -503,9 +507,12 @@ impl TraitImpl {
         let preds = &self.qual_pred.pred_constraints;
         let eqs = &self.qual_pred.eq_constraints;
         let kind_signs = &self.qual_pred.kind_constraints;
-        let res = kind_scope.extend(preds, eqs, kind_signs, kind_env);
-        if res.is_err() {
-            return Err(Errors::from_msg_srcs(res.unwrap_err(), &[&self.source]));
+        let extend_result = kind_scope.extend(preds, eqs, kind_signs, kind_env);
+        if extend_result.is_err() {
+            return Err(Errors::from_msg_srcs(
+                extend_result.unwrap_err(),
+                &[&self.source],
+            ));
         }
         self.qual_pred.predicate.set_kinds(&kind_scope);
         for pred in &mut self.qual_pred.pred_constraints {
@@ -516,15 +523,15 @@ impl TraitImpl {
         }
         for (_member_name, member_sig) in &mut self.member_sigs {
             let mut member_kind_scope = kind_scope.clone();
-            let res = member_kind_scope.extend(
+            let extend_result = member_kind_scope.extend(
                 &member_sig.preds,
                 &member_sig.eqs,
                 &member_sig.kind_signs,
                 kind_env,
             );
-            if res.is_err() {
+            if extend_result.is_err() {
                 return Err(Errors::from_msg_srcs(
-                    res.unwrap_err(),
+                    extend_result.unwrap_err(),
                     &[&member_sig.ty.get_source()],
                 ));
             }
@@ -639,19 +646,19 @@ impl TraitImpl {
             .cloned()
             .collect();
         let new_names = generate_fresh_varnames(vars_to_rename.len(), &used_names);
-        let mut s = Substitution::default();
+        let mut rename_subst = Substitution::default();
         for (fv, new_name) in vars_to_rename.iter().zip(new_names.iter()) {
             let new_fv = type_tyvar(new_name, &fv.kind);
-            let merge_succ = s.merge(&Substitution::single(&fv.name, new_fv));
+            let merge_succ = rename_subst.merge(&Substitution::single(&fv.name, new_fv));
             assert!(merge_succ);
         }
         // Rename type variables in `method_qualty`.
-        s.substitute_qualtype(&mut method_qualty);
+        rename_subst.substitute_qualtype(&mut method_qualty);
 
         // Then substitute `tyvar_name` with `impl_type`.
         // Now we get `(a, b) -> String` or `(c -> b) -> Arrow a c -> Arrow a b` in the above examples.
-        let s = Substitution::single(&tyvar_name, impl_type);
-        s.substitute_qualtype(&mut method_qualty);
+        let impl_subst = Substitution::single(&tyvar_name, impl_type);
+        impl_subst.substitute_qualtype(&mut method_qualty);
 
         // Prepare `vars`, `ty`, `preds`, and `eqs` to be generalized.
         let ty = method_qualty.ty.clone();
@@ -824,8 +831,8 @@ pub struct TraitEnv {
 impl TraitEnv {
     // Find the minimum node which includes the specified source code position.
     pub fn find_node_at(&self, pos: &SourcePos) -> Option<EndNode> {
-        for (_t, ti) in &self.traits {
-            let node = ti.find_node_at(pos);
+        for (_t, trait_defn) in &self.traits {
+            let node = trait_defn.find_node_at(pos);
             if node.is_some() {
                 return node;
             }
@@ -1098,7 +1105,7 @@ impl TraitEnv {
             return Err(Errors::from_err(err));
         }
 
-        for (impl_assoc_type, impl_info) in impl_assoc_types {
+        for (impl_assoc_type, assoc_ty_impl) in impl_assoc_types {
             if !trait_assoc_types.contains_key(impl_assoc_type) {
                 return Err(Errors::from_msg_srcs(
                     format!(
@@ -1106,33 +1113,33 @@ impl TraitEnv {
                         impl_assoc_type,
                         trait_id.to_string(),
                     ),
-                    &[&impl_info.source],
+                    &[&assoc_ty_impl.source],
                 ));
             }
             // Validate that the impl_type written in the associated type line matches the trait impl's impl_type.
-            if impl_info.impl_type_as_written != impl_.impl_type() {
+            if assoc_ty_impl.impl_type_as_written != impl_.impl_type() {
                 return Err(Errors::from_msg_srcs(
                     format!(
                         "The implementation of an associated type should be in the form `type {{AssocTyName}} {{impl_type}} {{type_var1}} ... {{type_varN}} = {{value_type}};`, where {{impl_type}} is `{}` here.",
                         impl_.impl_type().to_string()
                     ),
-                    &[&impl_info.source],
+                    &[&assoc_ty_impl.source],
                 ));
             }
             // Validate free variable of associated type implementation.
             let mut allowed_tyvars = vec![];
             impl_.impl_type().free_vars_to_vec(&mut allowed_tyvars);
-            for arg in &impl_info.params {
+            for arg in &assoc_ty_impl.params {
                 allowed_tyvars.push(arg.clone());
             }
-            for used_tv in impl_info.value.free_vars_vec() {
+            for used_tv in assoc_ty_impl.value.free_vars_vec() {
                 if allowed_tyvars
                     .iter()
                     .all(|allowed_tv| allowed_tv.name != used_tv.name)
                 {
                     return Err(Errors::from_msg_srcs(
                         format!("Unknown type variable `{}`.", used_tv.name),
-                        &[&impl_info.source],
+                        &[&assoc_ty_impl.source],
                     ));
                 }
             }
@@ -1447,8 +1454,8 @@ impl TraitEnv {
         let mut errors = Errors::empty();
 
         // Set kinds in trait definitions.
-        for (_id, ti) in &mut self.traits {
-            errors.eat_err(ti.set_trait_kind());
+        for (_id, trait_defn) in &mut self.traits {
+            errors.eat_err(trait_defn.set_trait_kind());
         }
 
         // Throw errors if any.
@@ -1500,8 +1507,8 @@ impl TraitEnv {
 
     pub fn trait_kind_map_with_aliases(&self) -> Map<TraitId, Arc<Kind>> {
         let mut res: Map<TraitId, Arc<Kind>> = Map::default();
-        for (id, ti) in &self.traits {
-            res.insert(id.clone(), ti.type_var.kind.clone());
+        for (id, trait_defn) in &self.traits {
+            res.insert(id.clone(), trait_defn.type_var.kind.clone());
         }
         for (id, ta) in &self.aliases.data {
             res.insert(id.clone(), ta.kind.clone());
@@ -1511,8 +1518,8 @@ impl TraitEnv {
 
     pub fn import(&mut self, other: TraitEnv) -> Result<(), Errors> {
         let mut errors = Errors::empty();
-        for (_, ti) in other.traits {
-            if let Err(es) = self.add_trait(ti) {
+        for (_, trait_defn) in other.traits {
+            if let Err(es) = self.add_trait(trait_defn) {
                 errors.append(es);
             }
         }

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -747,14 +747,18 @@ impl KindSignature {
     }
 }
 
-// Trait alias environment.
+/// The trait aliases a program declares, and the expansion of an alias into the traits it stands
+/// for.
 #[derive(Clone, Default)]
 pub struct TraitAliasEnv {
+    /// Every declared alias, keyed by the name it is declared under. A trait name absent from here
+    /// names a trait of its own.
     pub data: Map<TraitId, TraitAlias>,
 }
 
 impl TraitAliasEnv {
-    // Check if a trait name is an alias.
+    /// Whether `trait_id` names an alias. Trait names divide into the aliases declared here and the
+    /// traits `TraitEnv::traits` holds.
     pub fn is_alias(&self, trait_id: &TraitId) -> bool {
         self.data.contains_key(trait_id)
     }
@@ -829,7 +833,8 @@ pub struct TraitEnv {
 }
 
 impl TraitEnv {
-    // Find the minimum node which includes the specified source code position.
+    /// The innermost node covering `pos` among the trait definitions, the trait implementations and
+    /// the trait aliases.
     pub fn find_node_at(&self, pos: &SourcePos) -> Option<EndNode> {
         for (_t, trait_defn) in &self.traits {
             let node = trait_defn.find_node_at(pos);
@@ -916,7 +921,8 @@ impl TraitEnv {
         // If some errors are found upto here, throw them.
         errors.to_result()?;
 
-        // Circular aliasing will be detected in `TraitEnv::resolve_aliases`, so we don't need to check it here.
+        // Circular aliasing is reported by `TraitAliasEnv::resolve_alias`, which
+        // `TraitEnv::set_kinds_in_trait_and_alias_defns` calls for every declared alias.
 
         for (_trait_id, trait_defn) in &self.traits {
             // Forbid opaque type variables in trait definitions.

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -359,26 +359,14 @@ impl TraitDefn {
 
     // Get the document of this trait.
     pub fn get_document(&self) -> Option<String> {
-        // Try to get document from the source code.
-        let docs = self.source.as_ref().and_then(|src| src.get_document().ok());
-
-        // If the documentation is empty, treat it as None.
-        let docs = match docs {
-            Some(docs) if docs.is_empty() => None,
-            _ => docs,
-        };
-
-        // If the document is not available in the source code, use the document field.
-        let docs = match docs {
-            Some(_) => docs,
-            None => self.document.clone(),
-        };
-
-        // Again, if the documentation is empty, treat it as None.
-        match docs {
-            Some(docs) if docs.is_empty() => None,
-            _ => docs,
+        /// `docs` with an empty document read as absent.
+        fn nonempty(docs: Option<String>) -> Option<String> {
+            docs.filter(|docs| !docs.is_empty())
         }
+
+        // Prefer the document written in the source code, and fall back to the `document` field.
+        let from_source = nonempty(self.source.as_ref().and_then(|src| src.get_document().ok()));
+        nonempty(from_source.or_else(|| self.document.clone()))
     }
 
     // Resolve namespace.
@@ -1061,21 +1049,28 @@ impl TraitEnv {
             }
         }
 
-        for (impl_member, impl_expr) in impl_members {
-            if trait_members
-                .iter()
-                .find(|mi| mi.name == *impl_member)
-                .is_none()
-            {
-                return Err(Errors::from_msg_srcs(
-                    format!(
-                        "`{}` is not a member of trait `{}`.",
-                        impl_member,
-                        trait_id.to_string(),
-                    ),
-                    &[&impl_expr.source],
-                ));
+        /// Reports `member` unless `trait_members` declares it, anchoring the report at `src`.
+        fn validate_member_is_declared(
+            trait_members: &[TraitMember],
+            trait_id: &TraitId,
+            member: &Name,
+            src: &Option<Span>,
+        ) -> Result<(), Errors> {
+            if trait_members.iter().any(|mi| mi.name == *member) {
+                return Ok(());
             }
+            Err(Errors::from_msg_srcs(
+                format!(
+                    "`{}` is not a member of trait `{}`.",
+                    member,
+                    trait_id.to_string(),
+                ),
+                &[src],
+            ))
+        }
+
+        for (impl_member, impl_expr) in impl_members {
+            validate_member_is_declared(trait_members, trait_id, impl_member, &impl_expr.source)?;
         }
 
         // Validate the set of associated types.
@@ -1169,21 +1164,12 @@ impl TraitEnv {
 
         // Validate member type signatures.
         for (member_name, member_sig) in member_sigs {
-            // Check the member is defined in the trait.
-            if !trait_members
-                .iter()
-                .find(|mi| &mi.name == member_name)
-                .is_some()
-            {
-                return Err(Errors::from_msg_srcs(
-                    format!(
-                        "`{}` is not a member of trait `{}`.",
-                        member_name,
-                        trait_id.to_string(),
-                    ),
-                    &[&member_sig.ty.get_source()],
-                ));
-            }
+            validate_member_is_declared(
+                trait_members,
+                trait_id,
+                member_name,
+                &member_sig.ty.get_source(),
+            )?;
         }
 
         // Check Orphan rules.

--- a/src/tests/test_application_inlining.rs
+++ b/src/tests/test_application_inlining.rs
@@ -185,12 +185,12 @@ mod tests {
         test_source(source, Configuration::develop_mode());
     }
 
-    // Compiling this arity takes a few seconds while the cost is linear in it, and is out of reach
-    // while the cost doubles per parameter.
+    /// Compiling this arity takes a few seconds while the cost is linear in it, and is out of reach
+    /// while the cost doubles per parameter.
     const ARITY: usize = 25;
 
-    // Generous next to the few seconds the build takes, and short enough to report a regression as
-    // a failure instead of occupying the machine.
+    /// Generous next to the few seconds the build takes, and short enough to report a regression as
+    /// a failure instead of occupying the machine.
     const TIMEOUT: Duration = Duration::from_secs(180);
 
     /// The text `item` gives each of the `ARITY` parameter positions, joined by `separator`.

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -4714,6 +4714,99 @@ pub fn test_trait_alias_reachable_along_two_paths() {
 
 /// Each numeric type carries a value through `to_bytes` and back with `from_bytes`, and
 /// `from_bytes` on a byte array one byte short of the type's width answers an error.
+/// A trait of kind `*->*` that two aliases both stand for is reached twice while an alias naming
+/// both is expanded, and the alias takes that kind. A trait named twice in one definition is
+/// likewise arrived at twice.
+#[test]
+pub fn test_trait_alias_higher_kinded_reachable_along_two_paths() {
+    let source = r#"
+        module Main;
+
+        // `Functor` is reached through `Mappable` and again through `Liftable`.
+        trait Mappable = Functor;
+        trait Liftable = Functor + Monad;
+        trait Both = Mappable + Liftable;
+
+        twice : [f : Both] (a -> a) -> f a -> f a;
+        twice = |g, x| x.map(g).map(g);
+
+        // One trait named twice in one definition.
+        trait ShownTwice = ToString + ToString;
+
+        show : [a : ShownTwice] a -> String;
+        show = |x| x.to_string;
+
+        main : IO ();
+        main = (
+            assert_eq(|_|"case 1", twice(|x| x + 1, [1, 2]), [3, 4]);;
+            assert_eq(|_|"case 2", twice(|x| x + 1, Option::some(1)).as_some, 3);;
+            assert_eq(|_|"case 3", show(7), "7");;
+
+            pure()
+        );
+    "#;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// An alias that stands for itself is reported as circular even where the aliases it names are
+/// also named by a sibling, so what several paths share does not hide the cycle.
+#[test]
+pub fn test_trait_alias_circular_beside_shared_aliases() {
+    let source = r#"
+        module Main;
+
+        trait Base = ToString;
+        trait Left = Base;
+        trait Right = Base;
+        // Error (circular aliasing)
+        trait Top = Left + Right + Top;
+
+        show : [a : Top] a -> String;
+        show = |x| x.to_string;
+
+        main : IO ();
+        main = println(show(42));
+    "#;
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    assert!(
+        errmsg.contains("Circular aliasing detected in trait alias `Main::Top`."),
+        "the alias standing for itself is reported, but the message is:\n{}",
+        errmsg
+    );
+}
+
+/// An implementation that defines a member the trait does not declare is reported, and the report
+/// points at the definition of that member rather than at the implementation as a whole.
+#[test]
+pub fn test_trait_impl_defines_undeclared_member() {
+    let source = r#"
+        module Main;
+
+        trait a : MyTrait {
+            foo : a -> I64;
+        }
+
+        impl I64 : MyTrait {
+            foo = |x| x;
+            bar = |x| x + 1;
+        }
+
+        main : IO ();
+        main = println(MyTrait::foo(1).to_string);
+    "#;
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    assert!(
+        errmsg.contains("`bar` is not a member of trait `Main::MyTrait`."),
+        "the undeclared member is reported, but the message is:\n{}",
+        errmsg
+    );
+    assert!(
+        errmsg.contains("bar = |x| x + 1;"),
+        "the report points at the definition of the member, but the message is:\n{}",
+        errmsg
+    );
+}
+
 #[test]
 pub fn test129() {
     let source = r#"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -4578,6 +4578,8 @@ pub fn test_one_and_multiplicative() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An alias takes the kind of the traits it stands for, so one naming traits of two kinds — here a
+/// trait of kind `*->*` beside one of kind `*` — is reported.
 #[test]
 pub fn test_trait_alias_kind_mismatch() {
     let source = r#"
@@ -4595,6 +4597,8 @@ pub fn test_trait_alias_kind_mismatch() {
     );
 }
 
+/// An `impl` whose head names an alias is reported, and the report says to implement each of the
+/// traits the alias stands for.
 #[test]
 pub fn test_trait_alias_implement_trait_alias_directly() {
     let source = r#"
@@ -4623,6 +4627,8 @@ pub fn test_trait_alias_implement_trait_alias_directly() {
     );
 }
 
+/// Two aliases that stand for each other are reported as circular, so expanding one of them ends
+/// instead of running on forever.
 #[test]
 pub fn test_trait_alias_circular_aliasing() {
     let source = r#"
@@ -4706,9 +4712,10 @@ pub fn test_trait_alias_reachable_along_two_paths() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Each numeric type carries a value through `to_bytes` and back with `from_bytes`, and
+/// `from_bytes` on a byte array one byte short of the type's width answers an error.
 #[test]
 pub fn test129() {
-    // Test ToBytes/FromBytes
     let source = r#"
         module Main; 
         
@@ -4800,6 +4807,8 @@ pub fn test129() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `consumed_time_while_lazy` and `consumed_time_while_io` hand back the value their argument
+/// produced along with the time it took, for a long computation and for file IO.
 #[test]
 pub fn test_consumed_time() {
     if env_vars::get_max_opt_level() <= FixOptimizationLevel::Basic {

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -10866,6 +10866,8 @@ pub fn test_higher_kinded_instance_selected_by_annotation() {
         let o = (build(4) : Option I64);
         assert_eq(|_|"", a.@(0), 3);;
         assert_eq(|_|"", o.as_some, 4);;
+        assert_eq(|_|"", a.cmap(|x| x + 1).@(0), 4);;
+        assert_eq(|_|"", o.cmap(|x| x + 1).as_some, 5);;
         pure()
     );
     "##;

--- a/src/tests/test_let_elimination.rs
+++ b/src/tests/test_let_elimination.rs
@@ -537,14 +537,14 @@ mod tests {
         test_source(source, Configuration::develop_mode());
     }
 
-    // A chain this long builds in a few seconds while the inspection of a binding is proportional
-    // to where its name is read, and in several minutes while it walks the whole body of every
-    // binding.
+    /// A chain this long builds in a few seconds while the inspection of a binding is proportional
+    /// to where its name is read, and in several minutes while it walks the whole body of every
+    /// binding.
     const CHAIN_LENGTH: usize = 2400;
 
-    // Generous next to the few seconds the build takes, with room for a machine several times
-    // slower running the rest of the suite beside it, and well short of the minutes the build takes
-    // once the inspection walks whole bodies again.
+    /// Generous next to the few seconds the build takes, with room for a machine several times
+    /// slower running the rest of the suite beside it, and well short of the minutes the build
+    /// takes once the inspection walks whole bodies.
     const TIMEOUT: Duration = Duration::from_secs(120);
 
     /// Builds and runs a global whose body is a chain of `CHAIN_LENGTH` `let`s, failing if the

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -355,8 +355,8 @@ mod tests {
         // line 4: `    let iter = Iterator::range(0, n).map(|idx| x);` (binder)
         // line 5: `    iter` (use). Both resolve to the same opaque type.
         for (line, col) in [(4u32, 8u32), (5, 4)] {
-            let hov = ctx.hover("main.fix", line, col);
-            let text = hover_text(&hov).unwrap_or_else(|| {
+            let hover = ctx.hover("main.fix", line, col);
+            let text = hover_text(&hover).unwrap_or_else(|| {
                 panic!(
                     "hover on `iter` at ({}, {}) should return content",
                     line, col
@@ -426,8 +426,8 @@ mod tests {
                 cols.len()
             );
             for (col, want) in cols.iter().zip(*expected) {
-                let hov = ctx.hover("main.fix", line as u32, *col);
-                let text = hover_text(&hov).unwrap_or_else(|| {
+                let hover = ctx.hover("main.fix", line as u32, *col);
+                let text = hover_text(&hover).unwrap_or_else(|| {
                     panic!(
                         "hover on wildcard at {:?} col {} should return content",
                         needle, col
@@ -468,8 +468,8 @@ mod tests {
         // Hover at the closing `)` of the fold call (line 8, char 43-44)
         // and a few characters around — none should mention `#hole`.
         for col in 39..=44 {
-            let hov = ctx.hover("main.fix", 8, col);
-            if let Some(text) = hover_text(&hov) {
+            let hover = ctx.hover("main.fix", 8, col);
+            if let Some(text) = hover_text(&hover) {
                 assert!(
                     !text.contains("#hole"),
                     "hover at col {} leaked the internal `#hole` name. Got: {:?}",

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -391,7 +392,7 @@ mod tests {
     #[test]
     fn test_hover_type_wildcard_shows_inferred_type() {
         let mut ctx = LspTestCtx::setup("hover_type_wildcard", &["main.fix"]);
-        let src = std::fs::read_to_string(ctx.project_dir.join("main.fix"))
+        let src = fs::read_to_string(ctx.project_dir.join("main.fix"))
             .expect("should read the copied main.fix");
         let lines: Vec<&str> = src.lines().collect();
 

--- a/src/tests/test_trait_alias.rs
+++ b/src/tests/test_trait_alias.rs
@@ -60,3 +60,205 @@ mod tests {
         );
     }
 }
+
+/// Expanding an alias stands for substituting each alias by what it names until no alias is left,
+/// and keeping the first arrival at each trait. This module builds alias graphs of every shape a
+/// handful of aliases can take -- diamonds, chains, an alias naming another twice, cycles reachable
+/// along one path of several -- and holds `TraitAliasEnv::resolve_alias` to that substitution.
+#[cfg(test)]
+mod expansion_matches_substitution {
+    use crate::ast::name::FullName;
+    use crate::ast::traits::{TraitAlias, TraitAliasEnv, TraitId};
+    use crate::ast::types::kind_star;
+    use crate::misc::{Map, Set};
+    use crate::parse::sourcefile::{SourceFile, Span};
+    use std::path::PathBuf;
+
+    /// The aliases a generated graph declares, named `A0` to `A5`.
+    const ALIASES: usize = 6;
+
+    /// The traits a generated graph declares, named `T0` to `T2`. These are what an alias expands
+    /// to, so a generated graph reaches them along however many paths its aliases give.
+    const TRAITS: usize = 3;
+
+    /// The most traits and aliases one alias names.
+    const MAX_VALUE_LEN: usize = 3;
+
+    /// How many graphs to build. Every shape six aliases naming up to three names each can take is
+    /// reached within this many.
+    const GRAPHS: usize = 4000;
+
+    /// A xorshift generator, so the graphs are the same on every run.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 >> 12;
+            self.0 ^= self.0 << 25;
+            self.0 ^= self.0 >> 27;
+            self.0.wrapping_mul(0x2545F4914F6CDD1D)
+        }
+
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+    }
+
+    fn alias_id(i: usize) -> TraitId {
+        TraitId::from_fullname(FullName::from_strs(&["Test"], &format!("A{}", i)))
+    }
+
+    fn trait_id(i: usize) -> TraitId {
+        TraitId::from_fullname(FullName::from_strs(&["Test"], &format!("T{}", i)))
+    }
+
+    /// A span over a source file held in memory, so a report a generated graph draws renders.
+    fn span() -> Span {
+        let source = SourceFile::from_file_path_and_content(
+            PathBuf::from("generated_alias_graph.fix"),
+            "trait A0 = A1;\n".to_string(),
+        );
+        Span {
+            input: source,
+            start: 0,
+            end: 14,
+        }
+    }
+
+    /// An alias graph in which each alias names between one and `MAX_VALUE_LEN` of the aliases and
+    /// the traits.
+    ///
+    /// `standing_only_for_later` restricts an alias to the aliases declared after it, so that no
+    /// alias stands for itself however long a chain of them is followed. Lifting the restriction
+    /// lets an alias name any of them, itself included, and most such graphs do have an alias that
+    /// stands for itself.
+    fn generate_graph(rng: &mut Rng, standing_only_for_later: bool) -> TraitAliasEnv {
+        let mut data = Map::default();
+        for i in 0..ALIASES {
+            let first_alias = if standing_only_for_later { i + 1 } else { 0 };
+            let mut value = vec![];
+            for _ in 0..1 + rng.below(MAX_VALUE_LEN) {
+                let picked = first_alias + rng.below(ALIASES + TRAITS - first_alias);
+                let named = if picked < ALIASES {
+                    alias_id(picked)
+                } else {
+                    trait_id(picked - ALIASES)
+                };
+                value.push((named, span()));
+            }
+            data.insert(
+                alias_id(i),
+                TraitAlias {
+                    id: alias_id(i),
+                    value,
+                    source: Some(span()),
+                    name_src: Some(span()),
+                    kind: kind_star(),
+                },
+            );
+        }
+        TraitAliasEnv { data }
+    }
+
+    /// What `trait_id` stands for once every alias in it is substituted by what that alias names,
+    /// with `entered` the aliases already substituted along this branch.
+    ///
+    /// Answers `None` once a branch has substituted `ALIASES` of them and meets another, since a
+    /// branch that long has substituted one of them twice and the substitution does not terminate.
+    fn substitute(env: &TraitAliasEnv, trait_id: &TraitId, entered: usize) -> Option<Vec<TraitId>> {
+        let Some(alias) = env.data.get(trait_id) else {
+            return Some(vec![trait_id.clone()]);
+        };
+        if entered >= ALIASES {
+            return None;
+        }
+        let mut res = vec![];
+        for (named, _) in &alias.value {
+            res.extend(substitute(env, named, entered + 1)?);
+        }
+        Some(res)
+    }
+
+    /// `ids` as names, with the arrivals after the first at each name dropped.
+    fn first_arrivals(ids: Vec<TraitId>) -> Vec<String> {
+        let mut arrived = Set::default();
+        ids.into_iter()
+            .filter(|id| arrived.insert(id.clone()))
+            .map(|id| id.to_string())
+            .collect()
+    }
+
+    /// `ids` as names, each kept where it stands.
+    fn names(ids: Vec<TraitId>) -> Vec<String> {
+        ids.into_iter().map(|id| id.to_string()).collect()
+    }
+
+    #[test]
+    fn test_expansion_matches_substitution() {
+        let mut rng = Rng(0x9E3779B97F4A7C15);
+        let mut expanded = 0;
+        let mut reported = 0;
+        for graph_index in 0..2 * GRAPHS {
+            let env = generate_graph(&mut rng, graph_index % 2 == 0);
+            for i in 0..ALIASES {
+                let root = alias_id(i);
+                let graph = describe(&env);
+                match (env.resolve_alias(&root), substitute(&env, &root, 0)) {
+                    (Ok(found), Some(stands_for)) => {
+                        expanded += 1;
+                        assert_eq!(
+                            names(found),
+                            first_arrivals(stands_for),
+                            "`{}` was expanded into something other than what it stands for, in:\n{}",
+                            root.to_string(),
+                            graph
+                        );
+                    }
+                    (Err(errs), None) => {
+                        reported += 1;
+                        let msg = errs.to_string();
+                        assert!(
+                            msg.contains("Circular aliasing detected in trait alias `Test::A"),
+                            "expanding `{}` was refused for a reason other than circular aliasing, \
+                             or the report named a trait rather than an alias:\n{}\nin:\n{}",
+                            root.to_string(),
+                            msg,
+                            graph
+                        );
+                    }
+                    (Ok(found), None) => panic!(
+                        "`{}` stands for itself, and was expanded into [{}] all the same, in:\n{}",
+                        root.to_string(),
+                        names(found).join(", "),
+                        graph
+                    ),
+                    (Err(errs), Some(stands_for)) => panic!(
+                        "`{}` stands for [{}], and expanding it was refused, in:\n{}\n{}",
+                        root.to_string(),
+                        first_arrivals(stands_for).join(", "),
+                        graph,
+                        errs.to_string()
+                    ),
+                }
+            }
+        }
+        assert!(
+            expanded >= GRAPHS && reported >= GRAPHS,
+            "the graphs reached one of the two answers too rarely to hold the expansion to \
+             anything: {} expanded, {} reported",
+            expanded,
+            reported
+        );
+    }
+
+    /// The graph as the declarations that would produce it, for a failure to name.
+    fn describe(env: &TraitAliasEnv) -> String {
+        let mut res = String::new();
+        for i in 0..ALIASES {
+            let alias = env.data.get(&alias_id(i)).unwrap();
+            let named: Vec<String> = alias.value.iter().map(|(id, _)| id.to_string()).collect();
+            res += &format!("trait {} = {};\n", alias.id.to_string(), named.join(" + "));
+        }
+        res
+    }
+}


### PR DESCRIPTION
#216 (2 経路で到達できるトレイトエイリアスを受け入れる) のコードレビューが、変更の**まわり**で見つけた
手入れ。#216 の diff を読みやすく保つために別ブランチに分けてあり、宛先は `main` ではなく
`trait-alias-diamond` である。

どの編集も、振る舞いを変えない種類のものに限ってある: コメントと doc コメント、import、ローカル束縛の
改名、同一ファイル内の重複ブロックの関数化。

## 入っているもの

**1. トレイトメンバーを `main` から参照する** (`src/tests/test_basic.rs`)

`test_higher_kinded_instance_selected_by_annotation` は、トレイト `Container` のメンバー `cmap` を
宣言し `Array` と `Option` に実装しながら、`main` からは一度も呼んでいなかった。Fix のコンパイラは
`main` から到達しないシンボルの検査を飛ばすことがあるので、壊れた実装でもテストが通る。`main` から
両方の実装を呼ぶ 2 行を足した。`Array` の実装を壊すとテストが落ちることを確かめてある。

**2. 繰り返し書かれていた検査を 1 つの関数にまとめる** (`src/ast/traits.rs`)

- `TraitDefn::get_document`: 「空の document は無いものとして読む」判定が同じ関数の中に 2 度あった。
  入れ子関数 `nonempty` に寄せ、ソースの doc コメントを優先して `document` フィールドへ落ちる形を
  2 行にした。
- `TraitEnv::validate_trait_impl`: 「その名前をトレイトが宣言しているか、していなければ報告する」
  ブロックが、実装の本体を見る箇所と型注釈を見る箇所の 2 つにあった。`validate_member_is_declared`
  にまとめた。二重否定 `!....find(..).is_some()` もここで `any` になった。

**3. ローカル束縛を、それが持つ値の名前にする** (`src/ast/traits.rs`, `src/tests/test_lsp/test_hover.rs`)

`s` という名前の別々の `Substitution` 2 つ (後者が前者を隠していた) を `rename_subst` と `impl_subst`
に、`AssocTypeImpl` を持つ `impl_info` を `assoc_ty_impl` に、`Result` を持つ `res` (このファイルで
`res` は蓄積用のベクタを指す) を `extend_result` に、`TraitMember` の `mi` を `member` に、`TraitDefn`
の `ti` を `trait_defn` に。テスト側は `hov` を `hover` に。

**4. 呼んでいるモジュールを import する** (`src/tests/test_lsp/test_hover.rs`)

`std::fs::read_to_string` の 1 箇所を、`fs` を import して `fs::read_to_string` に。

**5. item が何であるかを述べ、参照先を実在する名前にする** (`src/ast/traits.rs`,
`src/tests/*`, `CHANGELOG.md`)

- `TraitEnv::validate_structure` のコメントが、存在しない `TraitEnv::resolve_aliases` を「循環はそこで
  検出される」と指していた。実際に報告するのは `TraitAliasEnv::resolve_alias` で、呼ぶのは
  `TraitEnv::set_kinds_in_trait_and_alias_defns` である。参照先を直し、「ここで検査する必要はない」の
  否定形を落とした。
- `TraitAliasEnv` とその `data`、`is_alias`、`TraitEnv::find_node_at` に doc コメントを付けた。
- テスト 5 本 + 定数 4 つに、何を確かめるものかを述べる doc コメントを付けた。
- `CHANGELOG.md` の `Array` が `Boxed` を実装しなくなった件のエントリから、以前の表現を説明する 1 文を
  落とした (移行先と embedded representation は残してある)。

`cargo test --release` 全件。

---

# 付録

## A. 手を付けずに残した所見

レビューが挙げたもののうち、振る舞いを変えるか、触るファイルが変更のまわりを越えるため、判断を著者に
残したもの。

**`TraitAlias::get_document` が doc の無いエイリアスに `Some("")` を返す。** `Span::get_document()` は
doc が無いとき `Ok("")` を返す。`TraitDefn::get_document` はこれを `None` に潰すが、`TraitAlias` と
`TyAliasInfo` の同名メソッドは潰さない。LSP の hover はこれを受けて、トレイトには出ない空のブロックを
markdown に足す。挙動の変更なので finding。

**`get_document` の本体が 3 ファイルに複製されている。** `TraitDefn` (`traits.rs`)、`TyConInfo`
(`types.rs`)、`GlobalValue` (`program.rs`) の 3 つが、フィールド名以外は一字一句同じである。正しい
住処は `Span` 上のメソッド。今回まとめたのは `traits.rs` の中だけである。

**`TraitEnv::validate_structure` が、溜めた診断を捨てる枝を持つ。** trait impl のループは
`errors.eat_err(..)` で複数のエラーを溜めるが、「トレイトエイリアスへの impl」だけが `return Err(..)`
で即座に返る。壊れた impl とエイリアスへの impl が同居すると、先に溜めた診断が出ない。

**`AssocTypeKindInfo::name` が読まれていない。** `#[allow(dead_code)]` が付いており、キーの
`AssocType` と同じものを値側でもう一度持っている。

**`test_util::test_files_in_directory` が特定のテストの出力ファイル名を直書きしている。** 汎用の
ヘルパがループの末尾で `remove_file("test_process_text_file.txt")` を呼び、失敗を握り潰す。対象は
カレントディレクトリなので、並行実行では他方の生成物を消し得る。

**`test_util::test_source_with_c` が gcc の終了ステータスを見ていない。** C のコンパイルが失敗しても
存在しない `.o` をリンクに渡し、失敗はリンカの別のメッセージとして遅れて出る。

**LSP テストのハーネスが複製されている。** `setup_test_env` が `src/tests/` 配下 23 ファイル、
`LspTestCtx` が LSP テスト 4 ファイル、`file_uri` が 7 ファイルにある。

**doc コメントの無い item。** `src/ast/traits.rs` に 65、`src/tests/test_basic.rs` の `#[test]` に 363。
ファイル 1 つあたり 5 件という上限を使い切った残り。
