### PR TITLE
高階型変数を消す判定を最小不動点にする (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - A trait alias that stands for one trait along two paths is now accepted. `trait Ring = Ordered + Showable;`, where `Ordered` and `Showable` both stand for `Additive`, was rejected as circular aliasing, and the message named a trait of the standard library that the program never mentions.
 - Two implementations of one trait are now reported as overlapping when one of their heads takes a type parameter of a higher kind, as `impl [f : *->*] Bar f : MyTrait` does beside `impl Bar Array : MyTrait`. Both used to be accepted, and the order they were written in decided which one a call reached.
 - A program that uses an unboxed struct of one field whose type names the struct itself now compiles at `-O max` and `-O experimental`. `type Phantom a = unbox struct { x : I64 }; type C = unbox struct { y : Phantom C };` aborted the compiler as soon as a value of `C` was used, and so did `it.mod_next(f)`, which updates the one field of a `Std::DynIterator`.
+- A program whose types name each other in a cycle and reach a type of a higher-kinded parameter now compiles at `-O max` and `-O experimental`. `type [f : *->*] H f = unbox struct { d : f I64 }; type Y a = unbox struct { p : Array X, q : a }; type X = unbox struct { r : Y I64, s : H Array };` aborted the compiler, and writing the two fields of `X` in the other order made the same program compile.
 
 #### Std
 

--- a/src/optimization/remove_hktvs.rs
+++ b/src/optimization/remove_hktvs.rs
@@ -43,53 +43,85 @@ struct Env {
 
 impl Env {
     fn new(tycons: Map<TyCon, TyConInfo>) -> Self {
-        let mut env = Self {
+        let removed_tycons = calculate_removed_tycons(&tycons);
+        Self {
             tycons,
-            removed_tycons: Set::default(),
-        };
-        let tycons = env.tycons.keys().cloned().collect::<Vec<_>>();
-        let mut visited = Set::default();
-        for tycon in tycons {
-            env.calculate_removed_tycons_internal(&tycon, &mut visited);
+            removed_tycons,
         }
-        env
     }
 
     fn is_removed(&self, tycon: &TyCon) -> bool {
         self.removed_tycons.contains(tycon)
     }
+}
 
-    fn calculate_removed_tycons_internal(&mut self, now: &TyCon, visited: &mut Set<TyCon>) {
-        if visited.contains(now) {
-            return;
-        }
-        visited.insert(now.clone());
-        let ti = self.tycons.get(now).unwrap();
+// The type constructors this transformation replaces by a copy per list of type arguments: a struct
+// or a union declared with a higher-kinded type variable, and a struct or a union that names such a
+// declaration in the type of a field, transitively.
+//
+// The type of a field can name the declaration the field belongs to, directly or through other
+// declarations, so "transitively" is taken over a graph that has cycles and the answer is its least
+// fixed point. It is reached by propagating backwards along the edge "names in the type of a field",
+// starting from the declarations that carry a higher-kinded type variable.
+fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
+    // For each type constructor, the struct and union declarations naming it in the type of a field.
+    let mut named_by: Map<TyCon, Vec<TyCon>> = Map::default();
+    // The declarations to propagate from, which start as those carrying a higher-kinded type
+    // variable.
+    let mut pending = vec![];
+    for (tc, ti) in tycons {
         match ti.variant {
             TyConVariant::Struct | TyConVariant::Union => {}
             _ => {
-                return;
+                continue;
             }
         }
         if ti.tyvars.iter().any(|tv| tv.kind != kind_star()) {
-            self.removed_tycons.insert(now.clone());
-            return;
+            pending.push(tc.clone());
         }
-        let field_tys = ti
-            .fields
-            .iter()
-            .map(|field| field.ty.clone())
-            .collect::<Vec<_>>();
-        for field_ty in field_tys {
-            let mut tycons = Set::default();
-            field_ty.collect_tycons(&mut tycons);
-            for tycon in tycons {
-                self.calculate_removed_tycons_internal(&tycon, visited);
-                if self.removed_tycons.contains(&tycon) {
-                    self.removed_tycons.insert(now.clone());
-                    return;
-                }
+        for field in &ti.fields {
+            let mut field_tycons = Set::default();
+            field.ty.collect_tycons(&mut field_tycons);
+            for field_tycon in field_tycons {
+                named_by.entry(field_tycon).or_default().push(tc.clone());
             }
+        }
+    }
+
+    let mut removed_tycons = Set::default();
+    while let Some(tc) = pending.pop() {
+        if !removed_tycons.insert(tc.clone()) {
+            continue;
+        }
+        if let Some(namers) = named_by.get(&tc) {
+            pending.extend(namers.iter().cloned());
+        }
+    }
+
+    removed_tycons
+}
+
+// Every type constructor a remaining declaration names is itself declared.
+//
+// A declaration that takes type parameters is left as it is written, so the type constructors it
+// names have to be ones this transformation keeps. A violation surfaces far from its origin, as a
+// later pass looking a declaration up and finding nothing.
+fn assert_every_named_tycon_is_declared(tycons: &Map<TyCon, TyConInfo>) {
+    for (tc, ti) in tycons {
+        let mut named_tycons = Set::default();
+        for field in &ti.fields {
+            field.ty.collect_tycons(&mut named_tycons);
+        }
+        if let Some(struct_tc) = &ti.punched_from {
+            named_tycons.insert(struct_tc.clone());
+        }
+        for named_tycon in &named_tycons {
+            assert!(
+                tycons.contains_key(named_tycon),
+                "The declaration of `{}` names `{}`, which is not declared.",
+                tc.to_string(),
+                named_tycon.to_string()
+            );
         }
     }
 }
@@ -106,6 +138,8 @@ pub fn run(prg: &mut Program) {
 
     // Run on type environment.
     run_on_type_env(&mut env);
+
+    assert_every_named_tycon_is_declared(&env.tycons);
 
     prg.type_env.tycons = Arc::new(env.tycons);
 }
@@ -148,7 +182,12 @@ fn run_on_type_env(env: &mut Env) {
             }
             let mut ti = env.tycons.get(tc).unwrap().clone();
             if ti.tyvars.len() > 0 {
-                // If there are type variables, we cannot process it.
+                // The type of a field of such a declaration has the declaration's type parameters
+                // free in it, and `run_on_type` takes a type with no free type variable, so the
+                // declaration is left as it is written. A declaration naming a type constructor
+                // this transformation removes is removed as well, so one that stays names only
+                // type constructors that stay, which
+                // `assert_every_named_tycon_is_declared` checks.
                 continue;
             }
             for field in &mut ti.fields {
@@ -185,43 +224,6 @@ fn run_on_symbol(sym: &mut Symbol, env: &mut Env) {
         sym.expr = Some(res.expr);
     }
 }
-
-// fn is_subject_to_removal(tc: &TyCon, env: &Map<TyCon, TyConInfo>) -> bool {
-//     let mut visited = Set::default();
-//     is_subject_to_removal_internal(tc, env, &mut visited)
-// }
-
-// fn is_subject_to_removal_internal(
-//     tc: &TyCon,
-//     env: &Map<TyCon, TyConInfo>,
-//     visited: &mut Set<TyCon>,
-// ) -> bool {
-//     let ti = env.get(tc).unwrap();
-//     match ti.variant {
-//         TyConVariant::Struct | TyConVariant::Union => {}
-//         _ => {
-//             return false;
-//         }
-//     }
-//     if ti.tyvars.iter().any(|tv| tv.kind != kind_star()) {
-//         return true;
-//     }
-//     visited.insert(tc.clone());
-//     for field in &ti.fields {
-//         let field_ty = &field.ty;
-//         let mut tycons = Set::default();
-//         field_ty.collect_tycons(&mut tycons);
-//         for tycon in tycons {
-//             if visited.contains(&tycon) {
-//                 continue;
-//             }
-//             if is_subject_to_removal(&tycon, env) {
-//                 return true;
-//             }
-//         }
-//     }
-//     return false;
-// }
 
 fn run_on_type(ty: &Arc<TypeNode>, env: &mut Env) -> Arc<TypeNode> {
     assert!(

--- a/src/optimization/remove_hktvs.rs
+++ b/src/optimization/remove_hktvs.rs
@@ -55,16 +55,33 @@ impl Env {
     }
 }
 
+// The type constructors a declaration names: those appearing in the type of one of its fields, and,
+// for a declaration holding a struct with one field punched out, that struct.
+//
+// A declaration written in terms of a type constructor stands or falls with it, which is the edge
+// both `calculate_removed_tycons` and `assert_every_named_tycon_is_declared` are about, so they read
+// it from here and agree on what naming is.
+fn named_tycons(ti: &TyConInfo) -> Set<TyCon> {
+    let mut named_tycons = Set::default();
+    for field in &ti.fields {
+        field.ty.collect_tycons(&mut named_tycons);
+    }
+    if let Some(struct_tc) = &ti.punched_from {
+        named_tycons.insert(struct_tc.clone());
+    }
+    named_tycons
+}
+
 // The type constructors this transformation replaces by a copy per list of type arguments: a struct
 // or a union declared with a higher-kinded type variable, and a struct or a union that names such a
-// declaration in the type of a field, transitively.
+// declaration, transitively.
 //
-// The type of a field can name the declaration the field belongs to, directly or through other
-// declarations, so "transitively" is taken over a graph that has cycles and the answer is its least
-// fixed point. It is reached by propagating backwards along the edge "names in the type of a field",
-// starting from the declarations that carry a higher-kinded type variable.
+// A declaration can name itself, directly or through other declarations, so "transitively" is taken
+// over a graph that has cycles and the answer is its least fixed point. It is reached by propagating
+// backwards along the naming edge, starting from the declarations that carry a higher-kinded type
+// variable.
 fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
-    // For each type constructor, the struct and union declarations naming it in the type of a field.
+    // For each type constructor, the struct and union declarations naming it.
     let mut named_by: Map<TyCon, Vec<TyCon>> = Map::default();
     // The declarations to propagate from, which start as those carrying a higher-kinded type
     // variable.
@@ -79,12 +96,8 @@ fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
         if ti.tyvars.iter().any(|tv| tv.kind != kind_star()) {
             pending.push(tc.clone());
         }
-        for field in &ti.fields {
-            let mut field_tycons = Set::default();
-            field.ty.collect_tycons(&mut field_tycons);
-            for field_tycon in field_tycons {
-                named_by.entry(field_tycon).or_default().push(tc.clone());
-            }
+        for named_tycon in named_tycons(ti) {
+            named_by.entry(named_tycon).or_default().push(tc.clone());
         }
     }
 
@@ -108,16 +121,9 @@ fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
 // later pass looking a declaration up and finding nothing.
 fn assert_every_named_tycon_is_declared(tycons: &Map<TyCon, TyConInfo>) {
     for (tc, ti) in tycons {
-        let mut named_tycons = Set::default();
-        for field in &ti.fields {
-            field.ty.collect_tycons(&mut named_tycons);
-        }
-        if let Some(struct_tc) = &ti.punched_from {
-            named_tycons.insert(struct_tc.clone());
-        }
-        for named_tycon in &named_tycons {
+        for named_tycon in named_tycons(ti) {
             assert!(
-                tycons.contains_key(named_tycon),
+                tycons.contains_key(&named_tycon),
                 "The declaration of `{}` names `{}`, which is not declared.",
                 tc.to_string(),
                 named_tycon.to_string()

--- a/src/optimization/remove_hktvs.rs
+++ b/src/optimization/remove_hktvs.rs
@@ -85,7 +85,7 @@ fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
     let mut named_by: Map<TyCon, Vec<TyCon>> = Map::default();
     // The declarations to propagate from, which start as those carrying a higher-kinded type
     // variable.
-    let mut pending = vec![];
+    let mut pending_tycons = vec![];
     for (tc, ti) in tycons {
         match ti.variant {
             TyConVariant::Struct | TyConVariant::Union => {}
@@ -94,7 +94,7 @@ fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
             }
         }
         if ti.tyvars.iter().any(|tv| tv.kind != kind_star()) {
-            pending.push(tc.clone());
+            pending_tycons.push(tc.clone());
         }
         for named_tycon in named_tycons(ti) {
             named_by.entry(named_tycon).or_default().push(tc.clone());
@@ -102,12 +102,12 @@ fn calculate_removed_tycons(tycons: &Map<TyCon, TyConInfo>) -> Set<TyCon> {
     }
 
     let mut removed_tycons = Set::default();
-    while let Some(tc) = pending.pop() {
+    while let Some(tc) = pending_tycons.pop() {
         if !removed_tycons.insert(tc.clone()) {
             continue;
         }
         if let Some(namers) = named_by.get(&tc) {
-            pending.extend(namers.iter().cloned());
+            pending_tycons.extend(namers.iter().cloned());
         }
     }
 

--- a/src/optimization/remove_hktvs.rs
+++ b/src/optimization/remove_hktvs.rs
@@ -58,9 +58,8 @@ impl Env {
 // The type constructors a declaration names: those appearing in the type of one of its fields, and,
 // for a declaration holding a struct with one field punched out, that struct.
 //
-// A declaration written in terms of a type constructor stands or falls with it, which is the edge
-// both `calculate_removed_tycons` and `assert_every_named_tycon_is_declared` are about, so they read
-// it from here and agree on what naming is.
+// A declaration written in terms of a type constructor stands or falls with it, so this is the
+// edge along which removal propagates.
 fn named_tycons(ti: &TyConInfo) -> Set<TyCon> {
     let mut named_tycons = Set::default();
     for field in &ti.fields {

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -11558,6 +11558,63 @@ main = (
     test_source(&source, Configuration::develop_mode());
 }
 
+// A union and a boxed struct that carry a higher-kinded type variable, beside a struct that carries
+// one, all three reached from one cycle of types. The compiler rebuilds each of them per
+// type-argument list, keeping a union's variants and a boxed struct's boxedness, and the same
+// declaration rebuilt at two different type arguments stays two types.
+#[test]
+pub fn test_higher_kinded_union_and_boxed_struct_reached_from_a_type_cycle() {
+    let source = r##"
+module Main;
+
+type [f : *->*] H f = unbox struct { d : f I64, n : I64 };
+type [f : *->*] U f = unbox union { left : f I64, right : I64 };
+type [f : *->*] B f = box struct { b : f I64, tag : Bool };
+
+type Y a = unbox struct { p : Array X, q : a };
+type X = unbox struct { r : Y I64, s : H Array, t : U Option, u : B Array };
+
+sum_x : X -> I64;
+sum_x = |x| (
+    let a = x.@r.@q;
+    let b = x.@s.@d.to_iter.fold(0, Add::add) + x.@s.@n;
+    let c = if x.@t.is_left {
+        if x.@t.as_left.is_some { x.@t.as_left.as_some } else { 0 }
+    } else { x.@t.as_right };
+    let d = x.@u.@b.to_iter.fold(0, Add::add) + (if x.@u.@tag { 100 } else { 200 });
+    a + b + c + d + x.@r.@p.@size
+);
+
+main : IO ();
+main = (
+    let x0 = X {
+        r : Y { p : [], q : 3 },
+        s : H { d : [1, 2, 3], n : 10 },
+        t : U::left(Option::some(5)),
+        u : B { b : [7, 8], tag : true }
+    };
+    assert_eq(|_|"", sum_x(x0), 139);;
+    let x1 = x0.mod_s(|h| h.mod_d(|d| d.push_back(4)).set_n(20));
+    assert_eq(|_|"", sum_x(x1), 153);;
+    let x2 = x1.mod_t(|_| U::right(9));
+    assert_eq(|_|"", sum_x(x2), 157);;
+    let x3 = x2.mod_u(|b| b.set_tag(false));
+    assert_eq(|_|"", sum_x(x3), 257);;
+    let x4 = x3.mod_r(|y| y.mod_p(|ps| ps.push_back(x0)).set_q(30));
+    assert_eq(|_|"", sum_x(x4), 285);;
+    let (taken, rest) = x4.act_s(|h| (h.@n, h.set_n(0)));
+    assert_eq(|_|"", taken, 20);;
+    assert_eq(|_|"", sum_x(rest), 265);;
+    let h_arr : H Array = H { d : [9], n : 1 };
+    assert_eq(|_|"", h_arr.@d.@(0), 9);;
+    let h_opt : H Option = H { d : Option::some(11), n : 2 };
+    assert_eq(|_|"", h_opt.@d.as_some, 11);;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
 // Updating and taking apart a field of a type that takes a type parameter and sits in a cycle
 // reaching a type of a higher-kinded parameter. Updating a field holds the rest of the value in the
 // type with that field punched out, which carries the type argument the value was made at, so the

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -11531,7 +11531,7 @@ main = (
 // the struct with that field punched out, which names what the struct names and so is rebuilt
 // alongside it.
 #[test]
-pub fn test_field_operations_on_a_type_cycle_reaching_a_higher_kinded_type_variable() {
+pub fn test_field_operations_on_a_type_in_a_cycle_reaching_a_higher_kinded_type_variable() {
     let source = r##"
 module Main;
 

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -11498,28 +11498,28 @@ main = (
     test_source(&source, Configuration::develop_mode());
 }
 
-// A cycle of three types, one of them a union, reaching a type of a higher-kinded parameter from its
-// last member. A type is rebuilt when it names a rebuilt type in the type of a field, and a union
-// carries that the way a struct does, so the whole cycle is rebuilt from a reach that only one of
-// its members has.
+// A union that takes a type parameter, sitting in a cycle that reaches a type of a higher-kinded
+// parameter through the struct it names. A declaration that takes type parameters is left as it is
+// written, so the union has to be rebuilt per type-argument list together with the struct it names,
+// which the compiler decides for a union the way it decides it for a struct.
 #[test]
-pub fn test_union_in_a_type_cycle_reaching_a_higher_kinded_type_variable() {
+pub fn test_parameterized_union_in_a_type_cycle_reaching_a_higher_kinded_type_variable() {
     let source = r##"
 module Main;
 
 type [f : *->*] H f = unbox struct { d : f I64 };
-type U = unbox union { l : Array V, r : I64 };
-type V = unbox struct { m : Array W };
-type W = unbox struct { u : Array U, h : H Array };
+type Y a = unbox union { p : Array X, q : a };
+type X = unbox struct { r : Y I64, s : H Array };
 
 main : IO ();
 main = (
-    let w = W { u : [U::r(3)], h : H { d : [1, 2] } };
-    let u : U = U::l([V { m : [w] }]);
-    assert_eq(|_|"", u.as_l.@(0).@m.@(0).@u.@(0).as_r, 3);;
-    assert_eq(|_|"", u.as_l.@(0).@m.@(0).@h.@d.@size, 2);;
-    let u = u.mod_l(|vs| vs.push_back(V { m : [] }));
-    assert_eq(|_|"", u.as_l.@size, 2);;
+    let x = X { r : Y::q(7), s : H { d : [1, 2] } };
+    assert_eq(|_|"", x.@r.as_q, 7);;
+    assert_eq(|_|"", x.@s.@d.@size, 2);;
+    let y : Y String = Y::q("hi");
+    assert_eq(|_|"", y.as_q, "hi");;
+    let y : Y I64 = Y::p([x]);
+    assert_eq(|_|"", y.as_p.@(0).@s.@d.@size, 2);;
     pure()
 );
     "##;
@@ -11552,6 +11552,37 @@ main = (
     let X { r : y, s : h } = x;
     assert_eq(|_|"", y.@q, 8);;
     assert_eq(|_|"", h.@d.@size, 3);;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// Updating and taking apart a field of a type that takes a type parameter and sits in a cycle
+// reaching a type of a higher-kinded parameter. Updating a field holds the rest of the value in the
+// type with that field punched out, which carries the type argument the value was made at, so the
+// punched form is rebuilt per type-argument list alongside the type it is punched from.
+#[test]
+pub fn test_field_update_on_a_parameterized_type_in_a_cycle_reaching_a_higher_kinded_type_variable()
+{
+    let source = r##"
+module Main;
+
+type [f : *->*] H f = unbox struct { d : f I64 };
+type Y a = unbox struct { p : Array X, q : a };
+type X = unbox struct { r : Y I64, s : H Array };
+
+main : IO ();
+main = (
+    let y : Y I64 = Y { p : [], q : 7 };
+    let y = y.mod_q(|v| v + 1);
+    assert_eq(|_|"", y.@q, 8);;
+    let t : (I64, Y I64) = y.act_p(|ps| (ps.@size, ps.push_back(X { r : y, s : H { d : [1] } })));
+    assert_eq(|_|"", t.@0, 0);;
+    assert_eq(|_|"", t.@1.@p.@(0).@s.@d.@size, 1);;
+    let z : Y String = Y { p : [], q : "hi" };
+    let z = z.mod_q(|s| s + "!");
+    assert_eq(|_|"", z.@q, "hi!");;
     pure()
 );
     "##;

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -11463,6 +11463,101 @@ main = (
     test_source(&source, Configuration::develop_mode());
 }
 
+// Types that name each other in a cycle and reach a type of a higher-kinded parameter, written once
+// in each field order. The compiler rebuilds such a type per type-argument list, and rebuilds every
+// type that names one, so each member of a cycle among them is rebuilt together with the rest of the
+// cycle however the fields are ordered.
+#[test]
+pub fn test_type_cycle_reaching_a_higher_kinded_type_variable() {
+    let source = r##"
+module Main;
+
+type [f : *->*] H f = unbox struct { d : f I64 };
+
+type FirstY a = unbox struct { p : Array FirstX, q : a };
+type FirstX = unbox struct { r : FirstY I64, s : H Array };
+
+type SecondY a = unbox struct { p : Array SecondX, q : a };
+type SecondX = unbox struct { s : H Array, r : SecondY I64 };
+
+main : IO ();
+main = (
+    let x = FirstX { r : FirstY { p : [], q : 7 }, s : H { d : [1, 2] } };
+    assert_eq(|_|"", x.@r.@q, 7);;
+    assert_eq(|_|"", x.@s.@d.@size, 2);;
+    let y : FirstY String = FirstY { p : [], q : "hi" };
+    assert_eq(|_|"", y.@q, "hi");;
+    let x = SecondX { r : SecondY { p : [], q : 7 }, s : H { d : [1, 2] } };
+    assert_eq(|_|"", x.@r.@q, 7);;
+    assert_eq(|_|"", x.@s.@d.@size, 2);;
+    let y : SecondY String = SecondY { p : [], q : "hi" };
+    assert_eq(|_|"", y.@q, "hi");;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// A cycle of three types, one of them a union, reaching a type of a higher-kinded parameter from its
+// last member. A type is rebuilt when it names a rebuilt type in the type of a field, and a union
+// carries that the way a struct does, so the whole cycle is rebuilt from a reach that only one of
+// its members has.
+#[test]
+pub fn test_union_in_a_type_cycle_reaching_a_higher_kinded_type_variable() {
+    let source = r##"
+module Main;
+
+type [f : *->*] H f = unbox struct { d : f I64 };
+type U = unbox union { l : Array V, r : I64 };
+type V = unbox struct { m : Array W };
+type W = unbox struct { u : Array U, h : H Array };
+
+main : IO ();
+main = (
+    let w = W { u : [U::r(3)], h : H { d : [1, 2] } };
+    let u : U = U::l([V { m : [w] }]);
+    assert_eq(|_|"", u.as_l.@(0).@m.@(0).@u.@(0).as_r, 3);;
+    assert_eq(|_|"", u.as_l.@(0).@m.@(0).@h.@d.@size, 2);;
+    let u = u.mod_l(|vs| vs.push_back(V { m : [] }));
+    assert_eq(|_|"", u.as_l.@size, 2);;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+// Reading, replacing, updating and destructuring the fields of a type that sits in a cycle reaching
+// a type of a higher-kinded parameter. Updating a field holds the rest of the struct in the type of
+// the struct with that field punched out, which names what the struct names and so is rebuilt
+// alongside it.
+#[test]
+pub fn test_field_operations_on_a_type_cycle_reaching_a_higher_kinded_type_variable() {
+    let source = r##"
+module Main;
+
+type [f : *->*] H f = unbox struct { d : f I64 };
+type Y a = unbox struct { p : Array X, q : a };
+type X = unbox struct { r : Y I64, s : H Array };
+
+main : IO ();
+main = (
+    let x = X { r : Y { p : [], q : 7 }, s : H { d : [1, 2] } };
+    let x = x.mod_r(|y| y.set_q(y.@q + 1));
+    assert_eq(|_|"", x.@r.@q, 8);;
+    let x = x.mod_s(|h| H { d : h.@d.push_back(3) });
+    assert_eq(|_|"", x.@s.@d.@size, 3);;
+    let t : (I64, X) = x.act_r(|y| (y.@q * 10, y.set_q(0)));
+    assert_eq(|_|"", t.@0, 80);;
+    assert_eq(|_|"", t.@1.@r.@q, 0);;
+    let X { r : y, s : h } = x;
+    assert_eq(|_|"", y.@q, 8);;
+    assert_eq(|_|"", h.@d.@size, 3);;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
 // Two types that name each other through the type argument of a phantom type, so each is reached
 // from itself in two steps. Neither is a type the compiler may replace with its field, and
 // unwrapping the phantom type leaves both of them one-field unboxed structs whose field operations


### PR DESCRIPTION
Closes #239

正しいプログラムが、既定の最適化レベルでコンパイラを落としていた。しかも落ちるかどうかが**フィールドを書いた順**と**型構築子のマップのハッシュ順**で変わるので、無関係な型を 1 つ足しただけで通っていたプログラムが落ちうる。判定を、順序に依存しない最小不動点に置き換える。

```fix
module Main;

type [f : *->*] H f = unbox struct { d : f I64 };
type Y a = unbox struct { p : Array X, q : a };
type X = unbox struct { r : Y I64, s : H Array };

main : IO ();
main = (
    let x = X { r : Y { p : [], q : 7 }, s : H { d : [1, 2] } };
    println $ x.@r.@q.to_string;;
    println $ x.@s.@d.@size.to_string;;
    pure()
);
```

```
$ fix run -f prog.fix -O none      # 7 / 2
$ fix run -f prog.fix -O max
thread '<unnamed>' panicked at src/optimization/unwrap_newtype.rs: called `Option::unwrap()` on a `None` value
```

`X` のフィールドを `{ s : H Array, r : Y I64 }` の順に書き直すと、同じプログラムが通る。

## 前提: 高階型変数を消す変換

型変数はふつう型そのものを表すが、Fix では**型を取る型変数**も書ける。`type [f : *->*] H f = unbox struct { d : f I64 };` の `f` は、`Array` や `Option` のような、型を 1 つ取って型になるものを表す。`H Array` の中身は `Array I64`、`H Option` の中身は `Option I64` である。

`remove_hktvs` パスは、`H Array` のような**型引数の組ごとに専用の型構築子を作り直し**、元の `H` を型環境 (型構築子の名前から、その宣言 — フィールドの型と型パラメータ — への表) から取り除く。作り直しの対象は `H` だけではない。`H` を名指す型をフィールドに持つ型も、そのフィールドの型を書き換える必要があるので、同じく作り直しの対象になる。

このパスが在るのは、直後に走る `unwrap_newtype` のためである。コード生成自体は高階の型変数を持つ型構築子を扱えるので、このパスは `-O max` 以上でしか走らない。上のプログラムが `-O none` と `-O basic` で動くのはそのためである。

どの型構築子を取り除くかは、この 2 つの規則で決まる。

1. 高階の型変数を持つ宣言は取り除く。
2. 取り除く型構築子を名指す宣言も取り除く。

## 欠陥の機構

### 関わる関数

- **`Env::new`** — このパスの環境を組み立てる。中心は「どの型構築子を取り除くか」を先に全部決めることで、パスの残りはその答えを引くだけになる。
- **`calculate_removed_tycons_internal`** (削除)— 上の 2 規則をフィールド型のグラフ上で解いていた。訪問済み集合 1 つを持つ深さ優先探索で、節点に降りる直前にその節点を訪問済みに入れる。
- **`run_on_type_env`** — 残った宣言のフィールド型を書き換える。ただし**型パラメータを持つ宣言は書き換えない**。そのフィールドの型にはパラメータが自由変数として現れ、書き換えを行う `run_on_type` は自由変数を含まない型しか受け取らないからである。

### 落ちる実行

訪問済みの印が意味しているのは「答えが出た」ではなく「**降り始めた**」である。冒頭のプログラムで、外側のループが `X` から入るとこうなる。

1. `X` に降りる。訪問済み `{X}`。`X` に高階の型変数は無い。第 1 フィールド `r : Y I64` に現れる型構築子は `Y` なので、`Y` に降りる。
2. `Y` に降りる。訪問済み `{X, Y}`。フィールド `p : Array X` に現れる型構築子は `Array` と `X`。`X` に降りようとするが訪問済みなので即座に戻る。**このとき `X` はまだ取り除くと決まっていない**ので、取り除く集合に `X` は入っていない。`Y` はフィールドを使い切り、**「取り除かない」で確定する**。
3. `X` に戻る。`Y` は取り除く集合に無いので次へ進む。第 2 フィールド `s : H Array` から `H` に降りる。`H` は高階の型変数を持つので取り除く集合に入る。よって `X` も取り除く集合に入る。
4. 取り除く集合は `{H, X}`。**`Y` は手順 2 で確定済みなので、見直されない。**

この答えを持って `run_on_type_env` が走る。`X` は取り除く対象なので飛ばされる。`Y` は型パラメータを持つので、フィールド `p : Array X` は `Array X` のまま残る。パスの最後に `X` と `H` が型環境から削除され、**残った `Y` の宣言が、もう宣言されていない `X` を名指している**状態になる。

次に走る `unwrap_newtype` は、型を書き換えるときに型構築子の宣言を引く。`X` の宣言は無いので `None` を unwrap して落ちる。落ちる場所は型の形によって変わる (1 フィールド構造体なら別の関数の中) が、原因は同じである。

`X` のフィールドの順が逆なら手順 3 が手順 1 より先に来る。`X` が先に確定し、`Y` はそのあと正しく「取り除く」になる。順序が答えを変えるのはここである。

### 直った実行

**`calculate_removed_tycons`** (新規) は、同じ 2 規則を**逆向きの伝播**で解く。フィールド型のグラフには閉路がありうるので、答えはその最小不動点であり、それは訪問順に依存しない。

まず「名指す」の逆辺を作る。ある型構築子に対して、それを名指している struct / union の宣言の一覧である。次に、高階の型変数を持つ宣言を種として置き、取り出しては取り除く集合に入れ、その逆辺の先を新たに積む。同じ節点は 2 度展開しない。

同じプログラムでは、逆辺はこうなる。`Y` は `Array` と `X` を名指し、`X` は `Y` と `H` と `Array` を名指す。種は `H` だけ。

1. `H` を取り出す。取り除く集合 `{H}`。`H` を名指すのは `X` なので `X` を積む。
2. `X` を取り出す。取り除く集合 `{H, X}`。`X` を名指すのは `Y` なので `Y` を積む。
3. `Y` を取り出す。取り除く集合 `{H, X, Y}`。積むものは無い。

`Y` も取り除く対象になった。よって `run_on_type_env` は `Y` を飛ばし、`Y` の宣言はパスの最後に型環境から削除される。**取り除かれた型構築子を名指す宣言は 1 つも残らない。**

この結論は、`X` のフィールドをどちらの順で書いても、型構築子のマップをどの順に走査しても同じである。最小不動点は一意だからである。

## 壁: 出口での表明

**`assert_every_named_tycon_is_declared`** (新規) を `run` の出口に置く。残っているどの宣言についても、それが名指す型構築子がすべて宣言されていることを確かめる。

この表明は `run_on_type_env` が型パラメータを持つ宣言を書き換えずに残すことの**安全性そのもの**を述べている。書き換えないでよいのは、取り除く型構築子を名指す宣言もまた取り除かれるからで、それが成り立つ限り、残る宣言が名指すのは残る型構築子だけである。

いま起きていたのは「その食い違いが、次のパスの `unwrap()` として、原因から離れた場所で現れる」ことだった。表明はそれを起点へ引き戻す。実際に、修正前の探索に戻して表明だけ残すと、`unwrap_newtype` の `unwrap()` より先に、自分の言葉で報告する。

```
The declaration of `Main::Y` names `Main::X`, which is not declared.
```

**この表明が鳴ることは確かめてある** (付録)。沈黙を信用してよい。

## 「名指す」を 1 か所から読む

**`named_tycons`** (新規) は、1 つの宣言が名指す型構築子を答える。フィールドの型に現れるものと、穴あき宣言 (`mod_` や `act_` がフィールドを取り出している間、構造体の残りを収める型) についてはその元の構造体である。

伝播と表明はどちらもこの関係を問う。分けて書くと、伝播はフィールドの型だけを数え、表明は元の構造体も数える、というように**別の定義**になりうる。実際そうなっていた。穴あき宣言は元の構造体と同じ型パラメータと同じフィールド列を持つので、答えはどちらの定義でも一致する — つまり伝播が正しいのは偶然に乗っていた。1 か所から読めば、一致は構成による。

**この統一は観測できる挙動を変えない** (付録に測定)。偶然を取り除くだけである。

## 変更履歴

`CHANGELOG.md` の `### Fixed` / `#### Language` に 1 項目。

> - A program whose types name each other in a cycle and reach a type of a higher-kinded parameter now compiles at `-O max` and `-O experimental`. `type [f : *->*] H f = unbox struct { d : f I64 }; type Y a = unbox struct { p : Array X, q : a }; type X = unbox struct { r : Y I64, s : H Array };` aborted the compiler, and writing the two fields of `X` in the other order made the same program compile.

## テスト

`src/tests/test_basic.rs` に 5 本。**誤った答えが観測できるのは、型パラメータを持つ宣言を通してだけ**である。`run_on_type_env` がそのまま残すのがその宣言だからで、パラメータを持たない宣言はフィールドが書き換えられるので、判定を取りこぼしても表に出ない。5 本ともその軸に乗せてある。

- `test_type_cycle_reaching_a_higher_kinded_type_variable` — 同じ閉路をフィールドの両方の順で 1 つのプログラムに書く。答えが順序に依存しないことを固定する。
- `test_parameterized_union_in_a_type_cycle_reaching_a_higher_kinded_type_variable` — 閉路の中の、型パラメータを持つ union。
- `test_field_operations_on_a_type_in_a_cycle_reaching_a_higher_kinded_type_variable` — 閉路の中の型のフィールドの読み・置換・更新・分解。
- `test_field_update_on_a_parameterized_type_in_a_cycle_reaching_a_higher_kinded_type_variable` — 型パラメータを持つ型のフィールド更新。穴あき形に型引数が付いた経路を通る。
- `test_higher_kinded_union_and_boxed_struct_reached_from_a_type_cycle` — 高階の型変数の担い手が union と boxed struct の場合、および同じ宣言を 2 つの型引数で使う場合。

5 本とも、修正前の探索に戻すと落ちることを確認済み。

---

# 付録

## A. 判定が変わる範囲

修正前後で判定を両方計算して一致を表明する probe を入れ、オブジェクトキャッシュを消してテスト一式を走らせた。

| | 数 |
|---|--:|
| このパスが実際に走ったコンパイル | 795 |
| 2 つの答えが一致したもの | 792 |
| 食い違ったもの | 3 |

食い違った 3 件は、この修正のために足したテストそのもの。**既存のプログラムで判定が変わるものは 1 つも無い。** 不動点の答えは探索の答えの上位集合になる (探索が印を付けるのは上の 2 規則のどちらかを適用したときだけで、どちらも不動点が認める理由である) ことも、同じ probe で 795 件すべてについて確かめた。

## B. 表明が鳴ることの確認

伝播を修正前の探索に戻し、表明だけ残してテストを走らせた。上の 3 件で、`unwrap_newtype` の `unwrap()` より先に、原因の宣言を名指して報告する。修正後の伝播では 795 件すべてで無発火。

## C. `named_tycons` の統一が変えるもの

不動点がある状態で、穴あき宣言の辺だけを伝播から外して 5 本のテストを走らせた。**全部通る。** この辺は観測できる挙動を持たず、伝播と表明の定義を一致させるためだけにある。

## D. 全テスト

release で 1348 + 135、失敗ゼロ。

## E. コーパス

命令数とメモリ参照数は動かない。判定の変わるプログラムがコーパスに 1 つも無い (付録 A) ので、生成されるコードは同一である。

## F. このパスに残る欠陥 (この変更の対象外)

バグハントで見つかった、この変更とは独立の既存欠陥を **#245** に起票した。捨てられる引数位置で増大する型族が高階型変数に届くと、`run_on_type` が型引数の組ごとの複製を無限に作り続け、メモリを食い尽くす。`-O none` と `-O basic` では正しく動く。

```fix
type [f : *->*] H f = unbox struct { d : f I64 };
type Ph a = unbox struct { z : I64 };
type Y a = unbox struct { p : Ph (Y (Array a)), h : H Array };
```

このプログラムは分岐点のコンパイラでも同じく終わらないので、この変更による退行ではない。

**この変更が新たに停止しなくさせるプログラムがあるか**は、正面から確かめた。不動点は探索より多く取り除くので、新たに取り除かれるようになった型パラメータ付きの宣言が上の成長を持てば、新たにこのループに入りうる。その形を構成した (`Y` が `H` に閉路を経由してのみ届き、かつ `Ph` による成長を持つ) が、**分岐点のコンパイラでも同じく終わらなかった**。残る隙間は、判定が変わるうえに誰もその宣言を引かず、分岐点では最後まで通っていたプログラムで、それは見つかっていない。付録 A のとおり、判定が変わる既存プログラムは 1 つも無い。

**#245 の方針が決まったことで、この隙間は構成的に閉じる。** #245 は「型引数の連鎖が伸びるプログラムを、最適化の前に走るバリデーションで落とす」を採る。受理されたプログラムでは連鎖が伸びないので、`run_on_type` が作る型構築子の集合は有限であり、判定がどちらに変わろうとこのループには入らない。

なお #245 のバリデーションはこの変更を不要にしない。#239 の再現プログラムは増大しないので受理される (閉包は `{X, Y I64, H Array, Array X, Array I64}` で有限)。受理されたうえで、深さ優先探索が `Y` を誤って確定させる。2 つは独立した欠陥である。