### PR TITLE
レビューが変更のまわりで見つけた手入れ (#235 へ)

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -327,17 +327,23 @@ impl TyCon {
         return self.name == FullName::from_strs(&[STD_NAME], BOOL_NAME);
     }
 
-    // Whether this is the type constructor `IO`.
+    /// Whether this is the type constructor `IO`.
     pub fn is_io(&self) -> bool {
         self == make_io_tycon().as_ref()
     }
 
-    // Whether this is the type `IOState`, the token that an `IO` action threads.
+    /// Whether this is the type `IOState`, the token that an `IO` action threads.
     #[allow(dead_code)]
     pub fn is_iostate(&self) -> bool {
         return self.name == make_iostate_name();
     }
 
+    /// Renames this struct's type constructor to the one that stands for the struct with one field
+    /// made a hole.
+    ///
+    /// # Arguments
+    /// * `punched_at` — the position of the field made the hole, counted from 0 in the order the
+    ///   fields are declared.
     pub fn into_punched_type_name(&mut self, punched_at: usize) {
         self.name.name += &format!("{}{}", PUNCHED_TYPE_SYMBOL, punched_at);
     }
@@ -353,11 +359,13 @@ impl TyCon {
         Some(tycon)
     }
 
+    /// Whether this is the type constructor `->` that heads a function type.
     #[allow(dead_code)]
     pub fn is_arrow(&self) -> bool {
         self == &make_arrow_tycon()
     }
 
+    /// Whether this is the type constructor `Std::Array`.
     #[allow(dead_code)]
     pub fn is_array(&self) -> bool {
         self == &make_array_tycon()

--- a/src/optimization/unwrap_newtype.rs
+++ b/src/optimization/unwrap_newtype.rs
@@ -27,6 +27,8 @@ use crate::{
 };
 use std::sync::Arc;
 
+/// Replaces every unwrappable newtype of `prg` with the type of its one field, in the types
+/// recorded throughout the program and in the type environment.
 pub fn run(prg: &mut Program) {
     let unwrapping = NewtypeUnwrapping::new(prg.type_env.tycons.as_ref().clone());
 
@@ -282,6 +284,9 @@ impl<'a> ExprVisitor for ExprUnwrapper<'a> {
         StartVisitResult::VisitChildren
     }
 
+    /// Unwraps the type recorded for an inline LLVM expression, and replaces the read, the write,
+    /// the punch and the plug-in of an unwrapped newtype's field by the field value itself, which
+    /// is what a value of that type has become.
     fn end_visit_llvm(&mut self, expr: &Arc<ExprNode>, state: &mut VisitState) -> EndVisitResult {
         let old_ty = expr.type_.as_ref().unwrap().clone();
         let mut expr = self.unwrapping.unwrap_inferred_type(expr);
@@ -293,7 +298,7 @@ impl<'a> ExprVisitor for ExprUnwrapper<'a> {
             unreachable!()
         };
 
-        // We don't need to change the LLVM type: TODO: rename llvm.ty to llvm.generic_ty.
+        // `llvm.generic_ty` stays as it is: type checking is the last pass that reads it.
 
         // Replace StructGetBody, StructSetBody, StructPunchBody, and StructPlugInBody for structures defined by the newtype pattern.
         let gen = llvm.generator.as_ref();
@@ -446,6 +451,8 @@ impl<'a> ExprVisitor for ExprUnwrapper<'a> {
         StartVisitResult::VisitChildren
     }
 
+    /// Unwraps the type recorded for a struct literal, and replaces a literal of an unwrapped
+    /// newtype by the expression its one field is built from.
     fn end_visit_make_struct(
         &mut self,
         expr: &Arc<ExprNode>,
@@ -510,7 +517,7 @@ impl<'a> ExprVisitor for ExprUnwrapper<'a> {
     }
 }
 
-// Is this type constructor a "newtype", i.e., is it an unbox struct type with only one field?
+/// Is this type constructor a "newtype", i.e., is it an unbox struct type with only one field?
 fn is_newtype(tycon: &TyCon, env: &Map<TyCon, TyConInfo>) -> bool {
     let ti = env.get(tycon).unwrap();
     ti.is_unbox && ti.variant == TyConVariant::Struct && ti.fields.len() == 1

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -2653,9 +2653,10 @@ pub fn test89() {
 /// distinct values or of an order that leaves one side of every split nearly empty.
 /// The routines are the stable merge sort, the heap sort and the insertion sort that introsort falls
 /// back on, introsort at a recursion depth low enough to force that fallback, and `sort_by` itself.
-/// Each runs over an unboxed and a boxed element type, and its result is checked to be increasing
-/// and to keep the size and the sum of the input; the stable one is also checked to leave equal
-/// elements in the order they came in.
+/// Each runs over an unboxed and a boxed element type, and its result is checked to be increasing,
+/// to keep the size and the sum of the input, and to hold the same sequence of values whichever of
+/// the two element types it ran over; the stable one is also checked to leave equal elements in the
+/// order they came in.
 #[test]
 pub fn test_sort_by() {
     let source = r#"
@@ -2757,6 +2758,9 @@ test_sort = |sort_method, sort_method_boxed| (
         assert(|_| case_name + "-boxed", ys_boxed.is_increasing);;
         assert_eq(|_| case_name + "-boxed-size", ys_boxed.@size, xs.@size);;
         assert_eq(|_| case_name + "-boxed-sum", ys_boxed.to_iter.map(|x| x.@v).sum, xs.to_iter.sum);;
+        // The same multiset put in the same order gives the same sequence of values, so the boxed
+        // run and the unboxed one have to agree element by element.
+        assert_eq(|_| case_name + "-boxed-elements", ys_boxed, ys.map(BoxedI64::make));;
 
         pure()
     );;
@@ -10812,6 +10816,9 @@ main : IO () = (
     let res = (foobar.as_some.@data.@data).run_reader(41);
     assert_eq(|_|"3", res, 42);;
 
+    let ra : Reader I64 I64 = do { pure $ (*get_env) + 1 };
+    assert_eq(|_|"4", ra.run_reader(41), 42);;
+
     pure()
 );
     "##;
@@ -10870,6 +10877,9 @@ main : IO () = (
     let foobar = foobar.(Foo::act_data << Bar::act_data $ |r| some(r));
     let res = (foobar.as_some.@data.@data).run_reader(41);
     assert_eq(|_|"3", res, 42);;
+
+    let ra : Reader I64 I64 = do { pure $ (*get_env) + 1 };
+    assert_eq(|_|"4", ra.run_reader(41), 42);;
 
     pure()
 );


### PR DESCRIPTION
Refs #231

#235 のコードレビューが、変更のまわり (触ったファイルのうち差分の外) で見つけた手入れ。振る舞いは
変わらない。ベースは #235 のブランチなので、そちらを読んだあとに読む差分になる。

## 1. テストが宣言しているトレイト実装のメンバを `main` から到達させる

Fix のコンパイラは、`main` から到達しないシンボルの elaboration を飛ばすことがある。トレイトの実装を
書いただけで一度も使わないテストは、その実装が壊れていてもコンパイルが通り、テストが緑になる。

3 つのテストがその形だった。

- **`test_regression_issue_64_more_complex`** と **`test_regression_issue_64_more_complex_boxed`** —
  `impl Reader e : Monad` を宣言しているが、`main` は `map` / `run_reader` / `reader` / `get_env` /
  `mod_data` しか使っておらず、`bind` と `pure` に到達していなかった (`main` 末尾の `pure()` は `IO` の
  ほう)。`main` に `do` 記法で `Reader` を 1 つ組み立てて走らせる行を足した。**このテストは自身の
  コメントで「remove-hktvs と unwrap-newtype のテストでもある」と述べており、#235 が触るパスそのものを
  対象にしている。**
- **`test_sort_by`** — `impl BoxedI64 : Eq` を宣言しているが、検査はすべて `I64` の要素数と総和に対する
  もので、順序は `less_than_or_eq` を通っていた。boxed の結果と unboxed の結果を要素ごとに突き合わせる
  検査を足し、`eq` に到達させた。

**確かめ方**: 各メンバの定義を `undefined` に置き換えると、対応するテストが落ちる。置き換えは元に戻して
ある。

## 2. doc コメント

`src/optimization/unwrap_newtype.rs`

- `run` (パスの入口)、`is_newtype` (1 フィールドの unbox 構造体かを答える述語) に doc コメントを付けた。
  後者は `//` で書かれていたものを `///` にした。
- `end_visit_llvm` と `end_visit_make_struct` に doc コメントを付けた。訪問器のメソッドのうち、型の
  書き換え以上のことをする 2 つである。
- `end_visit_llvm` の中の `// We don't need to change the LLVM type: TODO: rename llvm.ty to
  llvm.generic_ty.` を書き換えた。フィールドは既に `generic_ty` という名前で、この TODO は失効している。
  述べる価値があるのは「この型を最後に読むのは型検査である」ことなので、そう書いた
  (`generic_ty` を読むのは名前解決・型エイリアス解決・型検査の 3 か所だけであることを数え上げて確認)。

`src/ast/types.rs`

- `into_punched_type_name` に doc コメントを付けた。`punched_at` が 0 起点のフィールドの位置であることを
  `# Arguments` で述べている。
- `is_arrow` / `is_array` に doc コメントを付け、`is_io` / `is_iostate` を `//` から `///` にした。

## なぜ振る舞いを変えないか

1 は Fix のテストソースに検査を足すもので、コンパイラのコードには触れていない。2 は散文だけの変更で
ある。`cargo test --release` は `FIX_MAX_OPT_LEVEL` の既定 (`max`) で 1319 + 136 件すべて通る。

## 予算を超えて残ったもの

レビューは触ったファイルごとに 5 件までを手入れするので、以下は残っている。いずれもこの変更とは独立に
ファイル全体の方針を決める話である。

- `src/optimization/unwrap_newtype.rs` の `ExprUnwrapper` の訪問器メソッド 24 個のうち、doc コメントを
  付けたのは実質的な処理を持つ 2 個だけで、**22 個が無コメント**のまま。残りは「型を展開して返す」だけ
  なので、名前を言い換える以上の内容が書けない。まとめて省略する規約を置くか、全件に付けるか。
- `src/ast/types.rs` は、ファイル全体では doc コメントの無い item が **57 個**、`//` で書かれた item
  コメントが **69 個**ある。近傍の 5 件だけを直したので、`TyCon` の述語群が `///` と `//` の混在に
  なっている。
- `src/tests/test_basic.rs` は `#[test]` が 434 件あり、`///` 付きが 76 件、`//` 付きが 10 件、コメント
  無しが約 348 件。#235 が足した 3 本は前後のテストと同じ `//` の形にしてある。

## 別件として挙がったもの (この PR に入っていない)

- `CHANGELOG.md` の `Fixed / Tool` にある「`fix run` and `fix test` no longer crash on startup in debug
  builds of `fix`」は、リリース版のバイナリを使う利用者が踏めない。ただしソースから debug ビルドした
  利用者は踏めるうえ、いつ混入したかを判断できないので触っていない。
