### PR TITLE
レビュー清掃 (#274): main.rs の到達しないフォールバックと、引数読み取り関数の名前とコメント

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -373,11 +373,11 @@ fn run_cli() {
     let deps_update = App::new("update")
         .about("Update the lock file so that it satisfies the dependencies specified in the project file, and install the dependencies. By default, build lock file is updated. Use --test to update test lock file.")
         .arg(test_flag.clone());
-    let add_about_str = format!("Update the project file by adding `[[dependencies]]` tables which describe dependencies to specified Fix projects.\n\
+    let deps_add_about = format!("Update the project file by adding `[[dependencies]]` tables which describe dependencies to specified Fix projects.\n\
     Repositories for a Fix project is searched in the registry files listed in the configuration file (\"~/.fixconfig.toml\") and the default registry \"{}\".", DEFAULT_REGISTRY);
-    let add_about_str: &'static str = add_about_str.leak();
+    let deps_add_about: &'static str = deps_add_about.leak();
     let deps_add = App::new("add")
-        .about(add_about_str)
+        .about(deps_add_about)
         .arg(
             Arg::new("projects")
                 .multiple_values(true)
@@ -469,8 +469,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         .subcommand(check_subc);
 
     // Every path the option `opt_id` collects, across all of its occurrences.
-    fn read_path_list_option(m: &ArgMatches, opt_id: &str) -> Vec<PathBuf> {
-        let Some(paths) = m.get_many::<String>(opt_id) else {
+    fn read_path_list_option(args: &ArgMatches, opt_id: &str) -> Vec<PathBuf> {
+        let Some(paths) = args.get_many::<String>(opt_id) else {
             return vec![];
         };
         paths.map(PathBuf::from).collect()
@@ -478,14 +478,14 @@ Consecutive line comments immediately preceding an entity declaration in the sou
 
     // The kind of file the `--output-type` option asks the build to produce, if the invocation
     // gives that option.
-    fn read_output_file_type_option(m: &ArgMatches) -> Result<Option<OutputFileType>, Errors> {
-        match m.get_one::<String>("output-file-type") {
+    fn read_output_file_type_option(args: &ArgMatches) -> Result<Option<OutputFileType>, Errors> {
+        match args.get_one::<String>("output-file-type") {
             None => return Ok(None),
             Some(file_type) => Ok(Some(OutputFileType::from_str(file_type)?)),
         }
     }
 
-    fn read_docs_options(m: &ArgMatches, config: &mut Configuration) -> Result<(), Errors> {
+    fn read_docs_options(args: &ArgMatches, config: &mut Configuration) -> Result<(), Errors> {
         let docs_config = match &mut config.subcommand {
             SubCommand::Docs(docs_config) => docs_config,
             subcommand => unreachable!(
@@ -495,36 +495,36 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         };
 
         // `modules` option
-        docs_config.modules = read_string_list_option(m, "modules");
+        docs_config.modules = read_string_list_option(args, "modules");
 
         // `with-compiler-defined-methods` option
         docs_config.include_compiler_defined_methods =
-            m.contains_id("include-compiler-defined-methods");
+            args.contains_id("include-compiler-defined-methods");
 
         // `private` option
-        docs_config.include_private = m.contains_id("private");
+        docs_config.include_private = args.contains_id("private");
 
         // `out-dir` option
-        let dir = m
+        let dir = args
             .get_one::<String>("out-dir")
             .expect("the `--out-dir` option carries a default value");
         docs_config.out_dir = PathBuf::from(dir);
 
         // `test` option
-        docs_config.mode = get_build_mode(m);
+        docs_config.mode = get_build_mode(args);
 
         Ok(())
     }
 
     // The path the `--output` option names for the built file, if the invocation gives that option.
-    fn read_output_file_option(m: &ArgMatches) -> Option<PathBuf> {
-        m.get_one::<String>("output-file").map(PathBuf::from)
+    fn read_output_file_option(args: &ArgMatches) -> Option<PathBuf> {
+        args.get_one::<String>("output-file").map(PathBuf::from)
     }
 
     // Every value the option `opt_id` collects, across all of its occurrences. A subcommand that
     // has no such option yields an empty list.
-    fn read_string_list_option(m: &ArgMatches, opt_id: &str) -> Vec<String> {
-        m.try_get_many::<String>(opt_id)
+    fn read_string_list_option(args: &ArgMatches, opt_id: &str) -> Vec<String> {
+        args.try_get_many::<String>(opt_id)
             .unwrap_or_default()
             .unwrap_or_default()
             .cloned()
@@ -533,14 +533,14 @@ Consecutive line comments immediately preceding an entity declaration in the sou
 
     // Every library the invocation links, each paired with how it is bound: `--static-link` names
     // the libraries copied into the output, `--dynamic-link` the ones resolved at load time.
-    fn read_library_options(m: &ArgMatches) -> Vec<(String, LinkType)> {
+    fn read_library_options(args: &ArgMatches) -> Vec<(String, LinkType)> {
         let mut options = vec![];
         for (opt_id, link_type) in [
             ("static-link-library", LinkType::Static),
             ("dynamic-link-library", LinkType::Dynamic),
         ] {
             options.extend(
-                read_string_list_option(m, opt_id)
+                read_string_list_option(args, opt_id)
                     .into_iter()
                     .map(|name| (name, link_type)),
             );
@@ -549,8 +549,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
     }
 
     // The directories the `--library-paths` option adds to the linker's search path for libraries.
-    fn read_library_paths_option(m: &ArgMatches) -> Vec<PathBuf> {
-        read_string_list_option(m, "library-paths")
+    fn read_library_paths_option(args: &ArgMatches) -> Vec<PathBuf> {
+        read_string_list_option(args, "library-paths")
             .into_iter()
             .map(PathBuf::from)
             .collect()
@@ -558,16 +558,16 @@ Consecutive line comments immediately preceding an entity declaration in the sou
 
     // The CPU features the `--disable-cpu-feature` option turns off, as regex patterns matched
     // against the host's feature names, checked here for valid regex syntax.
-    fn read_disable_cpu_feature_option(m: &ArgMatches) -> Result<Vec<String>, Errors> {
-        let features = read_string_list_option(m, "disable-cpu-feature");
+    fn read_disable_cpu_feature_option(args: &ArgMatches) -> Result<Vec<String>, Errors> {
+        let features = read_string_list_option(args, "disable-cpu-feature");
         ProjectFile::validate_disable_cpu_features(&features)?;
         Ok(features)
     }
 
     // The LLVM passes listed in the file given by `--llvm-passes-file`, one pass-pipeline string
     // per line.
-    fn read_llvm_passes_file_option(m: &ArgMatches) -> Result<Option<Vec<String>>, Errors> {
-        let Some(path) = m.get_one::<String>("llvm-passes-file") else {
+    fn read_llvm_passes_file_option(args: &ArgMatches) -> Result<Option<Vec<String>>, Errors> {
+        let Some(path) = args.get_one::<String>("llvm-passes-file") else {
             return Ok(None);
         };
         let content = fs::read_to_string(path).map_err(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,7 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         .subcommand(edit_subc)
         .subcommand(check_subc);
 
-    // Every path the option `opt_id` collects, across all of its occurrences.
+    /// Every path the option `opt_id` collects, across all of its occurrences.
     fn read_path_list_option(args: &ArgMatches, opt_id: &str) -> Vec<PathBuf> {
         let Some(paths) = args.get_many::<String>(opt_id) else {
             return vec![];
@@ -476,8 +476,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         paths.map(PathBuf::from).collect()
     }
 
-    // The kind of file the `--output-type` option asks the build to produce, if the invocation
-    // gives that option.
+    /// The kind of file the `--output-type` option asks the build to produce, if the invocation
+    /// gives that option.
     fn read_output_file_type_option(args: &ArgMatches) -> Result<Option<OutputFileType>, Errors> {
         match args.get_one::<String>("output-file-type") {
             None => return Ok(None),
@@ -485,6 +485,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         }
     }
 
+    /// Apply the options of one `fix docs` invocation to the documentation settings `config`
+    /// carries.
     fn read_docs_options(args: &ArgMatches, config: &mut Configuration) -> Result<(), Errors> {
         let docs_config = match &mut config.subcommand {
             SubCommand::Docs(docs_config) => docs_config,
@@ -516,13 +518,14 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         Ok(())
     }
 
-    // The path the `--output` option names for the built file, if the invocation gives that option.
+    /// The path the `--output` option names for the built file, if the invocation gives that
+    /// option.
     fn read_output_file_option(args: &ArgMatches) -> Option<PathBuf> {
         args.get_one::<String>("output-file").map(PathBuf::from)
     }
 
-    // Every value the option `opt_id` collects, across all of its occurrences. A subcommand that
-    // has no such option yields an empty list.
+    /// Every value the option `opt_id` collects, across all of its occurrences. A subcommand that
+    /// has no such option yields an empty list.
     fn read_string_list_option(args: &ArgMatches, opt_id: &str) -> Vec<String> {
         args.try_get_many::<String>(opt_id)
             .unwrap_or_default()
@@ -531,8 +534,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
             .collect()
     }
 
-    // Every library the invocation links, each paired with how it is bound: `--static-link` names
-    // the libraries copied into the output, `--dynamic-link` the ones resolved at load time.
+    /// Every library the invocation links, each paired with how it is bound: `--static-link` names
+    /// the libraries copied into the output, `--dynamic-link` the ones resolved at load time.
     fn read_library_options(args: &ArgMatches) -> Vec<(String, LinkType)> {
         let mut options = vec![];
         for (opt_id, link_type) in [
@@ -548,7 +551,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         options
     }
 
-    // The directories the `--library-paths` option adds to the linker's search path for libraries.
+    /// The directories the `--library-paths` option adds to the linker's search path for
+    /// libraries.
     fn read_library_paths_option(args: &ArgMatches) -> Vec<PathBuf> {
         read_string_list_option(args, "library-paths")
             .into_iter()
@@ -556,16 +560,16 @@ Consecutive line comments immediately preceding an entity declaration in the sou
             .collect()
     }
 
-    // The CPU features the `--disable-cpu-feature` option turns off, as regex patterns matched
-    // against the host's feature names, checked here for valid regex syntax.
+    /// The CPU features the `--disable-cpu-feature` option turns off, as regex patterns matched
+    /// against the host's feature names, checked here for valid regex syntax.
     fn read_disable_cpu_feature_option(args: &ArgMatches) -> Result<Vec<String>, Errors> {
         let features = read_string_list_option(args, "disable-cpu-feature");
         ProjectFile::validate_disable_cpu_features(&features)?;
         Ok(features)
     }
 
-    // The LLVM passes listed in the file given by `--llvm-passes-file`, one pass-pipeline string
-    // per line.
+    /// The LLVM passes listed in the file given by `--llvm-passes-file`, one pass-pipeline string
+    /// per line.
     fn read_llvm_passes_file_option(args: &ArgMatches) -> Result<Option<Vec<String>>, Errors> {
         let Some(path) = args.get_one::<String>("llvm-passes-file") else {
             return Ok(None);
@@ -585,8 +589,8 @@ Consecutive line comments immediately preceding an entity declaration in the sou
         ))
     }
 
-    // The set of project-file declarations the invocation applies to: `--test` selects the test
-    // dependencies and test source files, and its absence the build ones.
+    /// The set of project-file declarations the invocation applies to: `--test` selects the test
+    /// dependencies and test source files, and its absence the build ones.
     fn get_build_mode(args: &ArgMatches) -> BuildConfigType {
         if args.contains_id("test") {
             BuildConfigType::Test

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,8 @@ fn run_cli() {
         .possible_value(PossibleValue::new(OPTIMIZATION_LEVEL_BASIC).help("Enables basic optimizations, providing a good balance between performance and compilation time."))
         .possible_value(PossibleValue::new(OPTIMIZATION_LEVEL_MAX).help("Enables all optimizations for maximum performance. This is the default optimization level."))
         .possible_value(PossibleValue::new(OPTIMIZATION_LEVEL_EXPERIMENTAL).help("Enables all optimizations, including experimental ones (intended for compiler development)."))
-        // .default_value(OPTIMIZATION_LEVEL_MAX) // we do not set default value because we want to check whether this option is specified by user explicitly.
+        // The option carries no default value, so that an invocation that gives it explicitly is
+        // told apart from one that leaves the level to the project file or to `--debug`.
         .help("Optimization level.");
     let disable_cpu_feature = Arg::new("disable-cpu-feature")
         .long("disable-cpu-feature")
@@ -487,7 +488,10 @@ Consecutive line comments immediately preceding an entity declaration in the sou
     fn read_docs_options(m: &ArgMatches, config: &mut Configuration) -> Result<(), Errors> {
         let docs_config = match &mut config.subcommand {
             SubCommand::Docs(docs_config) => docs_config,
-            _ => panic!("Invalid subcommand."),
+            subcommand => unreachable!(
+                "the options of `fix docs` were read into the configuration of `fix {}`",
+                subcommand.command_type_string()
+            ),
         };
 
         // `modules` option
@@ -514,7 +518,7 @@ Consecutive line comments immediately preceding an entity declaration in the sou
 
     // The path the `--output` option names for the built file, if the invocation gives that option.
     fn read_output_file_option(m: &ArgMatches) -> Option<PathBuf> {
-        m.get_one::<String>("output-file").map(|s| PathBuf::from(s))
+        m.get_one::<String>("output-file").map(PathBuf::from)
     }
 
     // Every value the option `opt_id` collects, across all of its occurrences. A subcommand that
@@ -652,7 +656,10 @@ Consecutive line comments immediately preceding an entity declaration in the sou
                 OPTIMIZATION_LEVEL_EXPERIMENTAL => {
                     config.set_fix_opt_level(FixOptimizationLevel::Experimental)
                 }
-                _ => panic!("Unknown optimization level: {}", opt_level),
+                _ => unreachable!(
+                    "the `--opt-level` option accepted the value `{}`, which names no optimization level",
+                    opt_level
+                ),
             }
         }
 


### PR DESCRIPTION
Refs #243

#274 のレビューが、変更した hunk の**周り**で見つけたものを直す。振る舞いは変えない。`src/main.rs` の 1 ファイルのみ。

このプルリクエストは #274 のブランチに向けている。#274 の diff を読むときに、この清掃が混ざっていない状態で読めるようにするための分割である。

## 1. 到達しない場合を吸収していた 2 か所を、その場で止まるようにする

`read_docs_options` は `fix docs` の引数を読んで設定に反映する。設定のうち `fix docs` 用の部分を取り出すところに、そうでなかった場合の腕がある。

```rust
let docs_config = match &mut config.subcommand {
    SubCommand::Docs(docs_config) => docs_config,
    _ => panic!("Invalid subcommand."),
};
```

`set_config_from_args` は `fix build` / `fix run` / `fix test` の引数を読んで設定に反映する。最適化レベルの名前を水準に変えるところに、同じ形がある。

```rust
_ => panic!("Unknown optimization level: {}", opt_level),
```

どちらも実際に到達しない。前者はこの関数を呼ぶ側が `fix docs` の腕であり、後者は `--opt-level` が clap の `possible_value` で 4 つの名前に限られている。到達しないので、`panic!` のままでも動作は同じである。変えたのは**何が起きたかを述べるかどうか**で、どちらのメッセージも受け取った値を名指ししていなかった。`unreachable!` にし、前者はサブコマンドの名前を、後者は受け取った文字列をメッセージに入れた。

## 2. 既定値があるので `None` にならない読み取りを、`expect` にする

`--out-dir`（`fix docs`）と `--max-cu-size`（`fix build` / `run` / `test`）は、どちらも引数の定義に既定値を持つ。よって値の取得は必ず成功する。それぞれ `unwrap_or_default()` と `unwrap_or(&DEFAULT_COMPILATION_UNIT_MAX_SIZE)` で受けていたものを `expect` にした。既定値が外れたときに、既定値が二重に書かれている状態で黙って進むのではなく、その場で止まる。

`--max-cu-size` の側で `DEFAULT_COMPILATION_UNIT_MAX_SIZE` の import が不要になったので落ちている（引数の定義が読む `..._STR` の方は残る）。

## 3. コメントアウトされたコードを消し、理由を散文にする

`--opt-level` の定義に、無効化された行が残っていた。

```rust
// .default_value(OPTIMIZATION_LEVEL_MAX) // we do not set default value because we want to check whether this option is specified by user explicitly.
```

述べている理由は今も有効である（この引数が指定されたかどうかを見分ける必要がある）。コードを消し、理由を散文で残した。

```rust
// The option carries no default value, so that an invocation that gives it explicitly is
// told apart from one that leaves the level to the project file or to `--debug`.
```

## 4. 引数の読み取り関数 9 つの、`ArgMatches` の名前を揃える

`run_cli` の中に、コマンドラインの値を取り出す小さな関数が 9 つある。

`read_path_list_option`、`read_output_file_type_option`、`read_docs_options`、`read_output_file_option`、`read_string_list_option`、`read_library_options`、`read_library_paths_option`、`read_disable_cpu_feature_option`、`read_llvm_passes_file_option`。

いずれも第 1 引数の `&ArgMatches` を `m` と呼んでいた。同じファイルの `get_build_mode`、`set_config_from_args`、`create_config` と、サブコマンドを振り分ける `match` の束縛は、同じものを `args` と呼ぶ。9 つを `args` に揃えた。

これは 5 件という 1 ファイルあたりの上限を超えるが、部分的に揃えると隣り合う兄弟関数の間で 2 つの呼び名が根拠なく混ざるので、全部行うか行わないかのどちらかである。全部行った。

## 5. `fix deps add` の説明文を束縛している名前

`add_about_str` という名前だった。`_str` は型を言い直しているだけで、`deps` の 4 つのサブコマンド（`install` / `update` / `add` / `list`）のどれの説明かを言っていない。`deps_add_about` にした。

## 6. 引数の読み取り関数 10 個を doc コメントにする

上の 9 つと `get_build_mode` は、説明を `//` で書いていた。同じ関数の中に並ぶ `set_config_from_args`、`create_config`、`print_subcommand_help` は `///` である。10 個を `///` に揃え、コメントの無かった `read_docs_options` に 1 行足した。

```rust
/// Apply the options of one `fix docs` invocation to the documentation settings `config` carries.
```

これで `src/main.rs` のすべての関数が doc コメントを持つ。残る `//` のコメントは `let` 束縛の上に付いたもので、そこに `///` を置くと `unused_doc_comments` になる。

## 振る舞いを変えていないこと

- 1 と 2 が触れた 4 か所は、いずれも到達しないか、既定値があるので成功する経路である。到達しないことは、引数の定義（`possible_value`、`default_value`）と呼び出し側の分岐から従う。
- 3 はコメントの削除である。
- 4 と 5 は関数の引数名とローカル束縛の名前で、スコープは 1 つの関数本体に閉じている。
- 6 はコメントである。

`cargo build --release` が警告なしで通り、`cargo fmt` は変更を出さない。全テストを `FIX_MAX_OPT_LEVEL=none` で流して 1357 + 139、失敗 0。

## 落とし方

#274 を読み終えたあとは、どちらの順序でも構わない。

- この PR を `help-header` にマージしてから、`help-header` を `main` にマージする。`main` へのマージは 1 回で、両方が入る。
- `help-header` を `main` にマージしてブランチを削除する。GitHub は削除されたブランチを base に持つ PR を、そのブランチ自身の base（`main`）へ張り替えるので、この PR は `main` への PR として単独で残る。

## レビューが見つけて、ここでは直していないもの

いずれも振る舞いか界面を変えるので、findings として #274 の会話に残す。

- `run_cli` が約 750 行あり、コマンドの組み立てと、解釈結果の振り分けを 1 つの関数に同居させている。`let mut app = App::new("fix")` が継ぎ目で、`fn build_command() -> App` として切り出せる。中に入れ子になっている 14 個の関数の置き場所も一緒に動く。
- `build_subc` の 24 個の `.arg` 連鎖と、`run` / `test` に引数を足すクロージャが、24 個中 22 個まで同じ。片方に足してもう片方を忘れる形である。共通化するとヘルプの表示順が変わるので、振る舞い保存にならない。
- `read_string_list_option` の `try_get_many(...).unwrap_or_default()` は、引数を定義していないサブコマンドから呼ばれた場合を吸収する。6 つの呼び出し側はすべて該当サブコマンドが定義済みなので到達しないが、clap のエラーの種類まで含めて不在を証明しきれなかったので、`expect` にしていない。
- モジュール `edit_explict_import` は "explicit" の綴り誤りで、同じ関数の中に正しい綴りのローカル束縛 `edit_explicit_import` が並んでいる。参照は 3 か所、ファイル名も同様。
- `SubCommand::command_type_string` の `_string` は型を言い直しており、返すのはコマンド名そのもの。`command_name` を提案する。
