### PR TITLE
レビュー反映: パターン側 fallback をファイルの語彙で命名する

### DIFF
--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -608,7 +608,7 @@ impl TypeCheckContext {
     ) -> Result<(Arc<PatternNode>, Map<FullName, Arc<TypeNode>>), Errors> {
         Ok(self
             .tolerate(res)?
-            .unwrap_or_else(|| (self.set_fallback_types_on_pattern(pat), Map::default())))
+            .unwrap_or_else(|| (self.set_fallback_types_for_pattern(pat), Map::default())))
     }
 
     /// Assign a type to every node of `ei`: `ty` at the root and a fresh type
@@ -629,7 +629,7 @@ impl TypeCheckContext {
 
     /// Pattern counterpart of `set_fallback_types`: a fresh type variable at
     /// the pattern and at each of its sub-patterns.
-    fn set_fallback_types_on_pattern(&mut self, pat: &Arc<PatternNode>) -> Arc<PatternNode> {
+    fn set_fallback_types_for_pattern(&mut self, pat: &Arc<PatternNode>) -> Arc<PatternNode> {
         self.map_types_for_pattern(pat, &mut |tc, p| Ok(tc.fresh_ty_with_src(&p.info.source)))
             .unwrap_or_else(|_| unreachable!("fresh-type callbacks cannot fail"))
     }


### PR DESCRIPTION
## 概要

レビューの naming の指摘を反映し、private メソッド `set_fallback_types_on_pattern` を `set_fallback_types_for_pattern` に改名します。

`src/elaboration/typecheck.rs` は、式の walk とそのパターン版の対を `fix_types` / `fix_types_for_pattern`、`map_types` / `map_types_for_pattern` のように `_for_pattern` という接尾辞で表しています。この関数だけが同じ関係を `_on_pattern` と書いており、読み手に同じ関係の 2 つ目の語を覚えさせていました。

改名するのは、tolerant モードでパターンの elaborate が失敗したときに、パターンとその全サブパターンへ fresh な型変数を付けた代替を作る関数です。変更は定義と呼び出し 1 箇所 (`tolerate_pattern_typed`) の識別子のみで、挙動は変わりません。

## 検証

- `cargo test --release test_set_fallback_types_types_every_node` pass (ビルドが通ることも兼ねる)。
- リポジトリ全体で旧名の出現ゼロを確認済み。
