### PR TITLE
穴の開いた構造体を、参照カウントの側から値の無いものとして扱う

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -900,7 +900,10 @@ impl TypeNode {
 
     /// The fields `self` declares, each with its type at this instance — the declaration read from
     /// `tycons`, with `self`'s type arguments substituted for the declaration's type variables.
-    fn fields_with_instance_types(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<(Field, Arc<TypeNode>)> {
+    fn fields_with_instance_types(
+        &self,
+        tycons: &Map<TyCon, TyConInfo>,
+    ) -> Vec<(Field, Arc<TypeNode>)> {
         let args = self.collect_type_argments();
         let tycon_info = self.toplevel_tycon_info_via_tycons(tycons);
         assert_eq!(args.len(), tycon_info.tyvars.len()); // Assumes fully applied

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -941,10 +941,10 @@ impl TypeNode {
     /// one per variant for a union, and the element field alone for `Array`. The field types carry
     /// the type parameters of the declaration; `field_types` substitutes this type's arguments in.
     pub fn fields(&self, type_env: &TypeEnv) -> Vec<Field> {
-        let args = self.collect_type_argments();
-        let ti = self.toplevel_tycon_info(type_env);
-        assert_eq!(args.len(), ti.tyvars.len());
-        ti.fields
+        self.fields_with_instance_types(&type_env.tycons)
+            .into_iter()
+            .map(|(field, _)| field)
+            .collect()
     }
 
     // The index of the struct/union field named `field_name`.

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -892,6 +892,15 @@ impl TypeNode {
     /// declaration's type variables. An array declares its element type as its one field. The
     /// declarations are read from `tycons`.
     pub fn field_types_via_tycons(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<Arc<TypeNode>> {
+        self.instantiated_fields(tycons)
+            .into_iter()
+            .map(|(_, ty)| ty)
+            .collect()
+    }
+
+    /// The fields `self` declares, each with its type at this instance — the declaration read from
+    /// `tycons`, with `self`'s type arguments substituted for the declaration's type variables.
+    fn instantiated_fields(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<(Field, Arc<TypeNode>)> {
         let args = self.collect_type_argments();
         let tycon_info = self.toplevel_tycon_info_via_tycons(tycons);
         assert_eq!(args.len(), tycon_info.tyvars.len()); // Assumes fully applied
@@ -902,8 +911,26 @@ impl TypeNode {
         }
         tycon_info
             .fields
-            .iter()
-            .map(|f| subst.substitute_type(&f.ty))
+            .into_iter()
+            .map(|f| {
+                let ty = subst.substitute_type(&f.ty);
+                (f, ty)
+            })
+            .collect()
+    }
+
+    /// The types of the fields that hold a value, each with the index it sits at. A punched field is
+    /// a hole — the value it held has moved out — so it holds none and is left out here, while the
+    /// slot stays in the layout and keeps the index the other fields are addressed by.
+    ///
+    /// This is what a walk over the values a type holds descends: reference counting reaches a hole's
+    /// slot through no path, and reading one would read a value that has moved on.
+    pub fn value_field_types(&self, type_env: &TypeEnv) -> Vec<(usize, Arc<TypeNode>)> {
+        self.instantiated_fields(&type_env.tycons)
+            .into_iter()
+            .enumerate()
+            .filter(|(_, (field, _))| !field.is_punched)
+            .map(|(i, (_, ty))| (i, ty))
             .collect()
     }
 
@@ -1255,7 +1282,8 @@ impl TypeNode {
         !self.is_unbox(type_env)
     }
 
-    /// Whether this type contains no boxed type.
+    /// Whether a value of this type holds no boxed value, so that reference counting has nothing to
+    /// do to it.
     ///
     /// Deciding this walks the fields of unboxed types, and that walk would not end on a type
     /// reaching itself that way; `Program::validate_layouts` rejects such a type before any of this
@@ -1276,10 +1304,9 @@ impl TypeNode {
         if self.is_funptr() {
             return true;
         }
-        let field_types = self.field_types(type_env);
-        field_types
+        self.value_field_types(type_env)
             .iter()
-            .all(|field_ty| field_ty.is_fully_unboxed(type_env))
+            .all(|(_, field_ty)| field_ty.is_fully_unboxed(type_env))
     }
 
     /// Whether a value of this type is one indivisible reference-counting unit — counted as a whole by

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -892,7 +892,7 @@ impl TypeNode {
     /// declaration's type variables. An array declares its element type as its one field. The
     /// declarations are read from `tycons`.
     pub fn field_types_via_tycons(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<Arc<TypeNode>> {
-        self.instantiated_fields(tycons)
+        self.fields_with_instance_types(tycons)
             .into_iter()
             .map(|(_, ty)| ty)
             .collect()
@@ -900,7 +900,7 @@ impl TypeNode {
 
     /// The fields `self` declares, each with its type at this instance — the declaration read from
     /// `tycons`, with `self`'s type arguments substituted for the declaration's type variables.
-    fn instantiated_fields(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<(Field, Arc<TypeNode>)> {
+    fn fields_with_instance_types(&self, tycons: &Map<TyCon, TyConInfo>) -> Vec<(Field, Arc<TypeNode>)> {
         let args = self.collect_type_argments();
         let tycon_info = self.toplevel_tycon_info_via_tycons(tycons);
         assert_eq!(args.len(), tycon_info.tyvars.len()); // Assumes fully applied
@@ -926,7 +926,7 @@ impl TypeNode {
     /// This is what a walk over the values a type holds descends: reference counting reaches a hole's
     /// slot through no path, and reading one would read a value that has moved on.
     pub fn value_field_types(&self, type_env: &TypeEnv) -> Vec<(usize, Arc<TypeNode>)> {
-        self.instantiated_fields(&type_env.tycons)
+        self.fields_with_instance_types(&type_env.tycons)
             .into_iter()
             .enumerate()
             .filter(|(_, (field, _))| !field.is_punched)

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -885,8 +885,9 @@ impl TypeNode {
     /// for a union, and the element type alone for `Array`, whose elements all share it. This type's
     /// arguments are substituted in, so the results are the field types at this instance.
     ///
-    /// This is the layout's answer, so a punched field's slot is among them, at the type it was
-    /// declared with; `value_field_types` answers which of the slots hold a value.
+    /// A punched field's slot is among them, at the type it was declared with, so a reader that can
+    /// meet a punched type wants this one only to lay the fields out or to address one by its index;
+    /// `value_field_types` answers which of the slots hold a value.
     pub fn field_types(&self, type_env: &TypeEnv) -> Vec<Arc<TypeNode>> {
         self.field_types_via_tycons(&type_env.tycons)
     }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -873,17 +873,20 @@ impl TypeNode {
         }
     }
 
-    // Take a struct type, and convert it to a punched version.
+    /// This struct type punched at field `punched_at`: a type of the same memory layout, whose
+    /// declaration marks that field as a hole the value has moved out of.
     pub fn to_punched_struct(self: &Arc<TypeNode>, punched_at: usize) -> Arc<TypeNode> {
         let mut tycon = self.toplevel_tycon().unwrap().as_ref().clone();
         tycon.into_punched_type_name(punched_at);
         self.set_toplevel_tycon(Arc::new(tycon))
     }
 
-    /// The types the fields of a value of this type hold: one per field for a struct, one per
-    /// variant for a union, and the element type alone for `Array`, whose elements all share it.
-    /// This type's arguments are substituted in, so the results are the field types at this
-    /// instance.
+    /// The type of every field slot this type declares: one per field for a struct, one per variant
+    /// for a union, and the element type alone for `Array`, whose elements all share it. This type's
+    /// arguments are substituted in, so the results are the field types at this instance.
+    ///
+    /// This is the layout's answer, so a punched field's slot is among them, at the type it was
+    /// declared with; `value_field_types` answers which of the slots hold a value.
     pub fn field_types(&self, type_env: &TypeEnv) -> Vec<Arc<TypeNode>> {
         self.field_types_via_tycons(&type_env.tycons)
     }
@@ -947,7 +950,8 @@ impl TypeNode {
             .collect()
     }
 
-    // The index of the struct/union field named `field_name`.
+    /// The index of the struct field or the union variant named `field_name`, which is the index it
+    /// sits at in the layout.
     pub fn field_index(&self, type_env: &TypeEnv, field_name: &str) -> Option<usize> {
         self.toplevel_tycon_info(type_env)
             .fields
@@ -976,7 +980,8 @@ impl TypeNode {
         tys
     }
 
-    // For type `f a b c` where `f` is a type constructor returns `vec![a, b, c]`.
+    /// The arguments applied to this type's head, in the order they are applied: `f a b c` gives
+    /// `vec![a, b, c]`.
     pub fn collect_type_argments(&self) -> Vec<Arc<TypeNode>> {
         let mut ret: Vec<Arc<TypeNode>> = vec![];
         match &self.ty {
@@ -1945,9 +1950,11 @@ pub fn tycon(name: FullName) -> Arc<TyCon> {
     Arc::new(TyCon { name })
 }
 
-// Additional information of types.
+/// What a type node carries beside the type itself.
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct TypeInfo {
+    /// The span of the source text the type was written at. A type the compiler builds itself has
+    /// none.
     source: Option<Span>,
 }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1973,7 +1973,13 @@ impl TypeNode {
         *self.depth_cache.get_or_init(|| match &self.ty {
             Type::TyVar(_) | Type::TyCon(_) => 1,
             Type::TyApp(fun, arg) => 1 + fun.depth().max(arg.depth()),
-            Type::AssocTy(_, args) => 1 + args.iter().map(|arg| arg.depth()).max().unwrap_or(0),
+            Type::AssocTy(_, args) => {
+                1 + args
+                    .iter()
+                    .map(|arg| arg.depth())
+                    .max()
+                    .expect("an associated type is applied to at least its implementing type")
+            }
         })
     }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4659,8 +4659,13 @@ impl LLVMGen for InlineLLVMCaptureProjectBody {
 /// `var_name`, and is returned together with the punched struct, whose type records the hole.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructPunchBody {
+    /// The operand: the struct the field is moved out of.
     pub var_name: FullName,
+    /// The index of the field moved out, in the struct's layout — the slot the result's punched
+    /// struct carries as a hole.
     field_idx: usize,
+    /// Whether a struct that is shared is cloned before the field is moved out. Where false, the
+    /// operand is taken to be uniquely owned already.
     pub(crate) force_unique: bool,
     /// Whether the object this op's declared uniqueness check tests is known to be in the local
     /// reference-counting state, so that the check reads the count without reading the state.
@@ -4814,20 +4819,15 @@ impl LLVMGen for InlineLLVMStructPunchBody {
 /// The index of the punched struct in the result of a struct punch, `(field, punched struct)`.
 const PUNCHED_STRUCT_FIELD: usize = 1;
 
-// Field punching function for a given struct.
-//
-// If the struct is `S` and the field is `x` of type `F`, then the function has the type `S -> (F, Sx)` where `Sx` is the punched `S` at the field `x`.
-// i.e., `Sx` has the same memory layout as `S`, but does not contain the field `x`.
-//
-// We are not sure whether we should clone the struct when a shared struct is given to `punch_x`.
-// If we do not clone the struct, it will lead to different types of values sharing the same memory area, which feels dangerous,
-// but we have not found an example that causes a memory management issue yet.
-//
-// There are two use cases for the current `punch_x` function.
-// One is the implementation of `act_x`, where the struct given to `punch_x` is guaranteed to be unique.
-// The other is the implementation of `mod_x`, where it is acceptable to clone the struct if it is shared.
-// So we have two versions of `punch_x`: one that does not clone the struct and one that does.
-// The above problem is unresolved, but the current use cases do not require solving this problem.
+/// The `punch_x` function of a struct: for a struct `S` with a field `x` of type `F`, a function of
+/// type `S -> (F, Sx)` that moves the field out. `Sx` is `S` punched at `x` — the memory layout of
+/// `S`, with the slot at `x` a hole whose value has moved out.
+///
+/// The field is handed over without being reference counted, so the struct it is taken out of has to
+/// be uniquely owned. `force_unique` picks how that is met, as `force_unique_or_assert` describes:
+/// forcing it clones a struct that is shared, and leaving it off takes the caller's guarantee that
+/// the struct is unique. That guarantee is what keeps `S` and `Sx` apart — a shared struct punched
+/// without a clone leaves the two types naming one region of memory.
 pub fn struct_punch(
     definition: &TypeDefn,
     field_name: &str,
@@ -4860,6 +4860,9 @@ pub fn struct_punch(
     (expr, scm)
 }
 
+/// The body of a struct's `plug_in_x`: the value bound to `field_name` is moved into the hole of the
+/// punched struct bound to `punched_struct_name`, giving back the struct type the hole was punched
+/// out of.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructPlugInBody {
     punched_struct_name: FullName,

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4667,6 +4667,31 @@ pub struct InlineLLVMStructPunchBody {
     pub(crate) assume_local: bool,
 }
 
+impl InlineLLVMStructPunchBody {
+    /// The path of the argument's boxed leaf that the result's boxed leaf at `path` carries, where
+    /// the struct is unboxed. A leaf of the punched-struct component sits at the path it had in the
+    /// argument; a leaf of the moved-out field sits under the punched field.
+    fn arg_leaf_path(&self, path: &FieldPath) -> FieldPath {
+        // A boxed leaf of the result descends through the field or through the punched struct.
+        let (head, rest) = path
+            .split_first()
+            .expect("a boxed leaf of an unboxed pair has a non-empty path");
+        if *head == PUNCHED_STRUCT_FIELD {
+            assert_ne!(
+                rest.first(),
+                Some(&self.field_idx),
+                "the punched struct holds nothing at field {}, so leaf {:?} names no value",
+                self.field_idx,
+                path
+            );
+            return rest.to_vec();
+        }
+        let mut p = vec![self.field_idx];
+        p.extend_from_slice(rest);
+        p
+    }
+}
+
 #[typetag::serde]
 impl LLVMGen for InlineLLVMStructPunchBody {
     fn generate<'c, 'm>(&self, gc: &mut Generator<'c, 'm>, ret_ty: &Arc<TypeNode>) -> Object<'c> {
@@ -4755,16 +4780,7 @@ impl LLVMGen for InlineLLVMStructPunchBody {
             return Provenance::fresh_under(result_ty, type_env, &[PUNCHED_STRUCT_FIELD]);
         }
         Provenance::build_shape(result_ty, type_env, &|path| {
-            // A boxed leaf of the result descends through the field or through the punched struct.
-            let (head, rest) = path
-                .split_first()
-                .expect("a boxed leaf of an unboxed pair has a non-empty path");
-            if *head == PUNCHED_STRUCT_FIELD {
-                return Provenance::leaf(LeafOrigin::Arg(0, rest.to_vec()));
-            }
-            let mut p = vec![self.field_idx];
-            p.extend_from_slice(rest);
-            Provenance::leaf(LeafOrigin::Arg(0, p))
+            Provenance::leaf(LeafOrigin::Arg(0, self.arg_leaf_path(path)))
         })
     }
 
@@ -4786,16 +4802,7 @@ impl LLVMGen for InlineLLVMStructPunchBody {
             return punched_out_locality(result_ty, type_env, 0, PUNCHED_STRUCT_FIELD);
         }
         ExtShape::build_shape(result_ty, type_env, &|path| {
-            let (head, rest) = path
-                .split_first()
-                .expect("a boxed leaf of an unboxed pair has a non-empty path");
-            if *head == PUNCHED_STRUCT_FIELD {
-                LeafCond::input_leaf(0, rest.to_vec())
-            } else {
-                let mut p = vec![self.field_idx];
-                p.extend_from_slice(rest);
-                LeafCond::input_leaf(0, p)
-            }
+            LeafCond::input_leaf(0, self.arg_leaf_path(path))
         })
     }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4686,9 +4686,9 @@ impl InlineLLVMStructPunchBody {
             );
             return rest.to_vec();
         }
-        let mut p = vec![self.field_idx];
-        p.extend_from_slice(rest);
-        p
+        let mut arg_path = vec![self.field_idx];
+        arg_path.extend_from_slice(rest);
+        arg_path
     }
 }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4748,8 +4748,8 @@ impl LLVMGen for InlineLLVMStructPunchBody {
         // Punching an unboxed struct only takes it apart in registers: the field and the remaining
         // fields carry the argument's, and nothing is retained or released. Declaring those
         // passthroughs is what carries a boxed field — an array in a loop state, say — through
-        // `mod`/`act` with what is known about it intact. The punched-out field is left holding a
-        // value the struct no longer owns; it names nothing, so `Unknown` says the least about it.
+        // `mod`/`act` with what is known about it intact. The punched struct holds nothing at the
+        // punched field, so every leaf it has is one it keeps, at the path it had in the argument.
         let punched_ty = &result_ty.field_types(type_env)[PUNCHED_STRUCT_FIELD];
         if punched_ty.is_box(type_env) {
             return Provenance::fresh_under(result_ty, type_env, &[PUNCHED_STRUCT_FIELD]);
@@ -4759,21 +4759,12 @@ impl LLVMGen for InlineLLVMStructPunchBody {
             let (head, rest) = path
                 .split_first()
                 .expect("a boxed leaf of an unboxed pair has a non-empty path");
-            if *head != PUNCHED_STRUCT_FIELD {
-                let mut p = vec![self.field_idx];
-                p.extend_from_slice(rest);
-                return Provenance::leaf(LeafOrigin::Arg(0, p));
+            if *head == PUNCHED_STRUCT_FIELD {
+                return Provenance::leaf(LeafOrigin::Arg(0, rest.to_vec()));
             }
-            // The punched struct is unboxed here, so a boxed leaf of it also starts with a field
-            // index.
-            let (field, _) = rest
-                .split_first()
-                .expect("a boxed leaf of an unboxed punched struct has a non-empty path");
-            if *field == self.field_idx {
-                Provenance::leaf(LeafOrigin::Unknown)
-            } else {
-                Provenance::leaf(LeafOrigin::Arg(0, rest.to_vec()))
-            }
+            let mut p = vec![self.field_idx];
+            p.extend_from_slice(rest);
+            Provenance::leaf(LeafOrigin::Arg(0, p))
         })
     }
 
@@ -4997,8 +4988,8 @@ const PLUG_IN_FIELD_ARG: usize = 1;
 /// and every other field the struct operand's, with nothing retained or released. Declaring those
 /// passthroughs is what carries a boxed field — an array in a loop state, say — through `mod`/`act`
 /// with what is known about it intact. The struct operand's leaf at the replaced field reaches no
-/// result path and so stays consumed: `set` releases the value it replaces, and `plug_in` fills a
-/// hole holding a value the struct no longer owns.
+/// result path and so stays consumed, which is what `set` does with it: it releases the value it
+/// replaces. A punched struct holds nothing at that field, so a `plug_in` operand has no leaf there.
 fn replaced_field_prov(
     result_ty: &Arc<TypeNode>,
     type_env: &TypeEnv,

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -7892,9 +7892,9 @@ fn mutated_in_place_locality(
     value_path: &[usize],
 ) -> ExtShape {
     let payload_holds_boxed = arg_tys[value_arg]
-        .field_types(type_env)
+        .value_field_types(type_env)
         .iter()
-        .any(|fty| !boxed_leaf_paths(fty, type_env).is_empty());
+        .any(|(_, fty)| !boxed_leaf_paths(fty, type_env).is_empty());
     let value_leaf = if payload_holds_boxed {
         LeafCond::new(ExtCond::bottom(), ExtCond::Always)
     } else {

--- a/src/object.rs
+++ b/src/object.rs
@@ -792,12 +792,7 @@ impl ObjectFieldType {
         mut dst: Object<'c>,
         state: RcState,
     ) -> Object<'c> {
-        for (i, field) in src.ty.fields(gc.type_env()).iter().enumerate() {
-            // Skip the punched field.
-            if field.is_punched {
-                continue;
-            }
-
+        for (i, _) in src.ty.value_field_types(gc.type_env()) {
             // Retain the field.
             let field = ObjectFieldType::move_out_struct_field(gc, src, i as u32);
             gc.retain(field.clone(), state);
@@ -1096,7 +1091,7 @@ impl ObjectFieldType {
         } else {
             // The struct is unboxed, so the fields taken out are released by whoever receives them.
             // Releasing the fields left behind here accounts for the struct itself.
-            for field_idx in 0..struct_obj.ty.field_types(gc.type_env()).len() {
+            for (field_idx, _) in struct_obj.ty.value_field_types(gc.type_env()) {
                 let field_idx = field_idx as u32;
                 if !field_indices.iter().any(|i| *i == field_idx) {
                     let field = ObjectFieldType::move_out_struct_field(gc, struct_obj, field_idx);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -310,11 +310,12 @@ fn param_ownership_shape(
         if ty.is_rc_unit_root(type_env) {
             return OwnershipShape::Unit(ownership_at(path));
         }
-        let fields = ty.field_types(type_env);
-        let mut children = Vec::with_capacity(fields.len());
-        for (i, fty) in fields.iter().enumerate() {
+        // A field the value holds nothing at keeps its place in the shape, so that a shape index is a
+        // field index.
+        let mut children = vec![OwnershipShape::NoUnit; ty.field_types(type_env).len()];
+        for (i, fty) in ty.value_field_types(type_env) {
             path.push(i);
-            children.push(go(var, fty, owned_units, type_env, path));
+            children[i] = go(var, &fty, owned_units, type_env, path);
             path.pop();
         }
         OwnershipShape::Fields(children)

--- a/src/rc_ir/leaf_map.rs
+++ b/src/rc_ir/leaf_map.rs
@@ -22,8 +22,9 @@ use std::sync::Arc;
 /// The paths of the boxed leaves of a value of type `ty` — the field indices from the root of `ty`
 /// down to each boxed leaf. A closure lowers to `{funptr, capture-pointer}`, so its one boxed leaf is
 /// the capture; a boxed value is a single leaf at the current path; an unboxed aggregate (struct,
-/// tuple, or union) recurses into its fields (a union's variants' payloads); a fully unboxed value
-/// has none. It is the single source of truth for which of a type's paths are boxed leaves.
+/// tuple, or union) recurses into the fields that hold a value (a union's variants' payloads); a
+/// fully unboxed value has none. It is the single source of truth for which of a type's paths are
+/// boxed leaves.
 pub fn boxed_leaf_paths(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath> {
     /// Descend a type, pushing onto `out` the path of each boxed leaf reached. `path` is the field
     /// path from the value's root down to `ty`, which each pushed leaf is named relative to.
@@ -47,9 +48,9 @@ pub fn boxed_leaf_paths(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath
             out.push(path.clone());
             return;
         }
-        for (i, fty) in ty.field_types(type_env).iter().enumerate() {
+        for (i, fty) in ty.value_field_types(type_env) {
             path.push(i);
-            go(fty, type_env, path, out);
+            go(&fty, type_env, path, out);
             path.pop();
         }
     }

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -571,16 +571,8 @@ pub(crate) fn truncate_to_unit(
             // boxed leaf under a union variant, or the punched array's inner array) keys to its root.
             break;
         }
-        // Here `cur` is an unboxed struct/tuple, so a well-formed unit/root path index is in range.
-        let fields = cur.field_types(type_env);
-        assert!(
-            idx < fields.len(),
-            "truncate_to_unit: path index {} out of range ({} fields)",
-            idx,
-            fields.len()
-        );
         out.push(idx);
-        cur = fields[idx].clone();
+        cur = field_type_at(&cur, idx, type_env, "truncate_to_unit");
     }
     out
 }
@@ -680,17 +672,24 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
         if cur.is_closure() || cur.is_rc_unit_root(type_env) || cur.is_fully_unboxed(type_env) {
             return None;
         }
-        // Here `cur` is an unboxed struct/tuple, so a well-formed unit/root path index is in range.
-        let fields = cur.field_types(type_env);
-        assert!(
-            idx < fields.len(),
-            "subtree_type: path index {} out of range ({} fields)",
-            idx,
-            fields.len()
-        );
-        cur = fields[idx].clone();
+        cur = field_type_at(&cur, idx, type_env, "subtree_type");
     }
     Some(cur)
+}
+
+/// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
+/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `what` names the
+/// walk in the message an out-of-range index aborts with.
+fn field_type_at(ty: &Arc<TypeNode>, idx: usize, type_env: &TypeEnv, what: &str) -> Arc<TypeNode> {
+    let fields = ty.field_types(type_env);
+    assert!(
+        idx < fields.len(),
+        "{}: path index {} out of range ({} fields)",
+        what,
+        idx,
+        fields.len()
+    );
+    fields[idx].clone()
 }
 
 #[cfg(test)]

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -543,15 +543,9 @@ fn rc_units_go(
         out.push(path.clone());
         return;
     }
-    let fields = ty.fields(type_env);
-    for (i, fty) in ty.field_types(type_env).iter().enumerate() {
-        // A punched struct field is a hole (its value has moved out): the whole-value traversal skips
-        // it, so it names no unit.
-        if fields[i].is_punched {
-            continue;
-        }
+    for (i, fty) in ty.value_field_types(type_env) {
         path.push(i);
-        rc_units_go(fty, type_env, path, out);
+        rc_units_go(&fty, type_env, path, out);
         path.pop();
     }
 }

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7912,6 +7912,68 @@ pub fn test_struct_act_on_the_only_reference_counted_field() {
     test_source(&source, Configuration::develop_mode());
 }
 
+// `act` on the only reference-counted field of an unboxed struct, where the actor's functor yields
+// nothing: the struct with that field punched out is dropped rather than plugged back.
+#[test]
+pub fn test_struct_act_yielding_nothing_on_the_only_reference_counted_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, n : I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1, 2], n : 3 };
+            let r = s.act_p(|p| if p.@size == 0 { Option::some(p) } else { Option::none() });
+            assert(|_|"", r.is_none);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// `act` on the only reference-counted field of an unboxed struct at a functor whose `map` rebuilds
+// the struct more than once, so each rebuild reads the same punched struct.
+#[test]
+pub fn test_struct_act_plugging_in_more_than_once_on_the_only_reference_counted_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, n : I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1], n : 3 };
+            let ss = s.act_p(|p| [p, p.push_back(2)]);
+            assert_eq(|_|"", ss.map(|t| t.@p.@size + t.@n), [4, 5]);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// `act` on the only reference-counted field of an unboxed struct, where that field is shared with a
+// binding that outlives the update: the update leaves that binding's value as it was.
+#[test]
+pub fn test_struct_act_on_a_shared_only_reference_counted_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, n : I64 };
+
+        main : IO ();
+        main = (
+            let a = [1, 2];
+            let s = S { p : a, n : 3 };
+            let t = s.act_p(|p| Option::some(p.push_back(9))).as_some;
+            assert_eq(|_|"", t.@p, [1, 2, 9]);;
+            assert_eq(|_|"", a, [1, 2]);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
 #[test]
 pub fn test_tuple_functor() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7650,6 +7650,8 @@ pub fn test_get_errno() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `*` inside a struct literal or a tuple binds the components in the order they are written: the
+/// value of the one written first is held while the later one runs through its values.
 #[test]
 pub fn test_monadic_bind_and_make_struct_ordering() {
     let source = r##"
@@ -7684,6 +7686,9 @@ pub fn test_monadic_bind_and_make_struct_ordering() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `*` in a function application binds in the order the two are written: in `f(x)` and `f $ x` the
+/// function's value is held while the argument's runs through its values, and in `x.f` the
+/// argument's is held while the function's runs.
 #[test]
 pub fn test_monadic_bind_and_function_application_ordering() {
     let source = r##"
@@ -7709,6 +7714,9 @@ pub fn test_monadic_bind_and_function_application_ordering() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `act` on a uniquely owned struct, over the four combinations of a boxed or unboxed struct with a
+/// boxed or unboxed field, at an actor that yields a value and at one that yields nothing. The actor
+/// asserts that the array field it is handed is unique.
 #[test]
 pub fn test_struct_act() {
     let source = MAIN_MODULE_WITH_ARRAY_ASSERT_UNIQUE.to_string()
@@ -7789,6 +7797,9 @@ pub fn test_struct_act() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `act` on a struct the caller goes on holding, on one whose field is shared with another binding,
+/// and on both at once: the update leaves what the other holder sees as it was. Also covers a
+/// generic struct, and a functor whose `map` rebuilds the struct more than once.
 #[test]
 pub fn test_struct_act2() {
     let source = r##"
@@ -7974,6 +7985,8 @@ pub fn test_struct_act_on_a_shared_only_reference_counted_field() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// The `Functor` instance of a tuple maps its last component and leaves the earlier ones as they
+/// are, for a 1-tuple and a 2-tuple.
 #[test]
 pub fn test_tuple_functor() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7871,6 +7871,47 @@ pub fn test_struct_act2() {
     test_source(&source, Configuration::develop_mode());
 }
 
+// `act` on the only field of an unboxed struct that holds a reference, where that reference is a
+// closure's capture — the shape `Std::DynIterator` has.
+#[test]
+pub fn test_struct_act_on_the_only_field_holding_a_closure() {
+    let source = r##"
+        module Main;
+
+        type Maker = unbox struct { make : I64 -> Array I64, n : I64 };
+
+        main : IO ();
+        main = (
+            let x = 7;
+            let m = Maker { make : |n| Array::fill(n, x), n : 2 };
+            let m = m.act_make(|f| Option::some(|n| f(n).push_back(9))).as_some;
+            assert_eq(|_|"", (m.@make)(m.@n).@size, 3);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// `act` on the only reference-counted field of an unboxed struct: while the actor runs, the struct
+// has that field punched out, so no part of it is reference-counted.
+#[test]
+pub fn test_struct_act_on_the_only_reference_counted_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, n : I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1, 2], n : 3 };
+            let s = s.act_p(|p| Option::some(p.push_back(9))).as_some;
+            assert_eq(|_|"", s.@p.@size + s.@n, 6);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
 #[test]
 pub fn test_tuple_functor() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7871,8 +7871,8 @@ pub fn test_struct_act2() {
     test_source(&source, Configuration::develop_mode());
 }
 
-// `act` on the only field of an unboxed struct that holds a reference, where that reference is a
-// closure's capture — the shape `Std::DynIterator` has.
+/// `act` on the only field of an unboxed struct that holds a reference, where that reference is a
+/// closure's capture — the shape `Std::DynIterator` has.
 #[test]
 pub fn test_struct_act_on_the_only_field_holding_a_closure() {
     let source = r##"
@@ -7892,8 +7892,8 @@ pub fn test_struct_act_on_the_only_field_holding_a_closure() {
     test_source(&source, Configuration::develop_mode());
 }
 
-// `act` on the only reference-counted field of an unboxed struct: while the actor runs, the struct
-// has that field punched out, so no part of it is reference-counted.
+/// `act` on the only reference-counted field of an unboxed struct: while the actor runs, the struct
+/// has that field punched out, so no part of it is reference-counted.
 #[test]
 pub fn test_struct_act_on_the_only_reference_counted_field() {
     let source = r##"
@@ -7912,8 +7912,8 @@ pub fn test_struct_act_on_the_only_reference_counted_field() {
     test_source(&source, Configuration::develop_mode());
 }
 
-// `act` on the only reference-counted field of an unboxed struct, where the actor's functor yields
-// nothing: the struct with that field punched out is dropped rather than plugged back.
+/// `act` on the only reference-counted field of an unboxed struct, where the actor's functor yields
+/// nothing: the struct with that field punched out is dropped rather than plugged back.
 #[test]
 pub fn test_struct_act_yielding_nothing_on_the_only_reference_counted_field() {
     let source = r##"
@@ -7932,8 +7932,8 @@ pub fn test_struct_act_yielding_nothing_on_the_only_reference_counted_field() {
     test_source(&source, Configuration::develop_mode());
 }
 
-// `act` on the only reference-counted field of an unboxed struct at a functor whose `map` rebuilds
-// the struct more than once, so each rebuild reads the same punched struct.
+/// `act` on the only reference-counted field of an unboxed struct at a functor whose `map` rebuilds
+/// the struct more than once, so each rebuild reads the same punched struct.
 #[test]
 pub fn test_struct_act_plugging_in_more_than_once_on_the_only_reference_counted_field() {
     let source = r##"
@@ -7952,8 +7952,8 @@ pub fn test_struct_act_plugging_in_more_than_once_on_the_only_reference_counted_
     test_source(&source, Configuration::develop_mode());
 }
 
-// `act` on the only reference-counted field of an unboxed struct, where that field is shared with a
-// binding that outlives the update: the update leaves that binding's value as it was.
+/// `act` on the only reference-counted field of an unboxed struct, where that field is shared with a
+/// binding that outlives the update: the update leaves that binding's value as it was.
 #[test]
 pub fn test_struct_act_on_a_shared_only_reference_counted_field() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7783,6 +7783,14 @@ pub fn test_struct_act() {
             let s = UU { x : false, y : [1, 2], z : 3 };
             assert_eq(|_|"", s.act_x(actor_bool), Option::none());;
 
+            // GB case 1
+            let s = GB { x : [true], y : [1, 2], z : 3 };
+            assert_eq(|_|"", s.act_x(actor_array), Option::some(GB { x : [true], y : [1, 2], z : 3 }));;
+
+            // GB case 2
+            let s = GB { x : [], y : [1, 2], z : 3 };
+            assert_eq(|_|"", s.act_x(actor_array), Option::none());;
+
             pure()
         );
     "##;
@@ -7828,6 +7836,25 @@ pub fn test_struct_act2() {
         main = (
             let actor_bool = |x| if x { Option::some(x) } else { Option::none() };
 
+            // Case where BU is shared: the field is unboxed, so the update reads it and the struct
+            // is left as it was.
+            let s = BU { x : true, y : [1, 2], z : 3 };
+            assert_eq(|_|"", s.act_x(actor_bool), Option::some(BU { x : true, y : [1, 2], z : 3 }));;
+            assert_eq(|_|"", s, BU { x : true, y : [1, 2], z : 3 });;
+
+            // Case where UU is shared.
+            let s = UU { x : true, y : [1, 2], z : 3 };
+            assert_eq(|_|"", s.act_x(actor_bool), Option::some(UU { x : true, y : [1, 2], z : 3 }));;
+            assert_eq(|_|"", s, UU { x : true, y : [1, 2], z : 3 });;
+
+            // Case where UB's field is shared with a binding that outlives the update.
+            let actor_set = |x| if x.Array::@size > 0 { Option::some(x.set(0, false)) } else { Option::none() };
+            let x = [true];
+            let s = UB { x : x, y : [1, 2], z : 3 };
+            assert_eq(|_|"", s.act_x(actor_set), Option::some(UB { x : [false], y : [1, 2], z : 3 }));;
+            assert_eq(|_|"", x, [true]);;
+            assert_eq(|_|"", s.@x, [true]);;
+
             // GB case 1
             let actor_array = |x| if x.Array::@size > 0 { Option::some(x) } else { Option::none() };
             let s = GB { x : [true], y : [1, 2], z : 3 };
@@ -7872,7 +7899,7 @@ pub fn test_struct_act2() {
 }
 
 /// `act` on the only field of an unboxed struct that holds a reference, where that reference is a
-/// closure's capture — the shape `Std::DynIterator` has.
+/// closure's capture rather than an array.
 #[test]
 pub fn test_struct_act_on_the_only_field_holding_a_closure() {
     let source = r##"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7979,6 +7979,177 @@ pub fn test_struct_act_plugging_in_more_than_once_on_the_only_reference_counted_
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `act` at the `Arrow` functor, whose `map` hands the plug back as a function: the caller decides
+/// how many times the struct is rebuilt, and each rebuild reads the same punched struct, which here
+/// still holds a field of its own beside the hole.
+#[test]
+pub fn test_struct_act_plugging_in_more_than_once_beside_a_sibling_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, q : Array I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1, 2], q : [10, 20] };
+            let k = s.act_p(|p| |r| p.push_back(r));
+            let a = k(7);
+            let b = k(8);
+            assert_eq(|_|"", a.@p, [1, 2, 7]);;
+            assert_eq(|_|"", a.@q, [10, 20]);;
+            assert_eq(|_|"", b.@p, [1, 2, 8]);;
+            assert_eq(|_|"", b.@q, [10, 20]);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// `act` at the `Arrow` functor where the function the update yields is dropped without being
+/// called: the punched struct goes with it, and the field it still holds beside the hole is released
+/// with it.
+#[test]
+pub fn test_struct_act_dropping_the_punched_struct_beside_a_sibling_field() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, q : Array I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1, 2], q : [10, 20] };
+            let k = s.act_p(|p| |r| p.push_back(r));
+            let _ = k;
+            assert_eq(|_|"", 1, 1);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// `act` at the pair functor, whose implementation punches with the clone and plugs without the
+/// uniqueness check — the pairing the other functors do not use. The field is shared with a binding
+/// that outlives the update, for a boxed and for an unboxed struct.
+#[test]
+pub fn test_struct_act_at_the_pair_functor() {
+    let source = r##"
+        module Main;
+
+        type U = unbox struct { p : Array I64, q : Array I64 };
+        type B = box struct { p : Array I64, q : Array I64 };
+
+        main : IO ();
+        main = (
+            let a = [1, 2];
+            let u = U { p : a, q : [7] };
+            let (n, u2) = u.act_p(|p| (p.@size, p.push_back(9)));
+            assert_eq(|_|"", n, 2);;
+            assert_eq(|_|"", u2.@p, [1, 2, 9]);;
+            assert_eq(|_|"", u2.@q, [7]);;
+
+            let b = B { p : a, q : [8] };
+            let (m, b2) = b.act_p(|p| (p.@size, p.push_back(9)));
+            assert_eq(|_|"", m, 2);;
+            assert_eq(|_|"", b2.@p, [1, 2, 9]);;
+            assert_eq(|_|"", b2.@q, [8]);;
+            assert_eq(|_|"", b.@p, [1, 2]);;
+
+            assert_eq(|_|"", a, [1, 2]);;
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// `act` and `mod` on a field whose neighbours also hold references: the middle field of an unboxed
+/// struct of three arrays, a field holding a union, a field holding a nested unboxed struct, and a
+/// field holding a closure. The update lands on that field and leaves the others as they were.
+#[test]
+pub fn test_struct_act_beside_fields_that_hold_references() {
+    let source = r##"
+        module Main;
+
+        type Mid = unbox struct { a : Array I64, b : Array I64, c : Array I64 };
+        type WithUnion = unbox struct { o : Option (Array I64), n : I64 };
+        type Inner = unbox struct { v : Array I64, w : I64 };
+        type Outer = unbox struct { i : Inner, s : String };
+        type Closy = unbox struct { f : I64 -> I64, g : Array I64 };
+
+        main : IO ();
+        main = (
+            let m = Mid { a : [1], b : [2, 2], c : [3, 3, 3] };
+            let m = m.act_b(|b| Option::some(b.push_back(9))).as_some;
+            assert_eq(|_|"", [m.@a.@size, m.@b.@size, m.@c.@size], [1, 3, 3]);;
+
+            let m = Mid { a : [1], b : [2, 2], c : [3, 3, 3] };
+            let m = m.mod_b(|b| b.push_back(9));
+            assert_eq(|_|"", [m.@a.@size, m.@b.@size, m.@c.@size], [1, 3, 3]);;
+
+            let m0 = Mid { a : [1], b : [2, 2], c : [3] };
+            let m1 = m0.mod_b(|b| b.push_back(9));
+            assert_eq(|_|"", m0.@b, [2, 2]);;
+            assert_eq(|_|"", m1.@b, [2, 2, 9]);;
+
+            let u = WithUnion { o : Option::some([1, 2]), n : 5 };
+            let u = u.mod_o(|o| o.map(|a| a.push_back(3)));
+            assert_eq(|_|"", u.@o.as_some, [1, 2, 3]);;
+            assert_eq(|_|"", u.@n, 5);;
+
+            let o = Outer { i : Inner { v : [1], w : 2 }, s : "abc" };
+            let o = o.mod_i(|i| i.mod_v(|v| v.push_back(4)));
+            assert_eq(|_|"", o.@i.@v, [1, 4]);;
+            assert_eq(|_|"", o.@s, "abc");;
+
+            let o = Outer { i : Inner { v : [1], w : 2 }, s : "abc" };
+            let o = o.mod_s(|s| s + "d");
+            assert_eq(|_|"", o.@s, "abcd");;
+            assert_eq(|_|"", o.@i.@v, [1]);;
+
+            let k = 3;
+            let c = Closy { f : |x| x + k, g : [1, 2] };
+            let c = c.mod_f(|f| |x| f(x) * 2);
+            assert_eq(|_|"", (c.@f)(1), 8);;
+            assert_eq(|_|"", c.@g, [1, 2]);;
+
+            let m = Mid { a : [1], b : [2], c : [3] };
+            let ms = m.act_b(|b| [b, b.push_back(8)]);
+            assert_eq(|_|"", ms.map(|x| x.@b.@size), [1, 2]);;
+            assert_eq(|_|"", ms.map(|x| x.@a.@size), [1, 1]);;
+
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// `act` at a functor whose `map` defers the plug-in into a closure, so the punched struct outlives
+/// the `act` and is plugged in only when the result is consumed. Covers a punched struct that holds
+/// no value and one that still holds references.
+#[test]
+pub fn test_struct_act_whose_plug_in_is_deferred() {
+    let source = r##"
+        module Main;
+
+        type S = unbox struct { p : Array I64, n : I64 };
+        type Mid = unbox struct { a : Array I64, b : Array I64, c : I64 };
+
+        main : IO ();
+        main = (
+            let s = S { p : [1, 2], n : 3 };
+            let it : DynIterator S = s.act_p(|p| [p, p.push_back(9), p.push_back(8)].to_iter.to_dyn);
+            assert_eq(|_|"", it.Iterator::map(|t| t.@p.@size + t.@n).to_array, [5, 6, 6]);;
+
+            let m = Mid { a : [1], b : [2, 2], c : 5 };
+            let it : DynIterator Mid = m.act_b(|b| [b, b.push_back(9)].to_iter.to_dyn);
+            let got = it.Iterator::map(|t| t.@a.@size * 100 + t.@b.@size * 10 + t.@c).to_array;
+            assert_eq(|_|"", got, [125, 135]);;
+
+            pure()
+        );
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
 /// `act` on the only reference-counted field of an unboxed struct, where that field is shared with a
 /// binding that outlives the update: the update leaves that binding's value as it was.
 #[test]


### PR DESCRIPTION
Closes #233

構造体のフィールドを `act` / `mod` で更新する途中には、そのフィールドが「穴」になった構造体の値が
現れる。参照を持つのがその穴のフィールドだけのとき、コンパイラはこの値について 2 つの食い違う答えを
出していた — 「参照カウントが要る」と「数える対象は 1 つも無い」。開発モードの RC IR 検証器はこの
矛盾を見つけて止まるので、この形を通るプログラムはテストとして書けなかった。

穴を「値を持たないもの」として扱う walk を 1 つに揃えることで直す。

## 穴とは何か

`s.act_p(g)` は、フィールド `p` を構造体から取り出し (punch)、それを `g` に渡し、返ってきた値を戻す
(plug_in) 形に脱糖される。取り出したあとの構造体は `S#PunchedAt0` という別の型を持つ。この型の宣言は
もとの構造体と同じフィールドの並びを持ち、取り出されたフィールドに `is_punched` の印が付いている。

印が付いたフィールドは、**レイアウトの上では席を保ち**（`plug_in` が値を書き戻す先が要る）、
**値の上では空である**（そこにあった値は `g` へ移った）。コード生成はこの区別に従っていて、構造体を
たどる処理 — retain、release、複製、traverser — はどれも印の付いたフィールドを飛ばす。

## 何が起きていたか

型を辿って「この値が何を持つか」を述べる関数は、この変更の前は 4 つあり、穴の扱いが割れていた。

| 関数 | 述べること | 穴を |
| --- | --- | --- |
| `TypeNode::is_fully_unboxed` | 参照を 1 つも持たないか | 数えていた |
| `boxed_leaf_paths` | 参照 1 本ごとのパス | 数えていた |
| `rc_units` | 参照カウント操作 1 回の対象ごとのパス | 飛ばしていた |
| `param_ownership_shape` | パラメータの各単位の所有・借用 | 数えていた |

参照を持つのが穴のフィールドだけであるとき、`is_fully_unboxed` は「参照を持つ」と答え、`rc_units` は
「対象は 0 個」と答える。両者を別々に読む挿入器と検証器が、そこで食い違った。

### 失敗する実行

```fix
type S = unbox struct { p : Array I64, n : I64 };
let s = S { p : [1, 2], n : 3 };
let s = s.act_p(|p| Option::some(p.push_back(9))).as_some;
```

関与する関数はこれだけである。

- `RcInsert::needs_rc(var)` — ある変数に `Retain` / `Release` を出すかを決める。`is_fully_unboxed` の
  否定を返していた。
- `rc_units(ty)` — その型の値が持つ参照カウント単位のパスを列挙する。
- `RcValidator::check_rc_unit(var, path)` — 開発モードで走り、`Retain` / `Release` のパスが単位の
  1 つに届いていることを確かめる。

`act_p` の脱糖は、punch の結果を `x`（取り出した配列）と `ps`（穴の開いた構造体）に分解し、`g` の
返した `Option` で分岐する。`some` の枝は `ps` を `plug_in` に渡し、`none` の枝は `ps` を捨てる。

1. 挿入器が `none` の枝を見る。`ps` はこの枝で使われずに死ぬので、所有している参照を手放す
   `Release` が要る。
2. `needs_rc(ps)` が呼ばれる。`ps` の型は `S#PunchedAt0` で、そのフィールドの型は
   `[Array I64（穴）, I64]`。`is_fully_unboxed` は穴も数えるので `Array I64` を見つけ、`false` を返す。
   `needs_rc` は `true`。
3. 挿入器が `Release(ps, [])` を置く。パス `[]` は値の根、すなわち「この値が持つ参照すべて」を指す。
4. 検証器が `check_rc_unit(ps, [])` を実行する。`rc_units(S#PunchedAt0)` は穴を飛ばし、残る `I64` は
   参照を持たないので、**空の列**を返す。`[]` で始まる単位が 1 つも無い。
5. 検証器が止まる:
   `reference counting 'ps#51' at [] in 'Main::main#1', which reaches none of its units []`。

手順 2 が最初に状態を誤る場所である。`ps` は参照を 1 本も持たないのに、持つと答えている。

### 直したあとの実行

手順 2 で分岐が変わる。`is_fully_unboxed` は穴を飛ばして `I64` だけを見るので `true` を返し、
`needs_rc` は `false`。手順 3 の `Release` は置かれず、手順 4 の検証は起きない。以降の状態は
`ps` が参照を持たないという事実と一致したまま最後まで進む。

`some` の枝も同じ理由で変わらず正しい: `plug_in` は `ps` の席にフィールドを書き戻すだけで、`ps` から
参照を受け取らない。

## 変更

### 穴を飛ばす 1 つの入口

`TypeNode::value_field_types`（新規）は、値を持つフィールドの型を、それが座るフィールド番号と対で
返す。穴は除く。番号を対にして返すのは、フィールドを名指す側 — レイアウト、添字によるフィールドの
読み書き、参照カウント操作のパス — が宣言の番号で数えるからで、絞り込んだ列の中での位置ではその
番号にならない。

**型を辿って「この値が何を持つか」を述べる walk はすべてこれを降りる。**コード生成がオブジェクトの
レイアウト表現のほうを辿るとき（`ObjectFieldType::SubObject`）は、その表現自体が穴の印を運ぶので、
そちらは変わらない。穴の規則は型の側とオブジェクトの側で 1 つずつ、計 2 か所で述べられている。

`TypeNode::fields_with_instance_types`（新規、非公開）は、宣言されたフィールドと、この型引数を
代入した型との対を返す。`field_types_via_tycons` と `value_field_types` の共通部分である（清掃の
PR #238 が `fields` もこれに載せる）。返す `Field` は宣言のもの（`ty` も `syn_ty` も宣言のまま）で、
この型での型は対の 2 番目だけが持つ。

`TypeNode::field_types_via_tycons`（変更）— 宣言されたフィールドの型をこの型で具体化して並べる。
`fields_with_instance_types` の結果から型だけを取り出す形になった。穴を含む点は変わらない。
この関数を読む側は型検査・パターン・lowering・組み込み演算と広いが、**穴の開いた型に出会い得る
読み手はどれもレイアウトか添字を問うている**（計測: 穴の開いたフィールドを持つ宣言に届く呼び出しは
8 か所で、値を問う 4 か所はいま `value_field_types` を降り、残る 4 か所 — オブジェクトのレイアウト
構築、参照カウント単位のパスを降りる 2 か所、フィールドの取り出し — は添字で数えている）。

### 揃えた 4 つの walk

- `TypeNode::is_fully_unboxed`（変更）— 値が参照を 1 つも持たないかを答える。フィールドを辿る先が
  `value_field_types` になり、穴を飛ばす。この関数が #233 の食い違いの一方だった。
- `boxed_leaf_paths`（`src/rc_ir/leaf_map.rs`、変更）— 値が持つ参照 1 本ごとのパスを列挙する。
  provenance と locality の各解析は、この列挙の 1 パスにつき 1 つの事実を持つ。穴を飛ばすことで、
  punch した構造体の解析結果から「そこには無い値」についての事実が消える。
- `rc_units_go`（`src/rc_ir/ownership.rs`、変更）— 参照カウント操作 1 回の対象ごとのパスを列挙する。
  もとから穴を飛ばしていたが、その判定を自分で書いていた。`value_field_types` に載せ替え、判定が
  1 か所になった。
- `param_ownership_shape` の `go`（`src/rc_ir/borrow.rs`、変更）— 関数のパラメータについて、各単位が
  所有か借用かを、値と同じ形の木として組み立てる（`--emit-rc-ir` の注釈に出る）。穴の位置は
  `NoUnit`（単位を持たない部分）になり、木の添字はフィールド番号のまま保たれる。

### punch の宣言

`InlineLLVMStructPunchBody` は、構造体からフィールドを取り出す組み込み演算である。結果は
`(取り出したフィールド, 穴の開いた構造体)` の対で、この演算は結果の各参照が**引数のどの参照から
来たか**を 2 つの形で宣言する — `result_prov`（その参照の出所）と `result_locality`（その参照が
指すオブジェクトが局所かどうかの条件）。どちらも同じ「結果のパス -> 引数のパス」の対応を使う。

- `InlineLLVMStructPunchBody::arg_leaf_path`（新規）— 結果の参照 1 本のパスを受け、それが引数の
  どのパスから来たかを返す。穴の開いた構造体の側の参照は、引数で持っていたパスをそのまま持つ。
  取り出したフィールドの側の参照は、引数では punch されたフィールドの下にあった。
  この関数は、穴の位置に参照が無いことを `assert_ne!` で述べる — 本 PR が確立する不変条件であり、
  これが破れたら（列挙器のどれかが穴を数えるようになったら）ここで止まる。
- `InlineLLVMStructPunchBody::result_prov` / `::result_locality`（変更）— 上の対応を各自で書いて
  いたのを `arg_leaf_path` に載せ替えた。`result_prov` には、穴の参照について「何も名指さない」と
  答える枝があったが、穴に参照が無くなったので消えた。

### 値を辿る残りの 3 か所

コード生成の側にも、値を辿りながら穴を自分で扱っていた（あるいは扱っていなかった）walk が 3 つ
あった。いずれも `value_field_types` を降りる形にして、規則を 1 か所にした。

- `ObjectFieldType::clone_struct`（`src/object.rs`、変更）— 構造体の値を複製する。フィールドを
  1 つずつ retain して複製先へ書き込む。穴を飛ばす判定を自分で書いていた。
- `ObjectFieldType::get_struct_fields`（`src/object.rs`、変更）— 指定されたフィールドを構造体から
  取り出し、構造体そのものを消費する。unbox の枝は、取り出されなかったフィールドを release する
  ことで構造体の分を精算するが、**穴を飛ばしていなかった**。今日ここへ穴の開いた構造体が届く経路は
  無い（`Destructure` のコンテナは struct パターンからしか来ず、穴の開いた型は Fix のソースに
  書けない）が、規則から漏れていた唯一の値 walk だった。
- `mutated_in_place_locality`（`src/fixstd/builtin.rs`、変更）— 場所を変えずに書き換える演算につい
  て、結果の各参照が指すオブジェクトが局所かどうかの条件を組み立てる。「書き込む値が参照を持つか」
  をフィールドの型から判定する部分がレイアウトの側の関数を読んでいた。

### そのほか

- `TypeNode::depth`（変更）— 型の入れ子の深さを返す。`type_size` のレイアウト計算が、深さの上限を
  超える型を「サイズを持たない」と診断するために読む。関連型 `AssocTy` の腕にあった
  `.max().unwrap_or(0)` を `.expect(...)` にした。引数 0 個の関連型は構文解析が拒否する
  （`validate_as_associated_type_impl_defn` が `app_seq.len() < 2` を診断し、`params` の先頭には
  常に `#impl_type` が積まれる）ので、この既定値は到達しない。到達したなら深さを 1 段小さく報告し、
  上限判定をすり抜けさせる方向に効く。

## テスト

`src/tests/test_basic.rs` に 10 本。いずれも `Configuration::develop_mode`（RC IR 検証器が走り、
プログラムを valgrind memcheck の下で実行する）で走る。

**#233 の形を述べる 5 本**（参照を持つのが punch されるフィールドだけ）。5 本とも、修正前の
コンパイラで落ちることを実測した（付録 C）。

- `test_struct_act_on_the_only_reference_counted_field` — issue の再現そのもの。
- `test_struct_act_on_the_only_field_holding_a_closure` — 参照がクロージャの捕捉である場合。
- `test_struct_act_yielding_nothing_on_the_only_reference_counted_field` — actor の functor が値を
  返さず、穴の開いた構造体が捨てられる経路。
- `test_struct_act_plugging_in_more_than_once_on_the_only_reference_counted_field` — `map` が
  再構築を複数回呼ぶ functor（`Array`）。穴の開いた構造体が関数のパラメータとして現れる唯一の形で、
  修正前は `Std::Functor::map` の側で検証器が止まる。
- `test_struct_act_on_a_shared_only_reference_counted_field` — フィールドが外の束縛と共有されている
  場合。参照カウント操作を消す変更なので、値意味論が保たれることを別に述べる。

**punch の周辺で既存のテストが届いていなかった 5 本**（バグハントが書き、修正前のコンパイラでも
通る。この変更を pin するのではなく、壊してはいけない軸を埋める）。

- `test_struct_act_plugging_in_more_than_once_beside_a_sibling_field` /
  `test_struct_act_dropping_the_punched_struct_beside_a_sibling_field` — `Arrow` functor。plug を
  何度呼ぶか、そもそも呼ぶかを呼び手が決める形で、穴の隣にもう 1 つ参照がある。
- `test_struct_act_at_the_pair_functor` — pair functor は、複製する punch と検査しない plug_in を
  組み合わせる唯一の functor である。
- `test_struct_act_beside_fields_that_hold_references` — 更新するフィールドの隣が配列・union・
  入れ子の unbox 構造体・クロージャである形（`act` と `mod` の両方）。
- `test_struct_act_whose_plug_in_is_deferred` — plug をクロージャの中へ遅らせる functor。

**既存の 2 本が宣言していた形に届くようにした**。`test_struct_act` は generic な boxed 構造体を、
`test_struct_act2` はコメントが名指す 4 形状のうち 3 つを宣言しながら `main` から使っておらず、
コンパイラはその宣言をプログラムに入れていなかった（生成された IR のシンボルを数えて確認）。
`UB` と `GB` の `Eq` を壊すと両方が赤くなることを実測した。

## 変更しなかったもの

CHANGELOG に項目を足していない。ユーザから見える振る舞いが変わらないためである（付録の実測）。

---

# 付録

## A. 修正前後で機械語が変わらないこと

`benchmark/speedtest/cases` の全ケースを、`main`（`ae692f6e`）のコンパイラと本ブランチのコンパイラで
同じフラグ（`-O experimental --emit-symbols --disable-cpu-feature 'avx512.*'`）で構築し、
リンク後の `.text` を比較した。

- **51 / 51 ケースが 1 バイト違わず一致**（`_` で始まる 3 ケースは harness と同様に除外）。
  穴の開いた構造体をちょうど作る `struct_field_mod`（`unbox struct { arr : Array I64, tag : I64 }` の
  `mod_arr`）も一致する。
- issue の再現プログラム自体も一致（1576 バイト、同一ハッシュ）。
- boxed な構造体の punch と、参照を持つフィールドが 2 つある構造体の punch も一致。

比較器が差を報告できることは、同じケースを `-O experimental` と `-O basic` で構築して確かめた
（770 バイト / 31304 バイト、異なるハッシュ）。

## B. RC IR には差が出る

同じ再現プログラムの `--emit-rc-ir Main`。

挿入直後（`rc_ir.Main.pre.txt`）。単位を 1 つも名指さない `release` が消える。

```
     let if#75 : Std::Bool = ... match v#67 {
         case 1(unit#68 : ()):
-            release ps#44
             release v#66
```

最適化後（`rc_ir.Main.post.txt`）。穴についての事実が消え、punch の結果は「参照を持たない」と
述べられる。

```
-    let v#42 : (Array I64, S#PunchedAt0) [{.0=fresh, .1.0=unknown}] = struct_punch_0[unique](struct#41)
-    destructure v#42 { .0 -> x#43 [fresh], .1 -> ps#44 [{.0=unknown}] } @local
+    let v#42 : (Array I64, S#PunchedAt0) [{.0=fresh}] = struct_punch_0[unique](struct#41)
+    destructure v#42 { .0 -> x#43 [fresh], .1 -> ps#44 [unboxed] } @local
```

参照を持つフィールドが 2 つある構造体では、残るフィールドの事実がパスを保ったまま残る
（`{.0=unknown, .1=fresh}` -> `{.1=fresh}`）。

## C. テストが赤くなることの確認

- **修正前のコンパイラ**（`main` 相当、テストだけを載せた状態）で 5 本すべてが落ちる。既定の
  最適化レベルで、いずれも `[RC IR validate] ... reaches none of its units []`。
- `is_fully_unboxed` だけを修正前の振る舞いに戻す変異でも 5 本すべてが落ち、既存の
  `test_struct_act` / `test_struct_act2` は通ったまま — 新しいテストが今回の食い違いだけを
  見ていることの確認である。
- `value_field_types` から穴の除外を外す変異（4 つの walk がそろって穴を数える）では、
  `test_struct_act` を含む 3 本が落ちる。

## D. テスト一式

`cargo test --release` を 3 つの最適化レベルで実行（既定のレベルは最終状態、`basic` と `none` は
テストを足す前の状態で）。いずれも失敗 0。

| `FIX_MAX_OPT_LEVEL` | 結果 |
| --- | --- |
| （既定 = max / experimental） | 1325 + 135 passed / 0 failed |
| `basic` | 1317 + 135 passed / 0 failed |
| `none` | 1317 + 135 passed / 0 failed |

## E. なぜ `is_fully_unboxed` を直したか

issue は狭い直し方を挙げていた — `needs_rc` が `is_fully_unboxed` ではなく `rc_units` を問うように
する。これでも #233 の症状は消える。採らなかった理由は 2 つある。

- **食い違いが残る。** `boxed_leaf_paths` は穴を数えたままになり、punch した構造体の解析結果に
  「そこには無い値」についての事実が残る。`rc_units` と `boxed_leaf_paths` は
  `truncate_to_unit` で互いに写り合う関係にあるので、片方だけが穴を持つ状態は次の食い違いの種である。
- **同じ判断がすでにコンパイラの中にある。** `unwrap_newtype` は、フィールドが 1 つだけの unbox 型を
  そのフィールドの型に置き換える最適化だが、その型を punch した型については `()` に置き換える
  （`unwrap_newtype_on_type_internal`）。穴だけが残った構造体は何も持たない、という本 PR と同じ
  判断である。`-O max` で `Std::DynIterator` の形が #233 を踏まなかったのはこのためで、
  フィールドが 2 つ以上の構造体だけが残っていた。

穴を「型の宣言には在るが、値の上では無い」ものとして 1 か所で扱うと、`needs_rc` は
`is_fully_unboxed` を問うままでよい（穴を除いたあとは `!is_fully_unboxed(ty)` と
「`rc_units(ty)` が空でない」が同値になる）。

## F. 修正前に落ちなかった最適化レベル

再現は `-O max` / `-O experimental` でのみ起きる。`-O none` / `-O basic` では、punch した構造体が
`#plug_in_fu_p` へクロージャの捕捉として 1 度だけ渡り、`Release` が要らない。`-O max` では
インライン化によって actor の返す `Option` の分岐が同じ関数の中に現れ、`none` の枝で `ps` が死ぬ。
その枝の `Release` が、数える対象を持たない参照カウント操作である。

## G. この PR では直していない、隣接する欠陥

issue が名指した `Std::DynIterator::act_next` は、本 PR のあとも既定の最適化レベルでコンパイラを
落とす。落ちる場所は別で、`src/generator.rs` の `assert_eq!(field.parts().len(), cnt)`
（`left: 2, right: 0`）。`main`（`ae692f6e`）でも同じ場所で同じように落ちるので、本 PR が入れた
退行ではない。

条件は「自分自身を名指す型のフィールドを 1 つだけ持つ unbox 構造体」である。
`is_unwrappable_newtype_internal` は「フィールドの型に自分自身の型構築子が現れるか」を見るが、
`Rec#PunchedAt0` のフィールドの型に現れるのは `Rec` であって `Rec#PunchedAt0` ではないので、
穴の開いた形だけが循環でないと判定されて `()` に畳まれる。`DynIterator a` はこの形である。

**#235（#231 と #234 を閉じる、レビュー中）のコンパイラでは両方とも直っている**ことを実測した。
再現プログラム 2 つは #234 のコメントに置いた。