### PR TITLE
lsp-import-completion の周辺清掃 (code-review neighborhood パス)

### DIFF
--- a/src/commands/lsp/completion/mod.rs
+++ b/src/commands/lsp/completion/mod.rs
@@ -41,6 +41,7 @@ use lsp_types::{
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::thread;
 
 /// Payload stashed in `CompletionItem::data`, carried from
 /// `textDocument/completion` to `completionItem/resolve`.
@@ -409,7 +410,7 @@ fn tiers_in_parallel(
     // threads); the memo is a `Mutex`, so the workers share one cache.
     let chunk_size = n.div_ceil(workers);
     let mut tiers = Vec::with_capacity(n);
-    std::thread::scope(|s| {
+    thread::scope(|s| {
         let handles: Vec<_> = names
             .chunks(chunk_size)
             .map(|chunk| {
@@ -923,7 +924,7 @@ pub(super) fn handle_completion_resolve_document(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::extract_namespace_from_typing_text;
 
     #[test]
     fn test_extract_namespace_from_typing_text_basic() {

--- a/src/commands/lsp/completion/mod.rs
+++ b/src/commands/lsp/completion/mod.rs
@@ -726,7 +726,8 @@ fn recurse_for_hole(
     }
 }
 
-// Check if the user's typing text is in the form of a dot followed by namespaces or a function name
+/// Checks whether the user's typing text ends in a dot followed by
+/// namespaces or a function name.
 fn is_dot_function(typing_text: &str) -> bool {
     let mut chars = typing_text.chars().rev();
     let identifier_chars = chars_allowed_in_identifiers();
@@ -741,8 +742,9 @@ fn is_dot_function(typing_text: &str) -> bool {
     false
 }
 
-// Extract namespace from typing text string.
-// This function performs string manipulation to extract namespace components from user input.
+/// Returns the trailing `Ns1::Ns2:`-shaped portion of the typing text as a
+/// `NameSpace`. A final component that does not start with an uppercase
+/// letter (a partially typed value name) is dropped.
 fn extract_namespace_from_typing_text(typing_text: &str) -> NameSpace {
     // Get the suffix of `typing_text` that consists of characters allowed in identifiers and colons.
     // Example: input "let x = Std::Array:" -> "Std::Array:"
@@ -783,7 +785,8 @@ fn extract_namespace_from_typing_text(typing_text: &str) -> NameSpace {
     namespace.unwrap()
 }
 
-// Get the text of the line being typed by the user up to the cursor position.
+/// Gets the text of the line being typed by the user up to the cursor
+/// position.
 fn get_typing_text(
     text_document_position: &TextDocumentPositionParams,
     uri_to_content: &Map<Uri, LatestContent>,
@@ -795,8 +798,9 @@ fn get_typing_text(
     typing_text
 }
 
-// Handle "completionItem/resolve" method.
-// Add documentation to the completion item.
+/// Handles the `completionItem/resolve` LSP request: attaches documentation
+/// to the completion item, appends an argument-snippet to the insert text of
+/// a global value, and adds text edits that import the completed name.
 pub(super) fn handle_completion_resolve_document(
     id: u32,
     params: &CompletionItem,

--- a/src/commands/lsp/completion/mod.rs
+++ b/src/commands/lsp/completion/mod.rs
@@ -728,12 +728,12 @@ fn recurse_for_hole(
 // Check if the user's typing text is in the form of a dot followed by namespaces or a function name
 fn is_dot_function(typing_text: &str) -> bool {
     let mut chars = typing_text.chars().rev();
-    let identifer_chars = chars_allowed_in_identifiers();
+    let identifier_chars = chars_allowed_in_identifiers();
     while let Some(c) = chars.next() {
         if c == '.' {
             return true;
         }
-        if !identifer_chars.contains(c) && c != ':' {
+        if !identifier_chars.contains(c) && c != ':' {
             return false;
         }
     }
@@ -745,11 +745,11 @@ fn is_dot_function(typing_text: &str) -> bool {
 fn extract_namespace_from_typing_text(typing_text: &str) -> NameSpace {
     // Get the suffix of `typing_text` that consists of characters allowed in identifiers and colons.
     // Example: input "let x = Std::Array:" -> "Std::Array:"
-    let identifer_chars = chars_allowed_in_identifiers();
+    let identifier_chars = chars_allowed_in_identifiers();
     let suffix_byte_start = typing_text
         .char_indices()
         .rev()
-        .find(|(_, c)| !(identifer_chars.contains(*c) || *c == ':'))
+        .find(|(_, c)| !(identifier_chars.contains(*c) || *c == ':'))
         .map(|(i, c)| i + c.len_utf8())
         .unwrap_or(0);
     let namespace_part = &typing_text[suffix_byte_start..];

--- a/src/commands/lsp/util.rs
+++ b/src/commands/lsp/util.rs
@@ -90,9 +90,9 @@ pub(super) fn position_to_bytes(string: &str, position: Position) -> usize {
     bytes
 }
 
-// Returns true when the cursor of `text_position` sits inside a comment
-// (`//` line comment or `/* */` block comment) in the latest content of
-// the file. If the content for the uri is unavailable, returns false.
+/// Returns true when the cursor of `text_position` sits inside a comment
+/// (`//` line comment or `/* */` block comment) in the latest content of
+/// the file. If the content for the uri is unavailable, returns false.
 pub(super) fn is_cursor_in_comment(
     uri_to_content: &Map<Uri, LatestContent>,
     text_position: &TextDocumentPositionParams,
@@ -106,8 +106,8 @@ pub(super) fn is_cursor_in_comment(
     is_byte_in_comment(content, cursor)
 }
 
-// Returns true when byte offset `cursor` in `content` falls inside a
-// `//` line comment or `/* */` block comment.
+/// Returns true when byte offset `cursor` in `content` falls inside a
+/// `//` line comment or `/* */` block comment.
 fn is_byte_in_comment(content: &str, cursor: usize) -> bool {
     let state = scan_outside_comments(content, cursor, &mut |_, _| {});
     matches!(state, ScanState::LineComment | ScanState::BlockComment)
@@ -274,11 +274,11 @@ pub(super) struct LocalOccurrences {
     pub uses: Vec<Span>,
 }
 
-// At cursor position `pos`, resolve the local name `target` to its
-// enclosing binding — the innermost `let` / lambda / match-arm binder of
-// `target` whose scope contains `pos` — and return that binding's
-// definition span together with every use that resolves to the *same*
-// binding. Uses captured by an inner re-binding of `target` are excluded.
+/// At cursor position `pos`, resolve the local name `target` to its
+/// enclosing binding — the innermost `let` / lambda / match-arm binder of
+/// `target` whose scope contains `pos` — and return that binding's
+/// definition span together with every use that resolves to the *same*
+/// binding. Uses captured by an inner re-binding of `target` are excluded.
 pub(super) fn find_local_occurrences(
     program: &Program,
     pos: &SourcePos,
@@ -591,7 +591,7 @@ fn collect_uses_of_binding(
     }
 }
 
-// Get the current directory, logging an error and returning None if it fails.
+/// Get the current directory, logging an error if it fails.
 pub(super) fn get_current_dir() -> Option<PathBuf> {
     match env::current_dir() {
         Ok(d) => Some(d),
@@ -633,8 +633,8 @@ pub(super) fn span_to_range(span: &Span) -> Range {
     }
 }
 
-// Convert a `Span` into an `lsp_types::Location` using `cdir` as the base directory.
-// Returns `None` if the path cannot be converted to a URI.
+/// Convert a `Span` into an `lsp_types::Location` using `cdir` as the base
+/// directory.
 pub(super) fn span_to_location(span: &Span, cdir: &PathBuf) -> Option<Location> {
     let uri = path_to_uri(&cdir.join(&span.input.file_path));
     match uri {

--- a/src/commands/lsp/util.rs
+++ b/src/commands/lsp/util.rs
@@ -17,6 +17,7 @@ use difference::{diff, Difference};
 use lsp_types::{
     Location, MarkupContent, MarkupKind, Position, Range, TextDocumentPositionParams, Uri,
 };
+use std::env;
 use std::path::{Component, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -592,7 +593,7 @@ fn collect_uses_of_binding(
 
 // Get the current directory, logging an error and returning None if it fails.
 pub(super) fn get_current_dir() -> Option<PathBuf> {
-    match std::env::current_dir() {
+    match env::current_dir() {
         Ok(d) => Some(d),
         Err(e) => {
             write_log!("Failed to get the current directory: {:?}", e);

--- a/src/commands/lsp/util.rs
+++ b/src/commands/lsp/util.rs
@@ -298,8 +298,8 @@ pub(super) fn find_local_occurrences(
                 continue;
             };
             let mut uses = vec![];
-            let mut stack2: Vec<(FullName, Span)> = vec![];
-            collect_uses_of_binding(root, target, &def_span, &mut stack2, &mut uses);
+            let mut uses_stack: Vec<(FullName, Span)> = vec![];
+            collect_uses_of_binding(root, target, &def_span, &mut uses_stack, &mut uses);
             return Some(LocalOccurrences {
                 definition: def_span,
                 uses,

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -29,14 +29,14 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    // Get the path to the test cases directory
+    /// Path to the directory holding the LSP test-case projects.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_lsp/cases");
         path
     }
 
-    // Create a temporary test environment with copied project files
+    /// Create a temporary test environment with copied project files.
     fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let test_case_src = get_test_cases_dir().join(project_name);
@@ -48,10 +48,11 @@ mod tests {
         (temp_dir, test_case_dst)
     }
 
+    /// The LSP server automatically generates a lock file containing the
+    /// project's dependencies, and diagnostics clear once a missing
+    /// dependency is added.
     #[test]
     fn test_lsp_auto_lockfile_generation() {
-        // Test: Verify that LSP automatically generates lock file with dependencies
-
         let (_temp_dir, project_dir) = setup_test_env("project_with_deps");
 
         // Clean up before test
@@ -151,12 +152,11 @@ mod tests {
             .expect("Reader thread should not have errors");
     }
 
+    /// The LSP server automatically generates a lock file covering
+    /// test-dependencies when test.fix imports an external library added
+    /// with `fix deps add --test`.
     #[test]
     fn test_lsp_auto_lockfile_generation_for_test_deps() {
-        // Test: Verify that LSP automatically generates lock file with test-dependencies
-        // when test.fix imports an external library that is listed in test_dependencies
-        // but not yet in fixproj.toml.
-
         let (_temp_dir, project_dir) = setup_test_env("project_with_test_deps");
 
         // Clean up before test
@@ -257,10 +257,10 @@ mod tests {
             .expect("Reader thread should not have errors");
     }
 
+    /// The LSP server shows diagnostic errors, anchored to fixproj.toml,
+    /// when dependency resolution fails.
     #[test]
     fn test_lsp_dependency_resolution_failure() {
-        // Test: Verify that LSP shows diagnostic errors when dependency resolution fails
-
         let (_temp_dir, project_dir) = setup_test_env("project_with_invalid_dep");
 
         // Clean up before test

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -299,15 +299,16 @@ mod tests {
     /// `42.<cursor>` in a body that mentions both `myfunc1 : U32 -> U32 -> U32`
     /// and `myfunc2 : I64 -> I64 -> I64` — `42` is `I64` so `myfunc2` should
     /// outrank `myfunc1` in the completion list. Verifies the dot-completion
-    /// type-aware ranking pipeline (Steps 1-4).
+    /// ranking pipeline: receiver-type extraction and tier-based `sortText`
+    /// assignment.
     #[test]
     fn test_completion_dot_sort_ranks_matching_receiver_above_others() {
         let mut ctx = LspCompletionCtx::setup("completion-dot-sort", &["main.fix"]);
 
         // Cursor right after the dot in `    42.` on line 13 (0-indexed),
         // column 7 (= byte right after `.`).
-        // Use a polling wait — Step 1's full re-elaborate can take longer
-        // than `complete`'s hard-coded 5s sleep on a cold cache.
+        // Use a polling wait — the dot-completion full re-elaborate can take
+        // longer than `complete`'s hard-coded 5s sleep on a cold cache.
         let items = ctx.complete_with_timeout("main.fix", 13, 7, Duration::from_secs(60));
 
         // Each item should carry a sortText derived from its tier.
@@ -352,16 +353,13 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Scenario B: the on-disk file has a parse error (`42` with no
-    /// dot inside `(...)`), so the snapshot Program built at LSP
-    /// startup may be missing the user's module entirely. The user
-    /// then types `.` (live buffer becomes parseable as `42.pure()`)
-    /// and triggers completion.
-    ///
-    /// This reproduces the user's report that priority ranking
-    /// doesn't apply after a "save with parse error → close → reopen
-    /// → type the dot" round trip. We expect the test to fail before
-    /// any fix lands; once it passes the regression is closed.
+    /// The on-disk file has a parse error (`42` with no dot inside
+    /// `(...)`), so the snapshot Program built at LSP startup may be
+    /// missing the user's module entirely. The user then types `.`
+    /// (live buffer becomes parseable as `42.pure()`) and triggers
+    /// completion. Type-aware ranking must still apply: the receiver
+    /// type is recovered from the repaired live buffer even when the
+    /// startup snapshot lacks the module.
     #[test]
     fn test_completion_dot_sort_stale_snapshot_after_dot_added() {
         let (temp_dir, project_dir) = setup_test_env("completion-dot-sort-stale");
@@ -503,13 +501,12 @@ mod tests {
         }
     }
 
-    /// Reproduces the user-report: `let n = range(50, 101).<cursor>`
-    /// with the cursor right after the dot at end of line. We expect
-    /// some `Std::Iterator::*` method (e.g. `fold`) to be ranked
-    /// strictly above an alphabetically-earlier candidate like
-    /// `Std::Add::add` — i.e. the dot-completion ranker must classify
-    /// the receiver as a `RangeIterator`-like type and place Iterator
-    /// methods in a lower-numbered tier.
+    /// `let n = range(50, 101).<cursor>` with the cursor right after
+    /// the dot at end of line. Some `Std::Iterator::*` method (e.g.
+    /// `fold`) must be ranked strictly above an alphabetically-earlier
+    /// candidate like `Std::Add::add` — the dot-completion ranker must
+    /// classify the receiver as a `RangeIterator`-like type and place
+    /// Iterator methods in a lower-numbered tier.
     #[test]
     fn test_completion_dot_sort_iterator_at_end_of_line() {
         let mut ctx = LspCompletionCtx::setup("completion-dot-sort-iterator", &["main.fix"]);
@@ -1168,8 +1165,7 @@ mod tests {
 
         // The receiver is a `String`, so the dot-context ranker must have
         // run: at least one `Std::String::*` candidate must land in
-        // Tier 0 (a `0`-prefixed sortText). Before the fix these were
-        // untiered (no sortText) because no receiver type was recovered.
+        // Tier 0 (a `0`-prefixed sortText).
         let best_string_sort = items
             .iter()
             .filter(|it| {


### PR DESCRIPTION
## 概要

PR #214 (import 文の補完) のコードレビューの neighborhood パスです。レビューは差分そのものへの修正 (ring 1) と、差分が触ったファイルの残り (ring 2) への清掃を分けて行い、前者は #214 のブランチに、後者はこの PR に載せています。#214 の差分を読み終えるまで、この清掃が差分に混ざらないようにするための分離です。

コミットはアスペクトごとに 1 つで、すべて振る舞いを構成上変えない種類の編集 (ローカル変数のリネーム、import の書き換え、コメント) に限定しています。`cargo check --tests` で確認済みです。

## コミット内容

### `code-review: rename misleading locals — cleanup near the change`

naming 規約 (名前から中身を予測できること) によるローカル変数のリネーム 2 件。スコープは関数内に閉じるので振る舞いに影響しません。

- `src/commands/lsp/completion/mod.rs`: `is_dot_function` と `extract_namespace_from_typing_text` のローカル `identifer_chars` を `identifier_chars` に (スペル修正。概念は `chars_allowed_in_identifiers`)。
- `src/commands/lsp/util.rs`: `find_local_occurrences` のローカル `stack2` を `uses_stack` に (番号付きスロット名から、担っている使用箇所収集の役割を表す名前に)。

### `code-review: shorten qualified paths — cleanup near the change`

shorten-qualifiers 規約 (明示 import、意味を担う修飾子だけ残す) の適用 3 件。

- `src/commands/lsp/completion/mod.rs`: テストモジュールの `use super::*;` を、実際に使う `extract_namespace_from_typing_text` だけの明示 import に。`std::thread::scope(...)` を `use std::thread;` + `thread::scope(...)` に (`scope` 単体では何の scope か読めないため、意味を担うモジュール名を 1 段残す形)。
- `src/commands/lsp/util.rs`: `std::env::current_dir()` を `use std::env;` + `env::current_dir()` に。

### `code-review: comment-style fixes — cleanup near the change`

comment-style 規約によるコメントのみの編集 19 件。ファイルごとの予算 (5 件) 内で、差分に近い順に適用しています。

- `src/tests/test_lsp/test_completion.rs`: "(Steps 1-4)" のような番号参照を機構名での参照に置換 (番号は編集でずれるため)。テスト doc に残っていた経緯の叙述 ("user's report"、"expect to fail before any fix lands" など) を、テストが固定する不変条件の記述に書き換え。
- `src/commands/lsp/completion/mod.rs`: `is_dot_function` / `extract_namespace_from_typing_text` / `get_typing_text` / `handle_completion_resolve_document` を `///` doc コメント化 (入力・出力を記述)。
- `src/commands/lsp/util.rs`: `is_cursor_in_comment` / `is_byte_in_comment` / `find_local_occurrences` の `///` 化、`span_to_location` の routine な "Returns None" 列挙の削除、`get_current_dir` の肯定形への書き換え。
- `src/tests/test_lsp/mod.rs`: ヘルパ 2 つと `#[test]` 3 つに、検証する観点を述べる doc を付与。

## 取り込み方

#214 の差分を読み終えたあと、この PR を #214 のブランチへマージしてから #214 を main にマージするか、先に #214 を main へマージしてブランチを削除する (GitHub がこの PR の base を main に付け替えるので、単独の main 宛 PR になる) かのどちらでも取り込めます。
