### PR TITLE
レビューが変更のまわりで見つけた手入れ (#225 へ)

### DIFF
--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -89,8 +89,19 @@ loop = |s, body| (
 
 namespace Array {
 
-    // A function like `get_sub`, but behaves as if the size of the array is the specified value, 
-    // and has a parameter to specify additional capacity of the returned `Array`.
+    // Copies `arr[begin, end)` into a new array, treating `arr` as having size `len` and giving the
+    // new array `additional_capacity` elements' worth of capacity beyond the elements copied.
+    //
+    // A negative `begin` reads as `0` and an `end` past `len` reads as `len`; a range that ends at
+    // or before it begins gives an array of no elements.
+    //
+    // # Parameters
+    //
+    // * `len` - The size to treat `arr` as having.
+    // * `additional_capacity` - The capacity of the returned array beyond the elements it holds.
+    // * `begin` - The start index of the range to copy.
+    // * `end` - The end index of the range to copy.
+    // * `arr` - The array to copy the range out of.
     _get_sub_size_with_length_and_additional_capacity : I64 -> I64 -> I64 -> I64 -> Array a -> Array a;
     _get_sub_size_with_length_and_additional_capacity = |len, additional_capacity, begin, end, arr| (
         let begin = max(0, begin);
@@ -538,12 +549,12 @@ namespace Array {
     );
 
     // Heap sort for the specified range in an array.
-    // 
-    // # parameters
+    //
+    // # Parameters
     // - `less_than`: A function that takes two elements and returns true if the first is
     //   less than the second.
-    // - `start`
-    // - `end`
+    // - `start`: The start index of the range to sort.
+    // - `end`: The end index of the range to sort.
     // - `arr`: An array of elements to be sorted.
     _heap_sort_by_ranged : ((a, a) -> Bool) -> I64 -> I64 -> Array a -> Array a;
     _heap_sort_by_ranged = |less_than, start, end, arr| (
@@ -564,13 +575,13 @@ namespace Array {
 
     // Down-heap (sift down) operation to maintain the heap property.
     //
-    // # parameters
+    // # Parameters
     // - `less_than`: A function that takes two elements and returns true if the first is
     //   less than the second.
     // - `i`: The index of the element to sift down.
     // - `heap_end`: The end index of the heap.
-    // - `start`: the range of an array.
-    // - `end`: the range of an array.
+    // - `start`: The start index of the range being sorted, where the root of the heap sits.
+    // - `end`: The end index of the range being sorted.
     // - `heap`: An array representing the heap.
     _heap_down_ranged : ((a, a) -> Bool) -> I64 -> I64 -> I64 -> I64 -> Array a -> Array a;
     _heap_down_ranged = |less_than, i, heap_end, start, end, heap| (
@@ -588,18 +599,18 @@ namespace Array {
     );
 
     // Stable sort by `LessThan` trait.
-    // 
-    // Note: Currently this is implemented by merge sort, which is not in-place.
-    // 
+    //
+    // Implemented by merge sort, which allocates an array as large as the one being sorted.
+    //
     // # Parameters
     // - `arr`: An array of elements to be sorted.
     sort_stable : [a : LessThan] Array a -> Array a;
     sort_stable = |arr| arr.sort_stable_by(|(lhs, rhs)| lhs < rhs);    
 
     // Stable sort by a "less than" comparator.
-    // 
-    // Note: Currently this is implemented by merge sort, which is not in-place.
-    // 
+    //
+    // Implemented by merge sort, which allocates an array as large as the one being sorted.
+    //
     // # Parameters
     // 
     // * `less_than` - The comparator function.

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -92,13 +92,13 @@ namespace Array {
     // A function like `get_sub`, but behaves as if the size of the array is the specified value, 
     // and has a parameter to specify additional capacity of the returned `Array`.
     _get_sub_size_with_length_and_additional_capacity : I64 -> I64 -> I64 -> I64 -> Array a -> Array a;
-    _get_sub_size_with_length_and_additional_capacity = |len, additional_capacity, s, e, arr| (
-        let s = max(0, s);
-        let e = min(len, e);
-        let n = if e > s { e - s } else { 0 };
+    _get_sub_size_with_length_and_additional_capacity = |len, additional_capacity, begin, end, arr| (
+        let begin = max(0, begin);
+        let end = min(len, end);
+        let n = if end > begin { end - begin } else { 0 };
         let res = Array::empty(n + additional_capacity);
         if n == 0 || len == 0 { res };
-        res._unsafe_copy_capacity_bounds_unchecked(arr, s, e)
+        res._unsafe_copy_capacity_bounds_unchecked(arr, begin, end)
     );
 
     // Gets an element of an array at the specified index.
@@ -374,9 +374,9 @@ namespace Array {
         Option::some $ arr.@(len - 1)
     );
 
-    // `arr.get_sub(s, e)` returns an array `[ arr.@(i) | i ∈ [s, e) ]`.
+    // `arr.get_sub(start, end)` returns an array `[ arr.@(i) | i ∈ [start, end) ]`.
     // 
-    // `s` and `e` are clamped to the range `[0, arr.@size]`.
+    // `start` and `end` are clamped to the range `[0, arr.@size]`.
     // 
     // # Parameters
     // 
@@ -384,7 +384,7 @@ namespace Array {
     // * `end` - The end index of the subarray.
     // * `array` - The array to be sliced.
     get_sub : I64 -> I64 -> Array a -> Array a;
-    get_sub = |s, e, arr| arr._get_sub_size_with_length_and_additional_capacity(arr.@size, 0, s, e);
+    get_sub = |start, end, arr| arr._get_sub_size_with_length_and_additional_capacity(arr.@size, 0, start, end);
 
     // Gets whether the array is empty.
     // 
@@ -568,23 +568,23 @@ namespace Array {
     // - `less_than`: A function that takes two elements and returns true if the first is
     //   less than the second.
     // - `i`: The index of the element to sift down.
-    // - `n`: The end index of the heap.
+    // - `heap_end`: The end index of the heap.
     // - `start`: the range of an array.
     // - `end`: the range of an array.
     // - `heap`: An array representing the heap.
     _heap_down_ranged : ((a, a) -> Bool) -> I64 -> I64 -> I64 -> I64 -> Array a -> Array a;
-    _heap_down_ranged = |less_than, i, n, start, end, heap| (
+    _heap_down_ranged = |less_than, i, heap_end, start, end, heap| (
         let left = 2 * (i - start) + 1 + start;
         let right = 2 * (i - start) + 2 + start;
 
         let largest = i;
-        let largest = if left < n && less_than((heap.@(i), heap.@(left))) { left } else largest;
-        let largest = if right < n && less_than((heap.@(largest), heap.@(right))) { right } else largest;
+        let largest = if left < heap_end && less_than((heap.@(i), heap.@(left))) { left } else largest;
+        let largest = if right < heap_end && less_than((heap.@(largest), heap.@(right))) { right } else largest;
 
         if largest == i { heap };
 
         let heap = heap.unsafe_swap_bounds_unchecked(i, largest);
-        heap._heap_down_ranged(less_than, largest, n, start, end)
+        heap._heap_down_ranged(less_than, largest, heap_end, start, end)
     );
 
     // Stable sort by `LessThan` trait.

--- a/src/tests/test_array_builder.rs
+++ b/src/tests/test_array_builder.rs
@@ -135,9 +135,9 @@ main : IO () = (
         Iterator::range(0, 40).map(|i| [i]).to_array);;
 
     // `get_sub` on a boxed array copies the range out; the source stays intact.
-    let g = [[1], [2], [3], [4]];
-    assert_eq(|_|"get_sub boxed", g.get_sub(1, 3), [[2], [3]]);;
-    assert_eq(|_|"get_sub boxed src intact", g, [[1], [2], [3], [4]]);;
+    let source = [[1], [2], [3], [4]];
+    assert_eq(|_|"get_sub boxed", source.get_sub(1, 3), [[2], [3]]);;
+    assert_eq(|_|"get_sub boxed src intact", source, [[1], [2], [3], [4]]);;
 
     // Writing into a boxed array after copying a range out of it. The copy retains each element it
     // takes and borrows the array itself, so the writes reach that array in place while the copy
@@ -149,10 +149,10 @@ main : IO () = (
     assert_eq(|_|"copy intact after write", head, [[1], [2]]);;
 
     // `append` of a shared empty boxed source takes the copy path over an empty range.
-    let e = ([] : Array (Array I64));
-    let d = [[1], [2]];
-    assert_eq(|_|"append shared empty src result", d.append(e), [[1], [2]]);;
-    assert_eq(|_|"append shared empty src intact", e, []);;
+    let empty_src = ([] : Array (Array I64));
+    let empty_src_dst = [[1], [2]];
+    assert_eq(|_|"append shared empty src result", empty_src_dst.append(empty_src), [[1], [2]]);;
+    assert_eq(|_|"append shared empty src intact", empty_src, []);;
 
     // `unsafe_set_bounds_unchecked` on a boxed array releases the overwritten element and, on a
     // shared array, clones so the original keeps its element.
@@ -256,22 +256,22 @@ module Main;
 
 main : IO () = (
     // A multi-threaded array: its storage and every element are out of the local state.
-    let t = [[1], [2], [3], [4]].mark_threaded;
+    let threaded = [[1], [2], [3], [4]].mark_threaded;
 
     // The borrowing copy retains each element it takes out of a threaded source.
-    assert_eq(|_|"get_sub of a threaded array", t.get_sub(1, 3), [[2], [3]]);;
+    assert_eq(|_|"get_sub of a threaded array", threaded.get_sub(1, 3), [[2], [3]]);;
 
     // The owning append over a threaded source that is uniquely held (the move path).
     assert_eq(|_|"append a uniquely held threaded source",
-        [[0]].append(t.get_sub(0, 2).mark_threaded), [[0], [1], [2]]);;
+        [[0]].append(threaded.get_sub(0, 2).mark_threaded), [[0], [1], [2]]);;
 
     // The owning append over a threaded source that is shared (the retain-per-element copy path).
-    assert_eq(|_|"append a shared threaded source", [[0]].append(t), [[0], [1], [2], [3], [4]]);;
+    assert_eq(|_|"append a shared threaded source", [[0]].append(threaded), [[0], [1], [2], [3], [4]]);;
 
     // A threaded destination, which the primitive clones before writing.
-    assert_eq(|_|"append onto a threaded destination", t.append([[5]]),
+    assert_eq(|_|"append onto a threaded destination", threaded.append([[5]]),
         [[1], [2], [3], [4], [5]]);;
-    assert_eq(|_|"the threaded array is intact", t, [[1], [2], [3], [4]]);;
+    assert_eq(|_|"the threaded array is intact", threaded, [[1], [2], [3], [4]]);;
     pure()
 );
 "#;
@@ -303,9 +303,9 @@ from_global = |_| (
 
 // A copy out of a struct field, then a write through the field.
 from_field : Holder -> (Array (Array I64), Array (Array I64));
-from_field = |hd| (
-    let head = hd.@xs.get_sub(0, 2);
-    (hd.mod_xs(|xs| xs.set(0, [88])).@xs, head)
+from_field = |holder| (
+    let head = holder.@xs.get_sub(0, 2);
+    (holder.mod_xs(|xs| xs.set(0, [88])).@xs, head)
 );
 
 // A copy out of an unboxed-union payload carried through a loop, then writes.

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -2928,16 +2928,16 @@ impl Pair : Eq {
 
 main : IO ();
 main = (
-    let x = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10];
-    let y = x.sort;
-    assert_eq(|_|"", y, [-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);;
-    assert_eq(|_|"", x, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]);;
+    let input = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10];
+    let sorted = input.sort;
+    assert_eq(|_|"", sorted, [-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);;
+    assert_eq(|_|"", input, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]);;
 
     // Long enough that the stable sort merges the range rather than sorting it by insertion.
-    let x = [make(5, "a"), make(5, "b"), make(4, "c"), make(4, "d"), make(4, "e"), make(3, "f"), make(2, "g"), make(2, "h"), make(1, "i"), make(1, "j"), make(1, "k"), make(7, "l"), make(6, "m"), make(7, "n"), make(6, "o")];
-    let y = x.sort_stable;
-    assert_eq(|_|"", y, [make(1, "i"), make(1, "j"), make(1, "k"), make(2, "g"), make(2, "h"), make(3, "f"), make(4, "c"), make(4, "d"), make(4, "e"), make(5, "a"), make(5, "b"), make(6, "m"), make(6, "o"), make(7, "l"), make(7, "n")]);;
-    assert_eq(|_|"", x, [make(5, "a"), make(5, "b"), make(4, "c"), make(4, "d"), make(4, "e"), make(3, "f"), make(2, "g"), make(2, "h"), make(1, "i"), make(1, "j"), make(1, "k"), make(7, "l"), make(6, "m"), make(7, "n"), make(6, "o")]);;
+    let input = [make(5, "a"), make(5, "b"), make(4, "c"), make(4, "d"), make(4, "e"), make(3, "f"), make(2, "g"), make(2, "h"), make(1, "i"), make(1, "j"), make(1, "k"), make(7, "l"), make(6, "m"), make(7, "n"), make(6, "o")];
+    let sorted = input.sort_stable;
+    assert_eq(|_|"", sorted, [make(1, "i"), make(1, "j"), make(1, "k"), make(2, "g"), make(2, "h"), make(3, "f"), make(4, "c"), make(4, "d"), make(4, "e"), make(5, "a"), make(5, "b"), make(6, "m"), make(6, "o"), make(7, "l"), make(7, "n")]);;
+    assert_eq(|_|"", input, [make(5, "a"), make(5, "b"), make(4, "c"), make(4, "d"), make(4, "e"), make(3, "f"), make(2, "g"), make(2, "h"), make(1, "i"), make(1, "j"), make(1, "k"), make(7, "l"), make(6, "m"), make(7, "n"), make(6, "o")]);;
 
     pure()
 );

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -2647,9 +2647,14 @@ pub fn test89() {
     test_source(source, Configuration::develop_mode());
 }
 
+/// Verifies every sorting routine of the standard library over one corpus of inputs: the empty
+/// array, a single element, an array whose keys repeat, and pseudo-random hundred-element arrays.
+/// The routines are the stable merge sort, the heap sort and the insertion sort that introsort falls
+/// back on, introsort at a recursion depth low enough to force that fallback, and `sort_by` itself.
+/// Each runs over an unboxed and a boxed element type, and the stable one is also checked to leave
+/// equal elements in the order they came in.
 #[test]
 pub fn test_sort_by() {
-    // Test "sort_by" and related functions.
     let source = r#"
 module Main;
 
@@ -2825,6 +2830,8 @@ case_random_9 = [4811598823819225076, 945484849661270666, 3974642354777520028, 4
     test_source(source, Configuration::develop_mode());
 }
 
+/// Verifies that `sort_by` returns the order in a new array and leaves the array it was given as it
+/// was, over an array the caller goes on holding.
 #[test]
 pub fn test_sort_by_immutability() {
     let source = r#"
@@ -2907,6 +2914,9 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// Verifies `sort` and `sort_stable`, which take their order from the `LessThan` trait rather than
+/// from a comparator the caller passes: the result is non-descending, elements the trait calls equal
+/// keep the order they came in, and the array the caller goes on holding is left as it was.
 #[test]
 pub fn test_sort() {
     let source = r#"

--- a/std_doc/Std.md
+++ b/std_doc/Std.md
@@ -457,9 +457,9 @@ compatibility; `@size` is the canonical accessor.
 
 Type: `Std::I64 -> Std::I64 -> Std::Array a -> Std::Array a`
 
-`arr.get_sub(s, e)` returns an array `[ arr.@(i) | i ∈ [s, e) ]`.
+`arr.get_sub(start, end)` returns an array `[ arr.@(i) | i ∈ [start, end) ]`.
 
-`s` and `e` are clamped to the range `[0, arr.@size]`.
+`start` and `end` are clamped to the range `[0, arr.@size]`.
 
 ##### Parameters
 
@@ -657,7 +657,7 @@ Type: `[a : Std::LessThan] Std::Array a -> Std::Array a`
 
 Stable sort by `LessThan` trait.
 
-Note: Currently this is implemented by merge sort, which is not in-place.
+Implemented by merge sort, which allocates an array as large as the one being sorted.
 
 ##### Parameters
 
@@ -669,7 +669,7 @@ Type: `((a, a) -> Std::Bool) -> Std::Array a -> Std::Array a`
 
 Stable sort by a "less than" comparator.
 
-Note: Currently this is implemented by merge sort, which is not in-place.
+Implemented by merge sort, which allocates an array as large as the one being sorted.
 
 ##### Parameters
 


### PR DESCRIPTION
`Array::sort_stable` を作り直す変更 (#222) のコードレビューが、**変更した行の外**で見つけた手入れ。
どれも振る舞いを変えない。本体の差分を読みやすく保つため、別の PR に分けてある。

マージ先はその変更のブランチ `improve-sort-stable` である。

## 何を直したか

### 1. 範囲を表す引数の名前が、doc と食い違っていた

`Array::get_sub` のシグネチャは `|s, e, arr|` で、その doc の `# Parameters` は `start` / `end` と
書いていた。**言語サーバーはこの `# Parameters` を引数リストのヒントとして読み、補完でプレース
ホルダを挿入する**ので、名前が 2 通りあると補完に出る名前と定義の名前が食い違う。定義側を
`start` / `end` に揃えた。

`get_sub` が中で呼ぶ `_get_sub_size_with_length_and_additional_capacity` の `s` / `e` は、値を
そのまま渡す先である範囲複写のプリミティブが `begin` / `end` と呼んでいるので、そちらに揃えた。

### 2. ヒープの終端が「長さ」に見える名前だった

`_heap_down_ranged` の引数 `n` は、配列の中での絶対位置による終端 index である。このファイルの
他の `n` はすべて要素数なので、読み手は長さだと思う。`heap_end` にした。

### 3. `# parameters` が小文字で、言語サーバーに読まれていなかった

言語サーバーは節の見出しを `Parameters` と**大文字小文字を区別して**照合する。
`_heap_down_ranged` と `_heap_sort_by_ranged` の見出しは小文字の `# parameters` だったので、
そこに書かれた引数リストは一度も使われていなかった。見出しを直し、ついでに本文が空だった
`start` / `end` の項に、それが範囲のどちらの端なのかを書いた。
`_get_sub_size_with_length_and_additional_capacity` には `# Parameters` 自体が無かったので足した。

### 4. 否定形で書かれた doc

`sort_stable` と `sort_stable_by` の "Note: Currently this is implemented by merge sort, which is
not in-place." を、"Implemented by merge sort, which allocates an array as large as the one being
sorted." にした。読み手が in-place を期待していない限り、「in-place ではない」は何も伝えない。
確保する大きさを述べる方が、呼び出し側が知りたいことに答える。

### 5. テストの束縛名

`test_array_builder.rs` の boxed 要素のテストで、`g` / `e` / `d` / `t` / `hd` が何を保持している
のかは、周囲を読まないと分からなかった。`source` / `empty_src` / `empty_src_dst` / `threaded` /
`holder` にした。`test_basic.rs` の `test_sort` の `x` / `y` は、同じファイルの `Pair` 型の
フィールド名 `x` / `y` と衝突していたので `input` / `sorted` にした。

### 6. テストが何を突くのかを述べる doc

`test_sort_by` / `test_sort_by_immutability` / `test_sort` に `///` を足した。どれも「何を
テストするか」ではなく「どの観点を突くか」を述べている。

## レビューが挙げて、直していないもの

いずれも振る舞いかインタフェースに触れるので、手入れの範囲を超える。

- **`_introsort_by_internal` の裸のリテラル `12`。** 「この長さ以下は挿入ソートに切り替える」と
  いう判断が、merge sort 側では `_merge_sort_insertion_limit` という名前を得たのに、introsort 側
  には無名のまま残る。読み手は 2 つの `12` が連動しているのかを判断できない。定数を新設するのは
  項目の追加なので、手入れでは行わない。
- **`_introsort_by_internal` の `if end - start <= 1 { arr };` は、すぐ下の `<= 12` のガードに
  包含される。** `_insertion_sort_by_ranged` 自身が長さ 1 以下でそのまま返すので、結果は同じ。
- **`_introsort_by_internal` という名前。** `_internal` は何も言わず、`_` 接頭辞が既に private を
  示している。兄弟 3 つは `_insertion_sort_by_ranged` / `_heap_sort_by_ranged` /
  `_merge_sort_by_ranged` である。`_introsort_by_ranged` が揃う。
- **`_heap_down_ranged` の引数 `end` は本体で一度も使われていない。**
- **`test_sort_by` の失敗メッセージ `"case {}-unboxed"` が `{}` を埋めていない。** すぐ下の boxed
  側は `.populate([case_n.to_string])` を呼んでいる。unboxed 側が落ちたとき、14 個のケースの
  どれが落ちたのか出力から分からない。
- **`_insertion_sort_by_ranged` の doc も見出しが小文字で、`start` / `end` の本文が空。**
  1 ファイルあたりの手入れの上限に当たって残した。
- **`test_basic.rs` の `test92` ほか `testNN` 系に `///` が無い。** `test92` は assertion を
  1 つも持たないので、何を守っているのかを書ける確信が持てなかった。
- **`std_doc/Std.md`** は `get_sub` の旧い引数名と `sort_stable` の旧い doc を持つ。生成物なので、
  次に生成し直したときに追従する。
