### PR TITLE
穴の開いたフィールドを除く walk を、その名前で呼ぶ

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -887,7 +887,7 @@ impl TypeNode {
     ///
     /// A punched field's slot is among them, at the type it was declared with, so a reader that can
     /// meet a punched type wants this one only to lay the fields out or to address one by its index;
-    /// `value_field_types` answers which of the slots hold a value.
+    /// `unpunched_field_types` answers which of the slots hold a value.
     pub fn field_types(&self, type_env: &TypeEnv) -> Vec<Arc<TypeNode>> {
         self.field_types_via_tycons(&type_env.tycons)
     }
@@ -926,13 +926,13 @@ impl TypeNode {
             .collect()
     }
 
-    /// The types of the fields that hold a value, each with the index it sits at. A punched field is
-    /// a hole — the value it held has moved out — so it holds none and is left out here, while the
-    /// slot stays in the layout and keeps the index the other fields are addressed by.
+    /// The types of the fields that are not punched, each with the index it sits at. A punched field
+    /// is a hole: the value it held has moved out, so it holds nothing, while its slot stays in the
+    /// layout and the other fields keep the indices they are addressed by.
     ///
     /// This is what a walk over the values a type holds descends: reference counting reaches a hole's
     /// slot through no path, and reading one would read a value that has moved on.
-    pub fn value_field_types(&self, type_env: &TypeEnv) -> Vec<(usize, Arc<TypeNode>)> {
+    pub fn unpunched_field_types(&self, type_env: &TypeEnv) -> Vec<(usize, Arc<TypeNode>)> {
         self.fields_with_instance_types(&type_env.tycons)
             .into_iter()
             .enumerate()
@@ -1313,7 +1313,7 @@ impl TypeNode {
         if self.is_funptr() {
             return true;
         }
-        self.value_field_types(type_env)
+        self.unpunched_field_types(type_env)
             .iter()
             .all(|(_, field_ty)| field_ty.is_fully_unboxed(type_env))
     }

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -7895,7 +7895,7 @@ fn mutated_in_place_locality(
     value_path: &[usize],
 ) -> ExtShape {
     let payload_holds_boxed = arg_tys[value_arg]
-        .value_field_types(type_env)
+        .unpunched_field_types(type_env)
         .iter()
         .any(|(_, fty)| !boxed_leaf_paths(fty, type_env).is_empty());
     let value_leaf = if payload_holds_boxed {

--- a/src/object.rs
+++ b/src/object.rs
@@ -792,7 +792,7 @@ impl ObjectFieldType {
         mut dst: Object<'c>,
         state: RcState,
     ) -> Object<'c> {
-        for (i, _) in src.ty.value_field_types(gc.type_env()) {
+        for (i, _) in src.ty.unpunched_field_types(gc.type_env()) {
             // Retain the field.
             let field = ObjectFieldType::move_out_struct_field(gc, src, i as u32);
             gc.retain(field.clone(), state);
@@ -1091,7 +1091,7 @@ impl ObjectFieldType {
         } else {
             // The struct is unboxed, so the fields taken out are released by whoever receives them.
             // Releasing the fields left behind here accounts for the struct itself.
-            for (field_idx, _) in struct_obj.ty.value_field_types(gc.type_env()) {
+            for (field_idx, _) in struct_obj.ty.unpunched_field_types(gc.type_env()) {
                 let field_idx = field_idx as u32;
                 if !field_indices.iter().any(|i| *i == field_idx) {
                     let field = ObjectFieldType::move_out_struct_field(gc, struct_obj, field_idx);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -313,7 +313,7 @@ fn param_ownership_shape(
         // A field the value holds nothing at keeps its place in the shape, so that a shape index is a
         // field index.
         let mut children = vec![OwnershipShape::NoUnit; ty.field_types(type_env).len()];
-        for (i, fty) in ty.value_field_types(type_env) {
+        for (i, fty) in ty.unpunched_field_types(type_env) {
             path.push(i);
             children[i] = go(var, &fty, owned_units, type_env, path);
             path.pop();

--- a/src/rc_ir/leaf_map.rs
+++ b/src/rc_ir/leaf_map.rs
@@ -48,7 +48,7 @@ pub fn boxed_leaf_paths(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath
             out.push(path.clone());
             return;
         }
-        for (i, fty) in ty.value_field_types(type_env) {
+        for (i, fty) in ty.unpunched_field_types(type_env) {
             path.push(i);
             go(&fty, type_env, path, out);
             path.pop();

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -543,7 +543,7 @@ fn rc_units_go(
         out.push(path.clone());
         return;
     }
-    for (i, fty) in ty.value_field_types(type_env) {
+    for (i, fty) in ty.unpunched_field_types(type_env) {
         path.push(i);
         rc_units_go(&fty, type_env, path, out);
         path.pop();


### PR DESCRIPTION
Refs #233

`TypeNode::value_field_types` を `TypeNode::unpunched_field_types` に改名する。振る舞いは変わらない。

## この関数は何か

構造体のフィールドを `act_x` / `mod_x` で更新する途中には、そのフィールドが「穴」になった構造体の値が
現れる。穴になったフィールドは、**レイアウトの上では席を保ち**（更新が終わったとき値を書き戻す先が
要る）、**値の上では空である**（そこにあった値は更新の関数へ移った）。

`TypeNode::unpunched_field_types` は、その区別のうち後者を答える関数である。穴になっていない
フィールドの型を、それが座るフィールド番号と対にして返す。番号を対にして返すのは、フィールドを
名指す側 — レイアウトの構築、添字によるフィールドの読み書き、参照カウント単位のパス — が宣言の
番号で数えるからで、絞り込んだ列の中での位置ではその番号にならない。

型を辿って「この値が何を持つか」を述べる walk は、7 か所すべてがこの関数を降りる。

- `TypeNode::is_fully_unboxed` — 値が参照を 1 つも持たないか。
- `boxed_leaf_paths` — 値が持つ参照 1 本ごとのパス。
- `rc_units_go` — 参照カウント操作 1 回の対象ごとのパス。
- `param_ownership_shape` — パラメータの各単位が所有か借用か。
- `ObjectFieldType::clone_struct` — 構造体の値を複製する。
- `ObjectFieldType::get_struct_fields` — 指定されなかったフィールドを release する枝。
- `mutated_in_place_locality` — 書き込む値が参照を持つか。

## 何を変えるか

関数の名前と、その doc コメントの言い出しだけである。7 か所の呼び出しと、`field_types` の doc に
ある言及も同じ名前に揃う。

## なぜ

`value` はこのプロジェクトの語彙ではない。穴を指す語は `Field::is_punched` の `punched` であり、
`object.rs`・`typedecl.rs`・`ownership.rs`・`builtin.rs` はどれもその語で書かれている。
`value_field_types` は隣に並ぶ `field_types` との違いを名前で述べておらず、読み手は
「どのフィールドが除かれるのか」を doc まで読まないと分からない。`unpunched_field_types` は
その 1 語で答える。

`field_types` の側は変えない。そちらは宣言されたフィールドを穴も込みで並べる関数で、穴の開いた型に
出会い得る読み手 — オブジェクトのレイアウト構築、参照カウント単位のパスを降りる 2 か所、
フィールドの取り出し — はどれも添字で数えており、この関数を読むのが正しい。

## 振る舞いが変わらないこと

- Rust の識別子の改名のみで、文字列としてこの名前を読む箇所は無い（`.md` / `.fix` / `.toml` を
  含めてリポジトリ全体を検索し、旧名の残りが 0 件であることを確認した）。
- `cargo test --release` 1325 + 135 件、失敗 0。
