### PR TITLE
unwrap_newtype が前段の変換に要求していることを書く

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -711,11 +711,13 @@ impl Configuration {
     }
 
     pub fn enable_remove_hktvs_transformation(&self) -> bool {
-        self.force_all_optimizations() || self.enable_unwrap_newtype_optimization()
+        // PROBE: is the pair optional for everything downstream?
+        false
     }
 
     pub fn enable_unwrap_newtype_optimization(&self) -> bool {
-        self.force_all_optimizations() || self.fix_opt_level >= FixOptimizationLevel::Max
+        // PROBE: turned off together with remove_hktvs.
+        false
     }
 
     pub fn enable_inline_optimization(&self) -> bool {

--- a/src/optimization/unwrap_newtype.rs
+++ b/src/optimization/unwrap_newtype.rs
@@ -6,9 +6,20 @@
 //! field would not terminate. `NewtypeUnwrapping` decides that by walking the type constructors
 //! reachable through field types.
 //!
-//! This optimization should be run after the remove-hk-tyvar transform.
-//! The unwrap-newtype optimization cannot be applied to programs with generic type definitions such as `type [f : * -> *] Foo f = box struct { data : f () };`.
-//! This is because if there is an expression with a type like `Foo IO`, `IO` is a partially applied type and cannot be unwrapped.
+//! A newtype that takes type parameters is replaced at each instance, with the field type read at
+//! that instance, so `Foo Bool` of `type Foo a = unbox struct { data : () -> a };` becomes
+//! `() -> Bool`. What a replacement does require is that the type constructor appears saturated
+//! everywhere it occurs, since a type constructor is dropped from the type environment once it is
+//! replaced, and an occurrence left standing would name a type constructor that is no longer
+//! declared. The transform that removes higher-kinded type variables establishes that, and runs
+//! first.
+//!
+//! A higher-kinded type variable is the only way a type constructor reaches a program's types
+//! without its arguments, and one it carries can be a newtype. Take
+//! `type [f : *->*] Foo f = box struct { data : f () };` and a program holding a `Foo IO`. `Foo` is
+//! boxed, so this pass keeps it, and the bare `IO` stays inside it. `IO` is itself a newtype
+//! (`type IO a = unbox struct { runner : IOState -> (IOState, a) };`), so `IO ()` and `IO I64` are
+//! replaced and `IO` is dropped — while the bare `IO` inside `Foo IO` still names it.
 
 use crate::{
     ast::{


### PR DESCRIPTION
`src/optimization/unwrap_newtype.rs` の冒頭 3 行を書き直す。コードは変えない。

## 何が読みづらいか

`unwrap_newtype` は、1 フィールドの unbox 構造体 (newtype) を、そのフィールドの型で置き換える最適化である。その冒頭に、前段の変換との関係が 3 行で書かれている。

```
//! This optimization should be run after the remove-hk-tyvar transform.
//! The unwrap-newtype optimization cannot be applied to programs with generic type definitions such as `type [f : * -> *] Foo f = box struct { data : f () };`.
//! This is because if there is an expression with a type like `Foo IO`, `IO` is a partially applied type and cannot be unwrapped.
```

述べていること自体は正しい。読み手に渡っていないものが 3 つある。

**1. 要求している性質が書かれていない。** 「remove-hk-tyvar の後に走らせるべき」とあるが、何を保証してほしいのかが無い。実際に要るのは「このパスが置き換える型構築子が、どの出現でも飽和していること」である。置き換えた型構築子はその宣言ごと型環境から落とされるので、飽和していない出現が 1 つでも残ると、そこが宣言されていない型構築子を名指すことになる。

**2. 例の要になっている事実が書かれていない。** 例が成り立つのは `IO` 自身が newtype (`type IO a = unbox struct { runner : IOState -> (IOState, a) };`) だからである。それが書かれていないので、「`IO` は畳めない」が、なぜ困るのかの分からない事実として読める。

**3. `box` が効いていることが見えない。** `Foo` が box であることは例の要である。`Foo` が box なので **このパスは `Foo IO` を畳まず、中の裸の `IO` もろとも残す**。もし `Foo` が unbox の 1 フィールド構造体なら `Foo IO` 自身が `IO ()` に畳まれ、裸の `IO` は消えて例が成立しない。読み手はこの分岐を自分で埋める必要がある。

加えて、2 行目の「generic type definitions には適用できない」は範囲が広すぎる。型パラメータを持つ newtype はその実例ごとに畳めており、`unwrap_type` の中のコメント自身がそう述べている。

```rust
// First, replace the top-level type constructor if it is a newtype. The field type is taken
// at this instance, so `Foo Bool` of `type Foo a = unbox struct { data : () -> a }` becomes
// `() -> Bool`.
```

畳めないのは**部分適用**であり、それが起きるのは高階の型変数がある場合に限られる。

## 書き直したもの

```
//! A newtype that takes type parameters is replaced at each instance, with the field type read at
//! that instance, so `Foo Bool` of `type Foo a = unbox struct { data : () -> a };` becomes
//! `() -> Bool`. What a replacement does require is that the type constructor appears saturated
//! everywhere it occurs, since a type constructor is dropped from the type environment once it is
//! replaced, and an occurrence left standing would name a type constructor that is no longer
//! declared. The transform that removes higher-kinded type variables establishes that, and runs
//! first.
//!
//! A higher-kinded type variable is the only way a type constructor reaches a program's types
//! without its arguments, and one it carries can be a newtype. Take
//! `type [f : *->*] Foo f = box struct { data : f () };` and a program holding a `Foo IO`. `Foo` is
//! boxed, so this pass keeps it, and the bare `IO` stays inside it. `IO` is itself a newtype
//! (`type IO a = unbox struct { runner : IOState -> (IOState, a) };`), so `IO ()` and `IO I64` are
//! replaced and `IO` is dropped — while the bare `IO` inside `Foo IO` still names it.
```

第 1 段落が要求している性質とその理由を述べ、第 2 段落がそれが破れる筋道を 1 本の例で最後まで辿る。`Foo` が box であること、`IO` が newtype であることを、どちらも本文の中で使う。

## 何を変えていないか

このパスの挙動、および `remove_hktvs` を先に走らせるという要件そのもの。同じ要件を、読み手が確かめられる形で述べ直しただけである。`cargo check` は通る。

## 付録: この記述を読み直した経緯

issue #245 の直し方を検討する中で、`remove_hktvs` を必要としているのがどのパスなのかを確かめる必要が出た。設定では `enable_remove_hktvs_transformation` が `enable_unwrap_newtype_optimization` そのものとして定義されており、両パスを止めて `-O max` で全テストを走らせると 1341/1348 が通り、失敗 7 件はいずれも RC IR ダンプの形を固定しているテストで、コンパイラの panic は 0 件だった。つまり要件はこの 2 パスの間にしか無い。その確認の過程で、要件の理由がこの 3 行に書かれていること、そして読み解くのに補いが要ることが分かった。