### PR TITLE
レビュー清掃 (#237): 穴の周りの重複統合とドキュメント

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -941,10 +941,10 @@ impl TypeNode {
     /// one per variant for a union, and the element field alone for `Array`. The field types carry
     /// the type parameters of the declaration; `field_types` substitutes this type's arguments in.
     pub fn fields(&self, type_env: &TypeEnv) -> Vec<Field> {
-        let args = self.collect_type_argments();
-        let ti = self.toplevel_tycon_info(type_env);
-        assert_eq!(args.len(), ti.tyvars.len());
-        ti.fields
+        self.fields_with_instance_types(&type_env.tycons)
+            .into_iter()
+            .map(|(field, _)| field)
+            .collect()
     }
 
     // The index of the struct/union field named `field_name`.

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -885,8 +885,9 @@ impl TypeNode {
     /// for a union, and the element type alone for `Array`, whose elements all share it. This type's
     /// arguments are substituted in, so the results are the field types at this instance.
     ///
-    /// This is the layout's answer, so a punched field's slot is among them, at the type it was
-    /// declared with; `value_field_types` answers which of the slots hold a value.
+    /// A punched field's slot is among them, at the type it was declared with, so a reader that can
+    /// meet a punched type wants this one only to lay the fields out or to address one by its index;
+    /// `value_field_types` answers which of the slots hold a value.
     pub fn field_types(&self, type_env: &TypeEnv) -> Vec<Arc<TypeNode>> {
         self.field_types_via_tycons(&type_env.tycons)
     }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -873,17 +873,20 @@ impl TypeNode {
         }
     }
 
-    // Take a struct type, and convert it to a punched version.
+    /// This struct type punched at field `punched_at`: a type of the same memory layout, whose
+    /// declaration marks that field as a hole the value has moved out of.
     pub fn to_punched_struct(self: &Arc<TypeNode>, punched_at: usize) -> Arc<TypeNode> {
         let mut tycon = self.toplevel_tycon().unwrap().as_ref().clone();
         tycon.into_punched_type_name(punched_at);
         self.set_toplevel_tycon(Arc::new(tycon))
     }
 
-    /// The types the fields of a value of this type hold: one per field for a struct, one per
-    /// variant for a union, and the element type alone for `Array`, whose elements all share it.
-    /// This type's arguments are substituted in, so the results are the field types at this
-    /// instance.
+    /// The type of every field slot this type declares: one per field for a struct, one per variant
+    /// for a union, and the element type alone for `Array`, whose elements all share it. This type's
+    /// arguments are substituted in, so the results are the field types at this instance.
+    ///
+    /// This is the layout's answer, so a punched field's slot is among them, at the type it was
+    /// declared with; `value_field_types` answers which of the slots hold a value.
     pub fn field_types(&self, type_env: &TypeEnv) -> Vec<Arc<TypeNode>> {
         self.field_types_via_tycons(&type_env.tycons)
     }
@@ -947,7 +950,8 @@ impl TypeNode {
             .collect()
     }
 
-    // The index of the struct/union field named `field_name`.
+    /// The index of the struct field or the union variant named `field_name`, which is the index it
+    /// sits at in the layout.
     pub fn field_index(&self, type_env: &TypeEnv, field_name: &str) -> Option<usize> {
         self.toplevel_tycon_info(type_env)
             .fields
@@ -976,7 +980,8 @@ impl TypeNode {
         tys
     }
 
-    // For type `f a b c` where `f` is a type constructor returns `vec![a, b, c]`.
+    /// The arguments applied to this type's head, in the order they are applied: `f a b c` gives
+    /// `vec![a, b, c]`.
     pub fn collect_type_argments(&self) -> Vec<Arc<TypeNode>> {
         let mut ret: Vec<Arc<TypeNode>> = vec![];
         match &self.ty {
@@ -1945,9 +1950,11 @@ pub fn tycon(name: FullName) -> Arc<TyCon> {
     Arc::new(TyCon { name })
 }
 
-// Additional information of types.
+/// What a type node carries beside the type itself.
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct TypeInfo {
+    /// The span of the source text the type was written at. A type the compiler builds itself has
+    /// none.
     source: Option<Span>,
 }
 

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4659,8 +4659,13 @@ impl LLVMGen for InlineLLVMCaptureProjectBody {
 /// `var_name`, and is returned together with the punched struct, whose type records the hole.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructPunchBody {
+    /// The operand: the struct the field is moved out of.
     pub var_name: FullName,
+    /// The index of the field moved out, in the struct's layout — the slot the result's punched
+    /// struct carries as a hole.
     field_idx: usize,
+    /// Whether a struct that is shared is cloned before the field is moved out. Where false, the
+    /// operand is taken to be uniquely owned already.
     pub(crate) force_unique: bool,
     /// Whether the object this op's declared uniqueness check tests is known to be in the local
     /// reference-counting state, so that the check reads the count without reading the state.
@@ -4814,20 +4819,15 @@ impl LLVMGen for InlineLLVMStructPunchBody {
 /// The index of the punched struct in the result of a struct punch, `(field, punched struct)`.
 const PUNCHED_STRUCT_FIELD: usize = 1;
 
-// Field punching function for a given struct.
-//
-// If the struct is `S` and the field is `x` of type `F`, then the function has the type `S -> (F, Sx)` where `Sx` is the punched `S` at the field `x`.
-// i.e., `Sx` has the same memory layout as `S`, but does not contain the field `x`.
-//
-// We are not sure whether we should clone the struct when a shared struct is given to `punch_x`.
-// If we do not clone the struct, it will lead to different types of values sharing the same memory area, which feels dangerous,
-// but we have not found an example that causes a memory management issue yet.
-//
-// There are two use cases for the current `punch_x` function.
-// One is the implementation of `act_x`, where the struct given to `punch_x` is guaranteed to be unique.
-// The other is the implementation of `mod_x`, where it is acceptable to clone the struct if it is shared.
-// So we have two versions of `punch_x`: one that does not clone the struct and one that does.
-// The above problem is unresolved, but the current use cases do not require solving this problem.
+/// The `punch_x` function of a struct: for a struct `S` with a field `x` of type `F`, a function of
+/// type `S -> (F, Sx)` that moves the field out. `Sx` is `S` punched at `x` — the memory layout of
+/// `S`, with the slot at `x` a hole whose value has moved out.
+///
+/// The field is handed over without being reference counted, so the struct it is taken out of has to
+/// be uniquely owned. `force_unique` picks how that is met, as `force_unique_or_assert` describes:
+/// forcing it clones a struct that is shared, and leaving it off takes the caller's guarantee that
+/// the struct is unique. That guarantee is what keeps `S` and `Sx` apart — a shared struct punched
+/// without a clone leaves the two types naming one region of memory.
 pub fn struct_punch(
     definition: &TypeDefn,
     field_name: &str,
@@ -4860,6 +4860,9 @@ pub fn struct_punch(
     (expr, scm)
 }
 
+/// The body of a struct's `plug_in_x`: the value bound to `field_name` is moved into the hole of the
+/// punched struct bound to `punched_struct_name`, giving back the struct type the hole was punched
+/// out of.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMStructPlugInBody {
     punched_struct_name: FullName,

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -571,16 +571,8 @@ pub(crate) fn truncate_to_unit(
             // boxed leaf under a union variant, or the punched array's inner array) keys to its root.
             break;
         }
-        // Here `cur` is an unboxed struct/tuple, so a well-formed unit/root path index is in range.
-        let fields = cur.field_types(type_env);
-        assert!(
-            idx < fields.len(),
-            "truncate_to_unit: path index {} out of range ({} fields)",
-            idx,
-            fields.len()
-        );
         out.push(idx);
-        cur = fields[idx].clone();
+        cur = field_type_at(&cur, idx, type_env, "truncate_to_unit");
     }
     out
 }
@@ -680,17 +672,24 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
         if cur.is_closure() || cur.is_rc_unit_root(type_env) || cur.is_fully_unboxed(type_env) {
             return None;
         }
-        // Here `cur` is an unboxed struct/tuple, so a well-formed unit/root path index is in range.
-        let fields = cur.field_types(type_env);
-        assert!(
-            idx < fields.len(),
-            "subtree_type: path index {} out of range ({} fields)",
-            idx,
-            fields.len()
-        );
-        cur = fields[idx].clone();
+        cur = field_type_at(&cur, idx, type_env, "subtree_type");
     }
     Some(cur)
+}
+
+/// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
+/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `what` names the
+/// walk in the message an out-of-range index aborts with.
+fn field_type_at(ty: &Arc<TypeNode>, idx: usize, type_env: &TypeEnv, what: &str) -> Arc<TypeNode> {
+    let fields = ty.field_types(type_env);
+    assert!(
+        idx < fields.len(),
+        "{}: path index {} out of range ({} fields)",
+        what,
+        idx,
+        fields.len()
+    );
+    fields[idx].clone()
 }
 
 #[cfg(test)]

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -7650,6 +7650,8 @@ pub fn test_get_errno() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `*` inside a struct literal or a tuple binds the components in the order they are written: the
+/// value of the one written first is held while the later one runs through its values.
 #[test]
 pub fn test_monadic_bind_and_make_struct_ordering() {
     let source = r##"
@@ -7684,6 +7686,9 @@ pub fn test_monadic_bind_and_make_struct_ordering() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `*` in a function application binds in the order the two are written: in `f(x)` and `f $ x` the
+/// function's value is held while the argument's runs through its values, and in `x.f` the
+/// argument's is held while the function's runs.
 #[test]
 pub fn test_monadic_bind_and_function_application_ordering() {
     let source = r##"
@@ -7709,6 +7714,9 @@ pub fn test_monadic_bind_and_function_application_ordering() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `act` on a uniquely owned struct, over the four combinations of a boxed or unboxed struct with a
+/// boxed or unboxed field, at an actor that yields a value and at one that yields nothing. The actor
+/// asserts that the array field it is handed is unique.
 #[test]
 pub fn test_struct_act() {
     let source = MAIN_MODULE_WITH_ARRAY_ASSERT_UNIQUE.to_string()
@@ -7789,6 +7797,9 @@ pub fn test_struct_act() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `act` on a struct the caller goes on holding, on one whose field is shared with another binding,
+/// and on both at once: the update leaves what the other holder sees as it was. Also covers a
+/// generic struct, and a functor whose `map` rebuilds the struct more than once.
 #[test]
 pub fn test_struct_act2() {
     let source = r##"
@@ -7974,6 +7985,8 @@ pub fn test_struct_act_on_a_shared_only_reference_counted_field() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// The `Functor` instance of a tuple maps its last component and leaves the earlier ones as they
+/// are, for a 1-tuple and a 2-tuple.
 #[test]
 pub fn test_tuple_functor() {
     let source = r##"


### PR DESCRIPTION
Refs #233

#237 のコードレビューが、変更したファイルの周辺（変更したハンクの外）で見つけた清掃である。#237 の
差分を読むときの邪魔にならないよう分けてある。振る舞いは変わらない。

## 重複の統合

### `TypeNode::fields`（`src/ast/types.rs`）

型が宣言するフィールドを並べて返す。型引数の取り出し・型構築子の情報の引き当て・引数の個数の検査を
自分で書いていたが、それは `fields_with_instance_types` がすでに行う手順そのものである。同じ手順を
1 か所にした。返す `Field` は宣言のもので変わらない（この型で具体化した型は対の 2 番目が持ち、
`fields` はそれを捨てる）。

規約: DRY。

### `field_type_at`（新規、`src/rc_ir/ownership.rs`）

`truncate_to_unit`（参照 1 本のパスを、それが属する参照カウント単位まで切り詰める）と `subtree_type`
（パスが名指す部分木の型を返す）は、どちらも「フィールドの型を並べ、添字が範囲内であることを同じ
文面で検査し、その型へ降りる」5 行を持っていた。関数にして両方をそこへ載せた。どちらの walk から
呼ばれたかは、範囲外で止まるときのメッセージに引数として渡る。

規約: 2 コピー目で関数化。

## ドキュメント

### `struct_punch`（`src/fixstd/builtin.rs`）

構造体からフィールドを取り出す `punch_x` を作る関数。前置きの `//` ブロックが、検討の経緯
（「クローンすべきかどうか自信がない」「メモリ管理の問題を起こす例はまだ見つかっていない」
「上記の問題は未解決だが、現在の用途では解く必要がない」）と、位置による参照（「上記の問題」）で
書かれていた。いまの契約 — 2 つの版がそれぞれ何を保証するか、その保証が破れると何が起きるか — を
述べる `///` に書き直した。

規約: 経緯を書かない / 参照は名前で行う / doc コメント。

### `field_types`（`src/ast/types.rs`）

「この型の値のフィールドが持つ型」と述べていたが、#237 が入れた `value_field_types` がその問いに
答える関数になった。`field_types` が答えるのはレイアウトの問い（穴になったフィールドの席も含む）
なので、そう述べ、どちらを読むべきかの分かれ目を書いた。

規約: doc コメント。

### そのほか

- `InlineLLVMStructPunchBody` の 3 つのフィールドと `InlineLLVMStructPlugInBody` に doc を付けた。
- `to_punched_struct`、`field_index`、`collect_type_argments`、`TypeInfo` とその `source` フィールド:
  `//` を内容のある `///` にした。
- `src/tests/test_basic.rs` の 5 つのテスト（`test_struct_act`、`test_struct_act2`、
  `test_tuple_functor`、`test_monadic_bind_and_make_struct_ordering`、
  `test_monadic_bind_and_function_application_ordering`）に、何の観点を確かめるテストかを 1 行で
  付けた。

## 振る舞いが変わらないこと

- 統合した 2 つは、どちらも既存の手順をそのまま呼び出しに置き換えたもので、返す値は同じである。
  `fields` は具体化した型を計算して捨てるようになるが、呼び出しは `ObjectFieldType::clone_struct`
  の 1 か所（コード生成時に構造体の複製を出すたび）だけである。
- ほかはすべてコメントである。
- `cargo test --release` は 1320 + 135 件すべて通る。

## 上限に達して残したもの

清掃は 1 ファイル 1 アスペクトあたり 5 件までとしているので、次が残っている。

- `src/fixstd/builtin.rs`: `InlineLLVMStructPlugInBody` の 4 フィールド、`struct_mod` /
  `struct_plug_in` / `struct_act` 系の `//` 見出し。ファイル全体では doc の無い item が 868 個。
- `src/ast/types.rs`: `new` / `new_arc` / `set_info` / `set_ty` / `kind` / `free_vars` /
  `type_tycon` / `tycon` / `flatten_type_application_inner` / `free_vars_to_vec_with_span` ほか、
  ファイル全体で 128 個。
- `src/tests/test_basic.rs`: 436 個のテストのうち 350 個に doc が無い（うち 7 個は `//` で書かれて
  いる）。

`impl LLVMGen` の各メソッド（`generate`、`name`、`free_vars_mut`、`result_prov`、`result_locality`
ほか）には doc を付けていない。トレイト側（`src/ast/inline_llvm.rs`）がそれぞれを詳しく述べており、
実装側に書くと言い換えになる。ファイル内の 78 個の実装がすべてそうなっている。
