### PR TITLE
循環したトレイト制約の演繹を拒否する (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 #### Language
 
+- A trait constraint that is deduced from itself is now rejected, instead of being accepted with nothing behind it. With `impl Wrap c : Holder { type Held (Wrap c) = Wrap (Wrap c); }`, the instance `impl [c : Holder, Held c = e, e : Show] Wrap c : Show` made deducing `Wrap (Wrap I64) : Show` ask for `Wrap (Wrap I64) : Show` again, and the program compiled although nothing gives `Show` to anything. Where each step asks about a larger type instead of the same one (`type Held (Wrap c) = Wrap (Wrap (Wrap c));`), the compiler used to take memory without end and report nothing; it now reports that the deduction asks about types nested more than 500 deep.
 - A struct pattern now requires the type at its head to be a struct, and reports an error otherwise. `let MyUnion { a : x } = u;` took the union's tag for the payload of `a`, and the build aborted; `let Item { data : x } = 42;`, whose head names an associated type, aborted the compiler.
 - A trait alias that stands for one trait along two paths is now accepted. `trait Ring = Ordered + Showable;`, where `Ordered` and `Showable` both stand for `Additive`, was rejected as circular aliasing, and the message named a trait of the standard library that the program never mentions.
 - Two implementations of one trait are now reported as overlapping when one of their heads takes a type parameter of a higher kind, as `impl [f : *->*] Bar f : MyTrait` does beside `impl Bar Array : MyTrait`. Both used to be accepted, and the order they were written in decided which one a call reached.

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -446,6 +446,19 @@ impl TyAliasInfo {
     }
 }
 
+/// How deeply a single type may nest before the compiler calls the program endless.
+///
+/// This is a property of one type, not of the program: a chain of a thousand types that each hold
+/// the next is a thousand types of depth one, and a project keeps compiling however many such types
+/// it gains. A type reached from itself at a larger type argument, on the other hand, gains a level
+/// at every step and passes any bound.
+///
+/// Over the benchmark corpus and the examples the deepest type reached is 10; a type written with
+/// 25 nested tuples reaches 27. The bound also caps how deep the walks over a type go — hashing it,
+/// substituting into it, printing it — so raising it costs stack on the programs it exists to
+/// reject.
+pub const MAX_TYPE_DEPTH: usize = 500;
+
 // Node of type ast tree with user defined additional information
 #[derive(Serialize, Deserialize)]
 pub struct TypeNode {

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -448,10 +448,10 @@ impl TyAliasInfo {
 
 /// How deeply a single type may nest before the compiler calls the program endless.
 ///
-/// This is a property of one type, not of the program: a chain of a thousand types that each hold
-/// the next is a thousand types of depth one, and a project keeps compiling however many such types
-/// it gains. A type reached from itself at a larger type argument, on the other hand, gains a level
-/// at every step and passes any bound.
+/// This bounds one type: a chain of a thousand types that each hold the next is a thousand types of
+/// depth one, and a project keeps compiling however many such types it gains. A type reached from
+/// itself at a larger type argument, on the other hand, gains a level at every step and passes any
+/// bound.
 ///
 /// Over the benchmark corpus and the examples the deepest type reached is 10; a type written with
 /// 25 nested tuples reaches 27. The bound also caps how deep the walks over a type go — hashing it,

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -426,20 +426,26 @@ impl TyConInfo {
     }
 }
 
+/// A declaration of a type alias: the type it stands for, and the parameters it takes.
 #[derive(Clone)]
 pub struct TyAliasInfo {
+    /// The kind of the type constructor the alias names.
     pub kind: Arc<Kind>,
+    /// The type the alias stands for, written in terms of `tyvars`.
     pub value: Arc<TypeNode>,
+    /// The parameters the alias takes, in the order they are declared.
     pub tyvars: Vec<Arc<TyVar>>,
+    /// Where the declaration was written.
     pub source: Option<Span>,
 }
 
 impl TyAliasInfo {
-    // Get the document of this type alias.
+    /// The documentation comment written above this declaration.
     pub fn get_document(&self) -> Option<String> {
         self.source.as_ref().and_then(|src| src.get_document().ok())
     }
 
+    /// Resolves the namespaces of the type names in the type the alias stands for.
     pub fn resolve_namespace(&mut self, ctx: &mut NameResolutionContext) -> Result<(), Errors> {
         self.value = self.value.resolve_namespace(ctx)?;
         Ok(())
@@ -459,10 +465,12 @@ impl TyAliasInfo {
 /// reject.
 pub const MAX_TYPE_DEPTH: usize = 500;
 
-// Node of type ast tree with user defined additional information
+/// A node of a type expression, together with the information the compiler carries alongside it.
 #[derive(Serialize, Deserialize)]
 pub struct TypeNode {
+    /// The type expression, which is what equality and hashing of a node read.
     pub ty: Type,
+    /// Where the type was written, for a type read from a source file.
     pub info: TypeInfo,
     /// The hash of `ty`, kept once computed.
     ///
@@ -485,6 +493,8 @@ pub struct TypeNode {
 }
 
 impl PartialEq for TypeNode {
+    /// Compares the type expressions; the source information a node carries stays out of the
+    /// comparison.
     fn eq(&self, other: &Self) -> bool {
         self.ty == other.ty
     }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -18,7 +18,7 @@ use crate::{
         types::{
             is_type_wildcard_tyvar, kind_star, make_tyvar, type_from_tyvar, type_fun, type_tyapp,
             type_tycon, AssocType, Kind, OpaqueTyConResolution, Scheme, TyCon, TyConInfo,
-            TyConVariant, TyVar, Type, TypeNode,
+            TyConVariant, TyVar, Type, TypeNode, MAX_TYPE_DEPTH,
         },
     },
     constants::{
@@ -234,6 +234,11 @@ impl Substitution {
         match e {
             UnificationErr::Unsatisfiable(predicate) => {
                 self.substitute_predicate(predicate);
+            }
+            UnificationErr::Circular(way) | UnificationErr::Endless(way) => {
+                for predicate in way {
+                    self.substitute_predicate(predicate);
+                }
             }
             UnificationErr::Disjoint(type_node, type_node1) => {
                 *type_node = self.substitute_type(type_node);
@@ -1164,13 +1169,13 @@ impl TypeCheckContext {
                             .find_map(|cand| cand.as_ref().err())
                             .unwrap();
                         let scm = tc.substitution.substitute_scheme(scm);
-                        let msg = format!(
+                        let msg = e.with_note(format!(
                             "`{}` of type `{}` does not match the expected type `{}` since `{}` cannot be deduced.",
                             fullname.to_string(),
                             scm.to_string(),
                             expected_type.to_string(),
                             e.to_constraint_string(),
-                        );
+                        ));
                         let mut tvs = vec![];
                         scm.free_vars_to_vec(&mut tvs);
                         expected_type.free_vars_to_vec(&mut tvs);
@@ -1197,13 +1202,13 @@ impl TypeCheckContext {
                         {
                             let cnt = candidates_errors.len() + 1;
                             let scm = tc.substitution.substitute_scheme(scm);
-                            let msg = format!(
+                            let msg = e.with_note(format!(
                                 "- ({}) `{}` of type `{}` does not match since `{}` cannot be deduced.",
                                 cnt,
                                 fullname.to_string(),
                                 scm.to_string(),
                                 e.to_constraint_string(),
-                            );
+                            ));
                             candidates_errors.push(msg);
                             let mut tvs = vec![];
                             scm.free_vars_to_vec(&mut tvs);
@@ -1693,12 +1698,12 @@ impl TypeCheckContext {
         unif_err.free_vars_to_vec(&mut tvs);
         let tv_loc_msgs = self.create_tyvar_location_messages(&tvs, None);
         let mut err = Error::from_msg_srcs(
-            format!(
+            unif_err.with_note(format!(
                 "Type mismatch. Expected `{}`, found `{}`. They do not match since `{}` cannot be deduced.",
                 expected_ty.to_string(),
                 found_ty.to_string(),
                 unif_err.to_constraint_string(),
-            ),
+            )),
             &[&source],
         );
         err.add_srcs(tv_loc_msgs);
@@ -1787,10 +1792,10 @@ impl TypeCheckContext {
         ) -> Error {
             tc.substitution.substitute_unification_error(&mut unif_err);
             let mut error = Error::from_msg_srcs(
-                format!(
+                unif_err.with_note(format!(
                     "`{}` is required in the type inference of this expression but cannot be deduced from assumptions.",
                     unif_err.to_constraint_string()
-                ),
+                )),
                 &[src],
             );
             let mut tvs = vec![];
@@ -2179,9 +2184,9 @@ impl TypeCheckContext {
     /// If a predicate is unsatisfiable, returns `Err`.
     pub(crate) fn reduce_predicates(&mut self) -> Result<(), UnifOrOtherErr> {
         let mut irr_preds = vec![];
-        let mut skip: Set<String> = Set::default();
+        let mut deduction = PredicateDeduction::default();
         while let Some(pred) = self.predicates.pop() {
-            self.reduce_predicate(pred, &mut irr_preds, &mut skip)?;
+            self.reduce_predicate(pred, &mut irr_preds, &mut deduction)?;
         }
         self.predicates = irr_preds;
         Ok(())
@@ -2192,10 +2197,10 @@ impl TypeCheckContext {
         &mut self,
         pred: Predicate,
         irr_preds: &mut Vec<Predicate>,
-        skip: &mut Set<String>,
+        deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         for pred in pred.resolve_trait_aliases(&self.trait_env.aliases)? {
-            self.reduce_predicate_noalias(pred, irr_preds, skip)?;
+            self.reduce_predicate_noalias(pred, irr_preds, deduction)?;
         }
         Ok(())
     }
@@ -2206,15 +2211,24 @@ impl TypeCheckContext {
         &mut self,
         mut pred: Predicate,
         irr_preds: &mut Vec<Predicate>,
-        skip: &mut Set<String>,
+        deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         self.substitute_predicate(&mut pred);
         let pred_str = pred.to_string();
-        if skip.contains(&pred_str) {
+        if deduction.settled.contains(&pred_str) {
             return Ok(());
         }
-        skip.insert(pred_str);
+        if deduction.on_path.contains(&pred_str) {
+            return Err(UnificationErr::Circular(deduction.way_round(&pred, &pred_str)).into());
+        }
         pred.ty = self.substitute_and_reduce_type(&pred.ty)?;
+        // An instance whose context asks for what it gives, on a larger type, never asks twice for
+        // the same predicate, so the check above never meets one of its deductions a second time.
+        // What such a deduction does at every step is ask about a deeper type, and this is where
+        // that ends.
+        if pred.ty.depth() > MAX_TYPE_DEPTH {
+            return Err(UnificationErr::Endless(deduction.way_down(&pred)).into());
+        }
         let mut unifiable = false;
         let assumed_preds = self.assumed_preds.clone();
         for qual_pred_scm in assumed_preds
@@ -2237,10 +2251,16 @@ impl TypeCheckContext {
                     match_subst.substitute_equality(&mut eq);
                     self.add_equality(eq)?;
                 }
-                for mut pred in qual_pred.pred_constraints {
-                    match_subst.substitute_predicate(&mut pred);
-                    self.reduce_predicate(pred, irr_preds, skip)?;
-                }
+                let context = qual_pred
+                    .pred_constraints
+                    .into_iter()
+                    .map(|mut ctx_pred| {
+                        match_subst.substitute_predicate(&mut ctx_pred);
+                        ctx_pred
+                    })
+                    .collect();
+                self.reduce_instance_context(&pred, &pred_str, context, irr_preds, deduction)?;
+                deduction.settled.insert(pred_str);
                 return Ok(());
             } else if !unifiable {
                 // If match fails, then we cannot reduce the predicate at now.
@@ -2254,7 +2274,30 @@ impl TypeCheckContext {
             return Err(UnificationErr::Unsatisfiable(pred).into());
         }
         irr_preds.push(pred);
+        deduction.settled.insert(pred_str);
         return Ok(());
+    }
+
+    /// Deduce the constraints the instance that gives `pred` asks for, with `pred` on the deduction
+    /// while they are deduced, so that a deduction coming back to `pred` is seen for what it is.
+    fn reduce_instance_context(
+        &mut self,
+        pred: &Predicate,
+        pred_str: &str,
+        context: Vec<Predicate>,
+        irr_preds: &mut Vec<Predicate>,
+        deduction: &mut PredicateDeduction,
+    ) -> Result<(), UnifOrOtherErr> {
+        deduction.enter(pred, pred_str);
+        let mut result = Ok(());
+        for ctx_pred in context {
+            result = self.reduce_predicate(ctx_pred, irr_preds, deduction);
+            if result.is_err() {
+                break;
+            }
+        }
+        deduction.leave();
+        result
     }
 
     /// Pattern half of `map_types`: rebuild `pat` with the type of the
@@ -2655,9 +2698,79 @@ fn short_span_snippet(span: &Span) -> Option<String> {
     Some(trimmed.to_string())
 }
 
+/// What the deduction of a predicate carries as it descends into the constraints that the instances
+/// it uses ask for.
+///
+/// A predicate is deduced by finding the instance whose head it matches and deducing what that
+/// instance's context asks for. Which of the two sets a predicate is in is what separates one that
+/// holds from one whose deduction needs itself: `on_path` holds the predicates whose deduction has
+/// begun and has yet to end, and `settled` the ones whose deduction ended.
+#[derive(Default)]
+struct PredicateDeduction {
+    /// The predicates whose deduction the current one is inside, outermost first, each with its
+    /// printed form. The printed form is what tells one predicate from another here, and it is kept
+    /// so that the way out costs no more printing than the way in did.
+    path: Vec<(Predicate, String)>,
+    /// The printed form of each predicate on `path`. Meeting one of these again is meeting a
+    /// predicate whose deduction needs itself.
+    on_path: Set<String>,
+    /// The printed form of each predicate whose deduction ended. Recorded on the way out, so that a
+    /// predicate the deduction is still inside is not taken for one already deduced. It keeps a
+    /// predicate that several instance contexts ask for from being deduced once for each of them.
+    settled: Set<String>,
+}
+
+impl PredicateDeduction {
+    /// Record that the deduction of `pred`, whose printed form is `pred_str`, has begun.
+    fn enter(&mut self, pred: &Predicate, pred_str: &str) {
+        self.on_path.insert(pred_str.to_string());
+        self.path.push((pred.clone(), pred_str.to_string()));
+    }
+
+    /// Record that the deduction entered last has ended.
+    fn leave(&mut self) {
+        let (_pred, pred_str) = self
+            .path
+            .pop()
+            .expect("a deduction ends only after it has begun");
+        self.on_path.remove(&pred_str);
+    }
+
+    /// The way from the predicate printed as `pred_str` round to it again, that predicate at both
+    /// ends.
+    fn way_round(&self, pred: &Predicate, pred_str: &str) -> Vec<Predicate> {
+        let start = self
+            .path
+            .iter()
+            .position(|(_ancestor, ancestor_str)| ancestor_str == pred_str)
+            .expect("the caller found `pred` among the deductions it is inside");
+        self.path[start..]
+            .iter()
+            .map(|(ancestor, _ancestor_str)| ancestor.clone())
+            .chain([pred.clone()])
+            .collect()
+    }
+
+    /// The way from the predicate the deduction started at down to `pred`, `pred` last.
+    fn way_down(&self, pred: &Predicate) -> Vec<Predicate> {
+        self.path
+            .iter()
+            .map(|(ancestor, _ancestor_str)| ancestor.clone())
+            .chain([pred.clone()])
+            .collect()
+    }
+}
+
 #[derive(Clone)]
 pub enum UnificationErr {
+    /// No instance the program declares gives the predicate.
     Unsatisfiable(Predicate),
+    /// Deducing the predicate comes back to the predicate itself, so nothing gives it. Carries the
+    /// way from the predicate round to it, the predicate at both ends.
+    Circular(Vec<Predicate>),
+    /// Deducing the predicate asks for one on a deeper type, and that one for a deeper one again, so
+    /// the deduction does not end. Carries the way down, deepest last.
+    Endless(Vec<Predicate>),
     Disjoint(Arc<TypeNode>, Arc<TypeNode>),
 }
 
@@ -2665,9 +2778,46 @@ impl UnificationErr {
     pub fn to_constraint_string(&self) -> String {
         match self {
             UnificationErr::Unsatisfiable(p) => p.to_string(),
+            UnificationErr::Circular(way) | UnificationErr::Endless(way) => {
+                Self::deduced_predicate(way).to_string()
+            }
             UnificationErr::Disjoint(ty1, ty2) => {
                 format!("{} = {}", ty1.to_string(), ty2.to_string())
             }
+        }
+    }
+
+    /// `sentence`, which names the constraint, followed by what the deduction of that constraint
+    /// did where the deduction rather than the constraint is what fails.
+    pub fn with_note(&self, sentence: String) -> String {
+        match self.note() {
+            Some(note) => format!("{} {}", sentence, note),
+            None => sentence,
+        }
+    }
+
+    /// What a report adds after naming the constraint, where what fails is the deduction of the
+    /// constraint rather than the constraint itself.
+    fn note(&self) -> Option<String> {
+        match self {
+            UnificationErr::Unsatisfiable(_) | UnificationErr::Disjoint(_, _) => None,
+            // A deduction that comes straight back to where it began is the whole story; a longer
+            // one is told by the constraints it passes through.
+            UnificationErr::Circular(way) if way.len() <= 2 => Some(
+                "Deducing it needs itself: the instance that gives it asks for it again."
+                    .to_string(),
+            ),
+            UnificationErr::Circular(way) => Some(format!(
+                "Deducing it needs itself: {}.",
+                Self::way_string(way)
+            )),
+            UnificationErr::Endless(way) => Some(format!(
+                "Deducing it asks about types nested more than {} deep, so the deduction does not \
+                 end: {}. An instance whose context asks for what it gives, on a larger type, does \
+                 this.",
+                MAX_TYPE_DEPTH,
+                Self::way_string(way)
+            )),
         }
     }
 
@@ -2675,11 +2825,57 @@ impl UnificationErr {
     pub fn free_vars_to_vec(&self, buf: &mut Vec<Arc<TyVar>>) {
         match self {
             UnificationErr::Unsatisfiable(p) => p.free_vars_to_vec(buf),
+            UnificationErr::Circular(way) | UnificationErr::Endless(way) => {
+                for pred in way {
+                    pred.free_vars_to_vec(buf);
+                }
+            }
             UnificationErr::Disjoint(ty1, ty2) => {
                 ty1.free_vars_to_vec(buf);
                 ty2.free_vars_to_vec(buf);
             }
         }
+    }
+
+    /// The predicate a failed deduction is about: the one the report names.
+    fn deduced_predicate(way: &[Predicate]) -> &Predicate {
+        way.first()
+            .expect("a deduction carries the predicate it started from")
+    }
+
+    /// The steps of a deduction, as the report shows them.
+    fn way_string(way: &[Predicate]) -> String {
+        /// How many steps to show. Enough for one turn of a deduction that asks about ever larger
+        /// types to be visible, and short enough that the reader can read what is printed.
+        const SHOWN_STEPS: usize = 3;
+        /// How much of a predicate to print before cutting it short. A predicate that ends a
+        /// deduction can name a type of any size, and the whole of one says no more than its
+        /// beginning does.
+        const MAX_SHOWN_CHARS: usize = 200;
+
+        fn shorten(pred: &Predicate) -> String {
+            let text = pred.to_string();
+            match text.char_indices().nth(MAX_SHOWN_CHARS) {
+                Some((cut, _)) => format!("`{}...`", &text[..cut]),
+                None => format!("`{}`", text),
+            }
+        }
+
+        // The last step is where the deduction shows what is wrong with it: the predicate it came
+        // back to, or the one on a type too deep to be one the program wrote.
+        let (last, rest) = way
+            .split_last()
+            .expect("a deduction carries the predicate it started from");
+        let mut steps = rest
+            .iter()
+            .take(SHOWN_STEPS)
+            .map(shorten)
+            .collect::<Vec<_>>();
+        if rest.len() > SHOWN_STEPS {
+            steps.push("...".to_string());
+        }
+        steps.push(shorten(last));
+        steps.join(" -> ")
     }
 }
 

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2814,6 +2814,13 @@ impl UnificationErr {
                 "Deducing it needs itself: {}.",
                 Self::way_string(way)
             )),
+            // A deduction that has yet to take a step reached the bound on the constraint it was
+            // asked for, which says nothing about any instance.
+            UnificationErr::Endless(way) if way.len() <= 1 => Some(format!(
+                "The type it names nests more than {} deep, which is past the depth the compiler \
+                 settles a constraint about.",
+                MAX_TYPE_DEPTH
+            )),
             UnificationErr::Endless(way) => Some(format!(
                 "Deducing it asks about types nested more than {} deep, so the deduction does not \
                  end: {}. An instance whose context asks for what it gives, on a larger type, does \

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2771,6 +2771,10 @@ impl PredicateDeduction {
     }
 }
 
+/// A constraint that type checking required and could not settle.
+///
+/// A report names the constraint, and adds what the deduction of it did where the deduction rather
+/// than the constraint is what fails.
 #[derive(Clone)]
 pub enum UnificationErr {
     /// No instance the program declares gives the predicate.
@@ -2781,10 +2785,13 @@ pub enum UnificationErr {
     /// Deducing the predicate asks for one on a deeper type, and that one for a deeper one again, so
     /// the deduction does not end. Carries the way down, deepest last.
     Endless(Vec<Predicate>),
+    /// Two types that are required to be equal and that unification could not make equal.
     Disjoint(Arc<TypeNode>, Arc<TypeNode>),
 }
 
 impl UnificationErr {
+    /// The constraint the report names, printed: the predicate that cannot be deduced, or an
+    /// equation between the two types that cannot be made equal.
     pub fn to_constraint_string(&self) -> String {
         match self {
             UnificationErr::Unsatisfiable(p) => p.to_string(),
@@ -2831,7 +2838,7 @@ impl UnificationErr {
         }
     }
 
-    // Append free type variables to a buffer of type Vec.
+    /// Appends to `buf` the type variables free in the types this error carries.
     pub fn free_vars_to_vec(&self, buf: &mut Vec<Arc<TyVar>>) {
         match self {
             UnificationErr::Unsatisfiable(p) => p.free_vars_to_vec(buf),
@@ -2882,8 +2889,12 @@ impl UnificationErr {
     }
 }
 
+/// What a step of type checking fails with: a constraint it could not settle, or errors raised for
+/// any other reason.
 pub enum UnifOrOtherErr {
+    /// A constraint the step required and could not settle.
     UnifErr(UnificationErr),
+    /// Errors raised for any other reason, carried as they are.
     Others(Errors),
 }
 

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1171,7 +1171,7 @@ impl TypeCheckContext {
                             .find_map(|cand| cand.as_ref().err())
                             .unwrap();
                         let scm = tc.substitution.substitute_scheme(scm);
-                        let msg = e.with_note(format!(
+                        let msg = e.message_with_note(format!(
                             "`{}` of type `{}` does not match the expected type `{}` since `{}` cannot be deduced.",
                             fullname.to_string(),
                             scm.to_string(),
@@ -1204,7 +1204,7 @@ impl TypeCheckContext {
                         {
                             let cnt = candidates_errors.len() + 1;
                             let scm = tc.substitution.substitute_scheme(scm);
-                            let msg = e.with_note(format!(
+                            let msg = e.message_with_note(format!(
                                 "- ({}) `{}` of type `{}` does not match since `{}` cannot be deduced.",
                                 cnt,
                                 fullname.to_string(),
@@ -1700,7 +1700,7 @@ impl TypeCheckContext {
         unif_err.free_vars_to_vec(&mut tvs);
         let tv_loc_msgs = self.create_tyvar_location_messages(&tvs, None);
         let mut err = Error::from_msg_srcs(
-            unif_err.with_note(format!(
+            unif_err.message_with_note(format!(
                 "Type mismatch. Expected `{}`, found `{}`. They do not match since `{}` cannot be deduced.",
                 expected_ty.to_string(),
                 found_ty.to_string(),
@@ -1794,7 +1794,7 @@ impl TypeCheckContext {
         ) -> Error {
             tc.substitution.substitute_unification_error(&mut unif_err);
             let mut error = Error::from_msg_srcs(
-                unif_err.with_note(format!(
+                unif_err.message_with_note(format!(
                     "`{}` is required in the type inference of this expression but cannot be deduced from assumptions.",
                     unif_err.to_constraint_string()
                 )),
@@ -2296,11 +2296,11 @@ impl TypeCheckContext {
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         deduction.enter(pred, pred_str);
-        let result = context
+        let deduced = context
             .into_iter()
             .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irr_preds, deduction));
         deduction.leave();
-        result
+        deduced
     }
 
     /// Pattern half of `map_types`: rebuild `pat` with the type of the
@@ -2784,7 +2784,7 @@ impl UnificationErr {
         match self {
             UnificationErr::Unsatisfiable(p) => p.to_string(),
             UnificationErr::Circular(way) | UnificationErr::Endless(way) => {
-                Self::deduced_predicate(way).to_string()
+                Self::reported_predicate(way).to_string()
             }
             UnificationErr::Disjoint(ty1, ty2) => {
                 format!("{} = {}", ty1.to_string(), ty2.to_string())
@@ -2794,7 +2794,7 @@ impl UnificationErr {
 
     /// `sentence`, which names the constraint, followed by what the deduction of that constraint
     /// did where the deduction rather than the constraint is what fails.
-    pub fn with_note(&self, sentence: String) -> String {
+    pub fn message_with_note(&self, sentence: String) -> String {
         match self.note() {
             Some(note) => format!("{} {}", sentence, note),
             None => sentence,
@@ -2843,7 +2843,7 @@ impl UnificationErr {
     }
 
     /// The predicate a failed deduction is about: the one the report names.
-    fn deduced_predicate(way: &[Predicate]) -> &Predicate {
+    fn reported_predicate(way: &[Predicate]) -> &Predicate {
         way.first()
             .expect("a deduction carries the predicate it started from")
     }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2854,6 +2854,7 @@ impl UnificationErr {
         /// types to be visible, and short enough that the reader can read what is printed.
         const SHOWN_STEPS: usize = 3;
 
+        /// One step of the way, quoted and cut short where the predicate is too long to show whole.
         fn shorten(pred: &Predicate) -> String {
             format!("`{}`", shorten_for_report(pred.to_string()))
         }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1,9 +1,7 @@
 use super::check_holes::collect_hole_errors;
 use super::typecheckcache::TypeCheckCache;
 use crate::ast::import;
-use crate::misc::{
-    collect_results, grow_stack, insert_to_map_vec, shorten_for_report, Map, Set,
-};
+use crate::misc::{collect_results, grow_stack, insert_to_map_vec, shorten_for_report, Map, Set};
 use crate::{
     ast::{
         equality::{Equality, EqualityScheme},

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2296,13 +2296,9 @@ impl TypeCheckContext {
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         deduction.enter(pred, pred_str);
-        let mut result = Ok(());
-        for ctx_pred in context {
-            result = self.reduce_predicate(ctx_pred, irr_preds, deduction);
-            if result.is_err() {
-                break;
-            }
-        }
+        let result = context
+            .into_iter()
+            .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irr_preds, deduction));
         deduction.leave();
         result
     }
@@ -2752,19 +2748,20 @@ impl PredicateDeduction {
             .position(|(_ancestor, ancestor_str)| ancestor_str == pred_str)
             .expect("the caller found the predicate among the deductions it is inside");
         let (repeated, _repeated_str) = &self.path[start];
-        self.path[start..]
-            .iter()
-            .map(|(ancestor, _ancestor_str)| ancestor.clone())
-            .chain([repeated.clone()])
-            .collect()
+        self.way_from(start, repeated)
     }
 
     /// The way from the predicate the deduction started at down to `pred`, `pred` last.
     fn way_down(&self, pred: &Predicate) -> Vec<Predicate> {
-        self.path
+        self.way_from(0, pred)
+    }
+
+    /// The way from the predicate at `start` of the path down to `last`, `last` last.
+    fn way_from(&self, start: usize, last: &Predicate) -> Vec<Predicate> {
+        self.path[start..]
             .iter()
             .map(|(ancestor, _ancestor_str)| ancestor.clone())
-            .chain([pred.clone()])
+            .chain([last.clone()])
             .collect()
     }
 }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -1,7 +1,9 @@
 use super::check_holes::collect_hole_errors;
 use super::typecheckcache::TypeCheckCache;
 use crate::ast::import;
-use crate::misc::{collect_results, grow_stack, insert_to_map_vec, Map, Set};
+use crate::misc::{
+    collect_results, grow_stack, insert_to_map_vec, shorten_for_report, Map, Set,
+};
 use crate::{
     ast::{
         equality::{Equality, EqualityScheme},
@@ -2214,12 +2216,17 @@ impl TypeCheckContext {
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         self.substitute_predicate(&mut pred);
+        // The constraint as it is asked for, before the associated types in it are reduced, is what
+        // tells one deduction from another here. Two spellings of one constraint are then two
+        // deductions, which costs a turn of the deduction before a circle through an associated
+        // type closes on a spelling it has already met. The depth bound below is what ends a
+        // deduction that keeps finding new spellings.
         let pred_str = pred.to_string();
         if deduction.settled.contains(&pred_str) {
             return Ok(());
         }
         if deduction.on_path.contains(&pred_str) {
-            return Err(UnificationErr::Circular(deduction.way_round(&pred, &pred_str)).into());
+            return Err(UnificationErr::Circular(deduction.way_round(&pred_str)).into());
         }
         pred.ty = self.substitute_and_reduce_type(&pred.ty)?;
         // An instance whose context asks for what it gives, on a larger type, never asks twice for
@@ -2738,16 +2745,17 @@ impl PredicateDeduction {
 
     /// The way from the predicate printed as `pred_str` round to it again, that predicate at both
     /// ends.
-    fn way_round(&self, pred: &Predicate, pred_str: &str) -> Vec<Predicate> {
+    fn way_round(&self, pred_str: &str) -> Vec<Predicate> {
         let start = self
             .path
             .iter()
             .position(|(_ancestor, ancestor_str)| ancestor_str == pred_str)
-            .expect("the caller found `pred` among the deductions it is inside");
+            .expect("the caller found the predicate among the deductions it is inside");
+        let (repeated, _repeated_str) = &self.path[start];
         self.path[start..]
             .iter()
             .map(|(ancestor, _ancestor_str)| ancestor.clone())
-            .chain([pred.clone()])
+            .chain([repeated.clone()])
             .collect()
     }
 
@@ -2848,17 +2856,9 @@ impl UnificationErr {
         /// How many steps to show. Enough for one turn of a deduction that asks about ever larger
         /// types to be visible, and short enough that the reader can read what is printed.
         const SHOWN_STEPS: usize = 3;
-        /// How much of a predicate to print before cutting it short. A predicate that ends a
-        /// deduction can name a type of any size, and the whole of one says no more than its
-        /// beginning does.
-        const MAX_SHOWN_CHARS: usize = 200;
 
         fn shorten(pred: &Predicate) -> String {
-            let text = pred.to_string();
-            match text.char_indices().nth(MAX_SHOWN_CHARS) {
-                Some((cut, _)) => format!("`{}...`", &text[..cut]),
-                None => format!("`{}`", text),
-            }
+            format!("`{}`", shorten_for_report(pred.to_string()))
         }
 
         // The last step is where the deduction shows what is wrong with it: the predicate it came

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -240,9 +240,9 @@ impl Substitution {
                     self.substitute_predicate(predicate);
                 }
             }
-            UnificationErr::Disjoint(type_node, type_node1) => {
-                *type_node = self.substitute_type(type_node);
-                *type_node1 = self.substitute_type(type_node1);
+            UnificationErr::Disjoint(ty1, ty2) => {
+                *ty1 = self.substitute_type(ty1);
+                *ty2 = self.substitute_type(ty2);
             }
         }
     }
@@ -1158,12 +1158,12 @@ impl TypeCheckContext {
                 if ok_count == 0 {
                     let mut extra_srcs = vec![];
 
-                    let err_cnt = candidates_check_res
+                    let err_count = candidates_check_res
                         .iter()
                         .filter(|cand| cand.is_err())
                         .count();
                     let expected_type = self.substitute_type(&ty);
-                    let msg = if err_cnt == 1 {
+                    let msg = if err_count == 1 {
                         let (tc, fullname, scm, e) = candidates_check_res
                             .iter()
                             .find_map(|cand| cand.as_ref().err())
@@ -1200,11 +1200,11 @@ impl TypeCheckContext {
                             .iter()
                             .filter_map(|cand| cand.as_ref().err())
                         {
-                            let cnt = candidates_errors.len() + 1;
+                            let ref_no = candidates_errors.len() + 1;
                             let scm = tc.substitution.substitute_scheme(scm);
                             let msg = e.message_with_note(format!(
                                 "- ({}) `{}` of type `{}` does not match since `{}` cannot be deduced.",
-                                cnt,
+                                ref_no,
                                 fullname.to_string(),
                                 scm.to_string(),
                                 e.to_constraint_string(),
@@ -1213,8 +1213,9 @@ impl TypeCheckContext {
                             let mut tvs = vec![];
                             scm.free_vars_to_vec(&mut tvs);
                             e.free_vars_to_vec(&mut tvs);
-                            extra_srcs
-                                .append(&mut self.create_tyvar_location_messages(&tvs, Some(cnt)));
+                            extra_srcs.append(
+                                &mut self.create_tyvar_location_messages(&tvs, Some(ref_no)),
+                            );
                         }
                         if candidates_errors.len() > 0 {
                             msg.push_str("\n");
@@ -2183,24 +2184,24 @@ impl TypeCheckContext {
     /// Reduces predicates stored in `self.predicates` as long as possible.
     /// If a predicate is unsatisfiable, returns `Err`.
     pub(crate) fn reduce_predicates(&mut self) -> Result<(), UnifOrOtherErr> {
-        let mut irr_preds = vec![];
+        let mut irreducible_preds = vec![];
         let mut deduction = PredicateDeduction::default();
         while let Some(pred) = self.predicates.pop() {
-            self.reduce_predicate(pred, &mut irr_preds, &mut deduction)?;
+            self.reduce_predicate(pred, &mut irreducible_preds, &mut deduction)?;
         }
-        self.predicates = irr_preds;
+        self.predicates = irreducible_preds;
         Ok(())
     }
 
-    // Reduce a predicate and add reduced predicates to `irr_preds`.
+    // Reduce a predicate and add reduced predicates to `irreducible_preds`.
     fn reduce_predicate(
         &mut self,
         pred: Predicate,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         for pred in pred.resolve_trait_aliases(&self.trait_env.aliases)? {
-            self.reduce_predicate_noalias(pred, irr_preds, deduction)?;
+            self.reduce_predicate_noalias(pred, irreducible_preds, deduction)?;
         }
         Ok(())
     }
@@ -2210,7 +2211,7 @@ impl TypeCheckContext {
     fn reduce_predicate_noalias(
         &mut self,
         mut pred: Predicate,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         self.substitute_predicate(&mut pred);
@@ -2264,7 +2265,13 @@ impl TypeCheckContext {
                         ctx_pred
                     })
                     .collect();
-                self.reduce_instance_context(&pred, &pred_str, context, irr_preds, deduction)?;
+                self.reduce_instance_context(
+                    &pred,
+                    &pred_str,
+                    context,
+                    irreducible_preds,
+                    deduction,
+                )?;
                 deduction.settled.insert(pred_str);
                 return Ok(());
             } else if !unifiable {
@@ -2278,7 +2285,7 @@ impl TypeCheckContext {
         if !unifiable {
             return Err(UnificationErr::Unsatisfiable(pred).into());
         }
-        irr_preds.push(pred);
+        irreducible_preds.push(pred);
         deduction.settled.insert(pred_str);
         return Ok(());
     }
@@ -2290,13 +2297,13 @@ impl TypeCheckContext {
         pred: &Predicate,
         pred_str: &str,
         context: Vec<Predicate>,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         deduction.enter(pred, pred_str);
         let deduced = context
             .into_iter()
-            .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irr_preds, deduction));
+            .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irreducible_preds, deduction));
         deduction.leave();
         deduced
     }
@@ -2906,12 +2913,21 @@ impl From<UnificationErr> for UnifOrOtherErr {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::TypeCheckContext;
     use crate::ast::expr::{
         expr_abs, expr_app, expr_array_lit, expr_eval, expr_ffi_call, expr_if, expr_let,
-        expr_make_struct, expr_match, expr_tyanno, expr_var, var_var,
+        expr_make_struct, expr_match, expr_tyanno, expr_var, var_var, ExprNode,
     };
+    use crate::ast::kind_scope::KindEnv;
+    use crate::ast::name::FullName;
+    use crate::ast::pattern::PatternNode;
+    use crate::ast::program::TypeEnv;
+    use crate::ast::traits::TraitEnv;
+    use crate::ast::types::TyCon;
     use crate::elaboration::typecheckcache::MemoryCache;
+    use crate::fixstd::builtin::make_bool_ty;
+    use crate::misc::Map;
+    use std::sync::Arc;
 
     /// Context over empty environments: the fallback typing reads only the
     /// fresh-type-variable counter, so no program state is needed.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -280,21 +280,26 @@ pub fn to_absolute_path(path: &Path) -> Result<PathBuf, Errors> {
     Ok(abs.unwrap())
 }
 
+/// Works deferred to the moment this value is dropped, run latest first.
 pub struct Finally {
+    /// The works deferred so far, in the order they were deferred.
     works: Vec<Box<dyn FnOnce()>>,
 }
 
 impl Finally {
+    /// A `Finally` with no work deferred.
     pub fn new() -> Self {
         Self { works: vec![] }
     }
 
+    /// Defers `work` until this value is dropped.
     pub fn defer<F: FnOnce() + 'static>(&mut self, work: F) {
         self.works.push(Box::new(work));
     }
 }
 
 impl Drop for Finally {
+    /// Runs the deferred works, latest first.
     fn drop(&mut self) {
         for work in self.works.drain(..).rev() {
             work();
@@ -310,10 +315,12 @@ pub fn disable_colored_no_tty() {
     }
 }
 
+/// Prints `msg` to standard error under an `info` label.
 pub fn info_msg(msg: &str) {
     eprintln!("{}: {}", "info".bright_blue().bold(), msg);
 }
 
+/// Prints `msg` to standard error under a `warning` label.
 pub fn warn_msg(msg: &str) {
     eprintln!("{}: {}", "warning".yellow().bold(), msg);
 }
@@ -338,7 +345,10 @@ pub fn shorten_for_report(text: String) -> String {
     }
 }
 
-// Splits a string by spaces, but keeps the words in quotes as a single word.
+/// Splits `s` at spaces, keeping a quoted run of characters as one word.
+///
+/// Single and double quotes both quote, and a backslash makes the character after it part of the
+/// word it stands in. The quotes and backslashes themselves stay out of the words returned.
 pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut current_word = String::new();
@@ -375,7 +385,9 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     words
 }
 
-// Upper CamelCase to lower_snake_case
+/// Rewrites `s`, written in `UpperCamelCase`, as `lower_snake_case`.
+///
+/// Requires `s` to be ASCII alphanumeric.
 pub fn upper_camel_to_lower_snake(s: &str) -> String {
     assert!(
         s.chars().all(|c| c.is_ascii_alphanumeric()),

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -324,6 +324,20 @@ pub fn prompt_style(s: &str) -> ColoredString {
     s.bright_green().bold()
 }
 
+/// `text` cut short where it is too long for a report to carry, with an ellipsis marking the cut.
+///
+/// A type or a constraint that trips one of the compiler's bounds can be a term of any size, and
+/// the whole of one says no more than its beginning does.
+pub fn shorten_for_report(text: String) -> String {
+    /// How much of one term a report shows.
+    const MAX_SHOWN_CHARS: usize = 200;
+
+    match text.char_indices().nth(MAX_SHOWN_CHARS) {
+        Some((cut, _)) => format!("{}...", &text[..cut]),
+        None => text,
+    }
+}
+
 // Splits a string by spaces, but keeps the words in quotes as a single word.
 pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     let mut result = Vec::new();

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -340,7 +340,7 @@ pub fn shorten_for_report(text: String) -> String {
 
 // Splits a string by spaces, but keeps the words in quotes as a single word.
 pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
-    let mut result = Vec::new();
+    let mut words = Vec::new();
     let mut current_word = String::new();
     let mut in_quotes = None; // None if not in quotes, Some(') if in single quotes, Some(") if in double quotes
     let mut escaped = false; // true if the previous character is an escape character
@@ -355,7 +355,7 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
         match c {
             ' ' if in_quotes.is_none() => {
                 if !current_word.is_empty() {
-                    result.push(current_word.clone());
+                    words.push(current_word.clone());
                     current_word.clear();
                 }
             }
@@ -369,10 +369,10 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     }
 
     if !current_word.is_empty() {
-        result.push(current_word);
+        words.push(current_word);
     }
 
-    result
+    words
 }
 
 // Upper CamelCase to lower_snake_case
@@ -398,11 +398,15 @@ pub fn upper_camel_to_lower_snake(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        char_pos_to_utf16_pos, join_compiler_threads, spawn_compiler_thread, split_by_max_size,
+        split_string_by_space_not_quated, upper_camel_to_lower_snake, utf16_pos_to_utf8_byte_pos,
+    };
     use crate::error::any_to_string;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::thread::{self, JoinHandle};
     use std::time::Duration;
 
     /// Every thread has finished by the time a worker's panic is carried on, so unwinding never

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod test_match_return_outer;
 mod test_memcheck;
 mod test_no_runtime_check_setting;
 mod test_opaque_type;
+mod test_predicate_deduction;
 mod test_preliminary_commands;
 mod test_provenance;
 mod test_punched_array;

--- a/src/tests/test_associated_type.rs
+++ b/src/tests/test_associated_type.rs
@@ -1047,3 +1047,160 @@ pub fn test_associated_type_inner_bound_only_by_equalities() {
     "##;
     test_source(&source, Configuration::develop_mode());
 }
+
+/// An equality constraint on an associated type of arity 2 whose extra argument is a concrete type:
+/// the constraint is accepted, and the reduction at the call site takes the implementation's value
+/// for that argument.
+#[test]
+pub fn test_equality_constraint_on_a_two_argument_associated_type() {
+    let source = r#"
+module Main;
+
+trait c : Coll {
+    type Conv c p;
+    conv : c -> Conv c I64;
+}
+
+impl Array a : Coll {
+    type Conv (Array a) p = p;
+    conv = |_| 42;
+}
+
+show_conv : [c : Coll, Conv c I64 = e, e : ToString] c -> String;
+show_conv = |x| x.conv.to_string;
+
+main : IO ();
+main = (
+    assert_eq(|_|"", show_conv([1, 2, 3]), "42");;
+    pure()
+);
+    "#;
+    test_source(&source, Configuration::develop_mode());
+}
+
+/// An equality constraint is accepted only where the signature also assumes that its first argument
+/// implements the trait the associated type belongs to.
+#[test]
+pub fn test_equality_constraint_whose_trait_is_not_assumed() {
+    let source = r#"
+module Main;
+
+trait c : Coll {
+    type Ele c;
+    first : c -> Ele c;
+}
+
+impl Array a : Coll {
+    type Ele (Array a) = a;
+    first = |xs| xs.@(0);
+}
+
+bad : [Ele c = I64] c -> I64;
+bad = |_| 0;
+
+main : IO ();
+main = println(bad([1, 2]).to_string);
+    "#;
+    test_source_fail(source, Configuration::develop_mode(), "is not assumed");
+}
+
+/// Two equality constraints on one associated type application are rejected, which is what leaves
+/// the reduction of a type by the assumed equalities a single answer.
+#[test]
+pub fn test_two_equality_constraints_with_the_same_left_side() {
+    let source = r#"
+module Main;
+
+trait c : Coll {
+    type Ele c;
+    first : c -> Ele c;
+}
+
+impl Array a : Coll {
+    type Ele (Array a) = a;
+    first = |xs| xs.@(0);
+}
+
+bad : [c : Coll, Ele c = I64, Ele c = Bool] c -> I64;
+bad = |_| 0;
+
+main : IO ();
+main = println(bad([1, 2]).to_string);
+    "#;
+    test_source_fail(
+        source,
+        Configuration::develop_mode(),
+        "Multiple equality constraints with the same left side are not allowed.",
+    );
+}
+
+/// Two implementations of a trait that declares an associated type and no value member are reported
+/// as overlapping. This is the check that keeps such an associated type a single answer: a trait
+/// with no value member contributes no global value for the checks that walk those to reach.
+#[test]
+pub fn test_overlapping_instances_of_a_trait_without_value_members() {
+    let source = r#"
+module Main;
+
+type [f : *->*] Hoge f = unbox struct { d : f I64 };
+
+trait c : Marker {
+    type Tag c;
+}
+
+impl [f : *->*] Hoge f : Marker {
+    type Tag (Hoge f) = I64;
+}
+
+impl Hoge Array : Marker {
+    type Tag (Hoge Array) = Bool;
+}
+
+pick : [c : Marker, Tag c = t, t : ToString] c -> t -> String;
+pick = |_, x| x.to_string;
+
+main : IO ();
+main = println(pick(Hoge { d : [1, 2] }, 42));
+    "#;
+    test_source_fail(
+        source,
+        Configuration::develop_mode(),
+        "Two trait implementations for `Main::Marker` are overlapping.",
+    );
+}
+
+/// Two values of one name whose constraints differ only in an equality on an associated type: the
+/// one whose equality holds for the receiver is the one the overloading resolves to.
+#[test]
+pub fn test_equality_constraint_alone_resolves_the_overload() {
+    let source = r##"
+module Main;
+
+trait c : Holder {
+    type Held c;
+}
+
+type W a = unbox struct { x : a };
+
+impl W a : Holder {
+    type Held (W a) = I64;
+}
+
+namespace NS1 {
+    f : [c : Holder, Held c = String] c -> I64;
+    f = |_| 0;
+}
+
+namespace NS2 {
+    f : [c : Holder, Held c = I64] c -> I64;
+    f = |_| 1;
+}
+
+main : IO ();
+main = (
+    assert_eq(|_|"", (W { x : 1 }).f, 1);;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}

--- a/src/tests/test_predicate_deduction.rs
+++ b/src/tests/test_predicate_deduction.rs
@@ -45,7 +45,7 @@ main = println(Wrap { data : Wrap { data : 42 } }.show);
 }
 
 #[test]
-pub fn test_unfounded_instance_context_via_equality() {
+pub fn test_unsatisfiable_instance_context_via_equality() {
     // The same program with an associated type that leads out of the instance instead of back into
     // it. What the context asks for is then a constraint of its own, and no instance gives it.
     let source = r##"
@@ -79,7 +79,7 @@ main = println(Wrap { data : Wrap { data : 42 } }.show);
 }
 
 #[test]
-pub fn test_nested_instance_context_via_equality() {
+pub fn test_shrinking_instance_context_via_equality() {
     // An instance of the same shape, with everything its context asks for given: deducing
     // `Wrap (Wrap I64) : Show` asks for `Wrap I64 : Show`, which asks for `I64 : Show`, which an
     // instance gives outright. A deduction that reaches the trait it started from, at a smaller

--- a/src/tests/test_predicate_deduction.rs
+++ b/src/tests/test_predicate_deduction.rs
@@ -9,11 +9,11 @@ use crate::{
     tests::test_util::{run_source_assert_failed, test_source, test_source_fail},
 };
 
+/// `Wrap (Wrap I64) : Show` is given by the instance below, whose context asks for
+/// `Held (Wrap I64) : Show`. The associated type sends that back to `Wrap (Wrap I64) : Show`, which
+/// is what is being deduced, so nothing gives `Show` here.
 #[test]
 pub fn test_circular_instance_context_via_equality() {
-    // `Wrap (Wrap I64) : Show` is given by the instance below, whose context asks for
-    // `Held (Wrap I64) : Show`. The associated type sends that back to `Wrap (Wrap I64) : Show`,
-    // which is what is being deduced, so nothing gives `Show` here.
     let source = r##"
 module Main;
 
@@ -44,10 +44,11 @@ main = println(Wrap { data : Wrap { data : 42 } }.show);
     );
 }
 
+/// The program of `test_circular_instance_context_via_equality` with an associated type that leads
+/// out of the instance instead of back into it. What the context asks for is then a constraint of
+/// its own, and no instance gives it.
 #[test]
 pub fn test_unsatisfiable_instance_context_via_equality() {
-    // The same program with an associated type that leads out of the instance instead of back into
-    // it. What the context asks for is then a constraint of its own, and no instance gives it.
     let source = r##"
 module Main;
 
@@ -78,12 +79,12 @@ main = println(Wrap { data : Wrap { data : 42 } }.show);
     );
 }
 
+/// An instance of the shape used in `test_circular_instance_context_via_equality`, with everything
+/// its context asks for given: deducing `Wrap (Wrap I64) : Show` asks for `Wrap I64 : Show`, which
+/// asks for `I64 : Show`, which an instance gives outright. A deduction that reaches the trait it
+/// started from, at a smaller type each time, is what a program writes, and is accepted.
 #[test]
 pub fn test_shrinking_instance_context_via_equality() {
-    // An instance of the same shape, with everything its context asks for given: deducing
-    // `Wrap (Wrap I64) : Show` asks for `Wrap I64 : Show`, which asks for `I64 : Show`, which an
-    // instance gives outright. A deduction that reaches the trait it started from, at a smaller
-    // type each time, is what a program writes, and stays accepted.
     let source = r##"
 module Main;
 
@@ -124,11 +125,11 @@ main = (
     test_source(&source, Configuration::develop_mode());
 }
 
+/// The associated type sends the deduction to a type one `Wrap` larger every time, so it never asks
+/// for the same constraint twice. The bound on how deep a type the deduction asks about is what
+/// ends it.
 #[test]
 pub fn test_growing_instance_context_via_equality() {
-    // The associated type sends the deduction to a type one `Wrap` larger every time, so it never
-    // asks for the same constraint twice. The bound on how deep a type the deduction asks about is
-    // what ends it.
     let source = r##"
 module Main;
 
@@ -168,10 +169,10 @@ main = println(Wrap { data : Wrap { data : 42 } }.show);
     );
 }
 
+/// A trait with no members: the instance says that `Foo a : Marker` holds when `Foo a : Marker`
+/// holds, which gives `Foo I64 : Marker` no more than declaring no instance would.
 #[test]
 pub fn test_circular_instance_context_of_trait_without_members() {
-    // A trait with no members: the instance says that `Foo a : Marker` holds when `Foo a : Marker`
-    // holds, which gives `Foo I64 : Marker` no more than declaring no instance would.
     let source = r##"
 module Main;
 
@@ -194,11 +195,11 @@ main = println(need_marker(Foo { x : 42 }).to_string);
     );
 }
 
+/// Two instances that each ask for what the other gives. The deduction comes back to where it
+/// started after a turn through both, and the report names the constraint it turned through, which
+/// is what leads the reader to the second instance.
 #[test]
 pub fn test_mutually_circular_instance_contexts() {
-    // Two instances that each ask for what the other gives. The deduction comes back to where it
-    // started after a turn through both, and the report names the constraint it turned through,
-    // which is what leads the reader to the second instance.
     let source = r##"
 module Main;
 
@@ -236,6 +237,7 @@ main = println(need_a(Foo { x : 42 }).to_string);
 /// would come from if the deduction did not carry the bound of its own.
 #[test]
 pub fn test_a_predicate_at_the_depth_bound_is_deduced_and_one_past_it_is_not() {
+    /// A program that requires `Marker` of `I64` wrapped in `levels` nested `W`s.
     fn source_nesting(levels: usize) -> String {
         let mut ty = "I64".to_string();
         for _ in 0..levels {
@@ -279,7 +281,7 @@ main = (
 }
 
 /// A circle is reported the same way when the constraint settles only after the whole definition
-/// has been checked, which is a report the type checker builds in another place.
+/// has been checked, where `check_type` builds the report.
 #[test]
 pub fn test_circular_instance_context_settled_at_the_end_of_a_definition() {
     let source = r##"
@@ -314,10 +316,10 @@ main = println(g(0).to_string);
     }
 }
 
+/// A trait whose only member is an associated type. The instance gives the associated type
+/// outright, but the constraint that lets the program name it is deduced from itself.
 #[test]
 pub fn test_circular_instance_context_of_associated_type() {
-    // A trait whose only member is an associated type. The instance gives the associated type
-    // outright, but the constraint that lets the program name it is deduced from itself.
     let source = r##"
 module Main;
 

--- a/src/tests/test_predicate_deduction.rs
+++ b/src/tests/test_predicate_deduction.rs
@@ -1,0 +1,244 @@
+//! Deducing the trait constraints a program requires.
+//!
+//! A constraint holds when an instance gives it and everything that instance's context asks for
+//! holds in turn. These tests fix what happens when the asking comes back to where it started, and
+//! when it goes on forever.
+
+use crate::{
+    configuration::Configuration,
+    tests::test_util::{test_source, test_source_fail},
+};
+
+#[test]
+pub fn test_circular_instance_context_via_equality() {
+    // `Wrap (Wrap I64) : Show` is given by the instance below, whose context asks for
+    // `Held (Wrap I64) : Show`. The associated type sends that back to `Wrap (Wrap I64) : Show`,
+    // which is what is being deduced, so nothing gives `Show` here.
+    let source = r##"
+module Main;
+
+trait c : Holder {
+    type Held c;
+}
+trait a : Show {
+    show : a -> String;
+}
+
+type Wrap c = unbox struct { data : c };
+
+impl Wrap c : Holder {
+    type Held (Wrap c) = Wrap (Wrap c);
+}
+
+impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
+    show = |_| "Wrap(" + (undefined("no value") : Held c).show + ")";
+}
+
+main : IO ();
+main = println(Wrap { data : Wrap { data : 42 } }.show);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Deducing it needs itself",
+    );
+}
+
+#[test]
+pub fn test_unfounded_instance_context_via_equality() {
+    // The same program with an associated type that leads out of the instance instead of back into
+    // it. What the context asks for is then a constraint of its own, and no instance gives it.
+    let source = r##"
+module Main;
+
+trait c : Holder {
+    type Held c;
+}
+trait a : Show {
+    show : a -> String;
+}
+
+type Wrap c = unbox struct { data : c };
+
+impl Wrap c : Holder {
+    type Held (Wrap c) = I64;
+}
+
+impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
+    show = |_| "Wrap(" + (undefined("no value") : Held c).show + ")";
+}
+
+main : IO ();
+main = println(Wrap { data : Wrap { data : 42 } }.show);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "`Std::I64 : Main::Show` cannot be deduced",
+    );
+}
+
+#[test]
+pub fn test_nested_instance_context_via_equality() {
+    // An instance of the same shape, with everything its context asks for given: deducing
+    // `Wrap (Wrap I64) : Show` asks for `Wrap I64 : Show`, which asks for `I64 : Show`, which an
+    // instance gives outright. A deduction that reaches the trait it started from, at a smaller
+    // type each time, is what a program writes, and stays accepted.
+    let source = r##"
+module Main;
+
+trait c : Holder {
+    type Held c;
+    to_held : c -> Held c;
+}
+trait a : Show {
+    show : a -> String;
+}
+
+type Wrap c = unbox struct { data : c };
+
+impl Wrap c : Holder {
+    type Held (Wrap c) = Wrap c;
+    to_held = |w| w;
+}
+
+impl I64 : Holder {
+    type Held I64 = I64;
+    to_held = |x| x;
+}
+
+impl I64 : Show {
+    show = |x| x.to_string;
+}
+
+impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
+    show = |w| "Wrap(" + w.@data.to_held.show + ")";
+}
+
+main : IO ();
+main = (
+    assert_eq(|_|"", Wrap { data : Wrap { data : 42 } }.show, "Wrap(Wrap(42))");;
+    pure()
+);
+    "##;
+    test_source(&source, Configuration::develop_mode());
+}
+
+#[test]
+pub fn test_growing_instance_context_via_equality() {
+    // The associated type sends the deduction to a type one `Wrap` larger every time, so it never
+    // asks for the same constraint twice. The bound on how deep a type the deduction asks about is
+    // what ends it.
+    let source = r##"
+module Main;
+
+trait c : Holder {
+    type Held c;
+}
+trait a : Show {
+    show : a -> String;
+}
+
+type Wrap c = unbox struct { data : c };
+
+impl Wrap c : Holder {
+    type Held (Wrap c) = Wrap (Wrap (Wrap c));
+}
+
+impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
+    show = |_| "Wrap(" + (undefined("no value") : Held c).show + ")";
+}
+
+main : IO ();
+main = println(Wrap { data : Wrap { data : 42 } }.show);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "so the deduction does not end",
+    );
+}
+
+#[test]
+pub fn test_circular_instance_context_of_trait_without_members() {
+    // A trait with no members: the instance says that `Foo a : Marker` holds when `Foo a : Marker`
+    // holds, which gives `Foo I64 : Marker` no more than declaring no instance would.
+    let source = r##"
+module Main;
+
+trait a : Marker {}
+
+type Foo a = unbox struct { x : a };
+
+impl [Foo a : Marker] Foo a : Marker {}
+
+need_marker : [a : Marker] a -> I64;
+need_marker = |_| 0;
+
+main : IO ();
+main = println(need_marker(Foo { x : 42 }).to_string);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Deducing it needs itself",
+    );
+}
+
+#[test]
+pub fn test_mutually_circular_instance_contexts() {
+    // Two instances that each ask for what the other gives. The deduction comes back to where it
+    // started after a turn through both.
+    let source = r##"
+module Main;
+
+trait a : A {}
+trait a : B {}
+
+type Foo a = unbox struct { x : a };
+
+impl [Foo a : B] Foo a : A {}
+impl [Foo a : A] Foo a : B {}
+
+need_a : [a : A] a -> I64;
+need_a = |_| 0;
+
+main : IO ();
+main = println(need_a(Foo { x : 42 }).to_string);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Deducing it needs itself",
+    );
+}
+
+#[test]
+pub fn test_circular_instance_context_of_associated_type() {
+    // A trait whose only member is an associated type. The instance gives the associated type
+    // outright, but the constraint that lets the program name it is deduced from itself.
+    let source = r##"
+module Main;
+
+trait a : Holder {
+    type Held a;
+}
+
+type Foo a = unbox struct { x : a };
+
+impl [Foo a : Holder] Foo a : Holder {
+    type Held (Foo a) = I64;
+}
+
+pick : [a : Holder, Held a = h] a -> h -> h;
+pick = |_, h| h;
+
+main : IO ();
+main = println(pick(Foo { x : 1 }, 5).to_string);
+    "##;
+    test_source_fail(
+        &source,
+        Configuration::develop_mode(),
+        "Deducing it needs itself",
+    );
+}

--- a/src/tests/test_predicate_deduction.rs
+++ b/src/tests/test_predicate_deduction.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     configuration::Configuration,
-    tests::test_util::{test_source, test_source_fail},
+    tests::test_util::{run_source_assert_failed, test_source, test_source_fail},
 };
 
 #[test]
@@ -152,10 +152,19 @@ impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
 main : IO ();
 main = println(Wrap { data : Wrap { data : 42 } }.show);
     "##;
-    test_source_fail(
-        &source,
-        Configuration::develop_mode(),
-        "so the deduction does not end",
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    assert!(
+        errmsg.contains("so the deduction does not end"),
+        "the deduction that does not end went unreported:\n{}",
+        errmsg
+    );
+    // The deduction asks about hundreds of constraints, the last of them on a type of thousands of
+    // characters. What the report shows of that is a few steps, each cut short.
+    assert!(
+        errmsg.len() < 4000,
+        "the report is {} characters long, which is more of the way than a reader can read:\n{}",
+        errmsg.len(),
+        errmsg
     );
 }
 
@@ -188,7 +197,8 @@ main = println(need_marker(Foo { x : 42 }).to_string);
 #[test]
 pub fn test_mutually_circular_instance_contexts() {
     // Two instances that each ask for what the other gives. The deduction comes back to where it
-    // started after a turn through both.
+    // started after a turn through both, and the report names the constraint it turned through,
+    // which is what leads the reader to the second instance.
     let source = r##"
 module Main;
 
@@ -206,11 +216,102 @@ need_a = |_| 0;
 main : IO ();
 main = println(need_a(Foo { x : 42 }).to_string);
     "##;
-    test_source_fail(
-        &source,
-        Configuration::develop_mode(),
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    for named in [
         "Deducing it needs itself",
+        "`Main::Foo Std::I64 : Main::A`",
+        "`Main::Foo Std::I64 : Main::B`",
+    ] {
+        assert!(
+            errmsg.contains(named),
+            "`{}` is missing from the report:\n{}",
+            named,
+            errmsg
+        );
+    }
+}
+
+/// A constraint on a type just under the depth bound is deduced, and one past it is reported by the
+/// deduction: the same bound holds for the layout of a type, and the layout is where the report
+/// would come from if the deduction did not carry the bound of its own.
+#[test]
+pub fn test_a_predicate_at_the_depth_bound_is_deduced_and_one_past_it_is_not() {
+    fn source_nesting(levels: usize) -> String {
+        let mut ty = "I64".to_string();
+        for _ in 0..levels {
+            ty = format!("W ({})", ty);
+        }
+        format!(
+            r##"
+module Main;
+
+type W a = unbox struct {{ x : a }};
+
+trait a : Marker {{}}
+
+impl I64 : Marker {{}}
+
+impl [a : Marker] W a : Marker {{}}
+
+need_marker : [a : Marker] a -> I64;
+need_marker = |_| 7;
+
+deep : {} -> I64;
+deep = |w| need_marker(w);
+
+main : IO ();
+main = (
+    let argc = *IO::get_arg_count;
+    let n = if argc < 0 {{ deep(undefined("no value")) }} else {{ 7 }};
+    assert_eq(|_|"", n, 7);;
+    pure()
+);
+            "##,
+            ty
+        )
+    }
+    test_source(&source_nesting(490), Configuration::develop_mode());
+    test_source_fail(
+        &source_nesting(510),
+        Configuration::develop_mode(),
+        "so the deduction does not end",
     );
+}
+
+/// A circle is reported the same way when the constraint settles only after the whole definition
+/// has been checked, which is a report the type checker builds in another place.
+#[test]
+pub fn test_circular_instance_context_settled_at_the_end_of_a_definition() {
+    let source = r##"
+module Main;
+
+trait a : Marker {}
+
+type Foo a = unbox struct { x : a };
+
+impl [Foo a : Marker] Foo a : Marker {}
+
+need_marker : [a : Marker] a -> I64;
+need_marker = |_| 0;
+
+g : I64 -> I64;
+g = |_| need_marker(Foo { x : 42 });
+
+main : IO ();
+main = println(g(0).to_string);
+    "##;
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    for named in [
+        "`Main::Foo Std::I64 : Main::Marker`",
+        "Deducing it needs itself",
+    ] {
+        assert!(
+            errmsg.contains(named),
+            "`{}` is missing from the report:\n{}",
+            named,
+            errmsg
+        );
+    }
 }
 
 #[test]

--- a/src/tests/test_predicate_deduction.rs
+++ b/src/tests/test_predicate_deduction.rs
@@ -276,7 +276,7 @@ main = (
     test_source_fail(
         &source_nesting(510),
         Configuration::develop_mode(),
-        "so the deduction does not end",
+        "past the depth the compiler settles a constraint about",
     );
 }
 
@@ -343,5 +343,42 @@ main = println(pick(Foo { x : 1 }, 5).to_string);
         &source,
         Configuration::develop_mode(),
         "Deducing it needs itself",
+    );
+}
+
+/// A deduction that takes a first step and then circles among the steps after it: the report shows
+/// the circle the deduction closes on rather than the step that led into it.
+#[test]
+pub fn test_circular_instance_context_reached_after_a_first_step() {
+    let source = r##"
+module Main;
+
+trait a : A {}
+trait a : B {}
+trait a : C {}
+
+type Foo a = unbox struct { x : a };
+
+impl [Foo a : B] Foo a : A {}
+impl [Foo a : C] Foo a : B {}
+impl [Foo a : B] Foo a : C {}
+
+need_a : [a : A] a -> I64;
+need_a = |_| 0;
+
+g : I64 -> I64;
+g = |_| need_a(Foo { x : 42 });
+
+main : IO ();
+main = println(g(0).to_string);
+    "##;
+    let errmsg = run_source_assert_failed(&source, Configuration::develop_mode());
+    assert!(
+        errmsg.contains(
+            "Deducing it needs itself: `Main::Foo Std::I64 : Main::B` -> \
+             `Main::Foo Std::I64 : Main::C` -> `Main::Foo Std::I64 : Main::B`."
+        ),
+        "the circle the deduction closes on went unreported:\n{}",
+        errmsg
     );
 }

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -31,23 +31,10 @@
 //! type.
 
 use crate::ast::program::TypeEnv;
-use crate::ast::types::TypeNode;
+use crate::ast::types::{TypeNode, MAX_TYPE_DEPTH};
 use crate::misc::{grow_stack, Set};
 use crate::object::{ty_to_object_ty, ObjectFieldType};
 use std::sync::Arc;
-
-/// How deeply a single type may nest before it is called endless.
-///
-/// This is a property of one type, not of the program: a chain of a thousand types that each hold
-/// the next is a thousand types of depth one, and a project keeps compiling however many such types
-/// it gains. A type reached from itself at a larger argument, on the other hand, gains a level at
-/// every step and passes any bound.
-///
-/// Over the benchmark corpus and the examples the deepest type reached is 10; a type written with
-/// 25 nested tuples reaches 27. The bound also caps how deep the walks over a type go — hashing it,
-/// substituting into it, printing it — so raising it costs stack on the programs it exists to
-/// reject.
-const MAX_TYPE_DEPTH: usize = 500;
 
 /// What the walk carries from one root to the next, so that a type is answered once however many
 /// values carry it.

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -171,15 +171,15 @@ fn depth_message(root: &Arc<TypeNode>, asked_for: &[Arc<TypeNode>]) -> String {
     /// visible, and short enough that the types printed are ones the reader can read.
     const SHOWN_STEPS: usize = 3;
 
-    let shown = asked_for
+    let steps = asked_for
         .iter()
         .take(SHOWN_STEPS)
         .map(|ty| format!("`{}`", shorten(ty)))
         .collect::<Vec<_>>();
-    let way_down = if shown.is_empty() {
+    let way_down = if steps.is_empty() {
         String::new()
     } else {
-        format!(" ({} -> ...)", shown.join(" -> "))
+        format!(" ({} -> ...)", steps.join(" -> "))
     };
     format!(
         "`{}` has no size: laying it out asks for types nested more than {} deep{}, so it needs \

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -163,6 +163,7 @@ fn no_size_in_place(
 /// where a type reached from itself at a larger argument shows itself. The type actually at fault
 /// is one the walk built on the way, and printing that one would print a term as deep as the bound.
 fn depth_message(root: &Arc<TypeNode>, asked_for: &[Arc<TypeNode>]) -> String {
+    /// One type as the report shows it, cut short where it is too long to show whole.
     fn shorten(ty: &Arc<TypeNode>) -> String {
         shorten_for_report(ty.to_string())
     }

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -32,7 +32,7 @@
 
 use crate::ast::program::TypeEnv;
 use crate::ast::types::{TypeNode, MAX_TYPE_DEPTH};
-use crate::misc::{grow_stack, Set};
+use crate::misc::{grow_stack, shorten_for_report, Set};
 use crate::object::{ty_to_object_ty, ObjectFieldType};
 use std::sync::Arc;
 
@@ -163,16 +163,8 @@ fn no_size_in_place(
 /// where a type reached from itself at a larger argument shows itself. The type actually at fault
 /// is one the walk built on the way, and printing that one would print a term as deep as the bound.
 fn depth_message(root: &Arc<TypeNode>, asked_for: &[Arc<TypeNode>]) -> String {
-    /// How much of a type to print before cutting it short. A type that trips the bound can be a
-    /// term of any size, and the whole of one says no more than its beginning does.
-    const MAX_SHOWN_CHARS: usize = 200;
-
     fn shorten(ty: &Arc<TypeNode>) -> String {
-        let text = ty.to_string();
-        match text.char_indices().nth(MAX_SHOWN_CHARS) {
-            Some((cut, _)) => format!("{}...", &text[..cut]),
-            None => text,
-        }
+        shorten_for_report(ty.to_string())
     }
 
     /// How many steps of the way down to show. Enough for one turn of a growing family to be


### PR DESCRIPTION
Closes #246

トレイト制約の演繹が、演繹の途中で同じ制約に戻ったとき、それを「成立」と読んでいた。根拠の無い制約が受理される。段ごとに制約が大きくなる形では同じ制約に戻らないので演繹が止まらず、診断もタイムアウトも無いままメモリを食い尽くす。

この PR は、演繹が持つ 1 つの集合を **経路** と **決着済み** の 2 つに割り、循環した演繹を報告する。加えて、大きくなり続ける演繹を制約の型の深さで打ち切る。

## 何が起きていたか

制約は、その制約を与える instance を見つけ、その instance の文脈が要求する制約を順に演繹して成立する。演繹はこの再帰を降りる前に、いま演繹している制約の印字形を集合 `skip` に入れ、**上がるときに外さなかった**。集合が意味していたのは「答えが出た」ではなく「降り始めた」で、判定はそれを「答えが出た」として読む。

```fix
module Main;

trait c : Holder { type Held c; }
trait a : Show { show : a -> String; }

type Wrap c = unbox struct { data : c };

impl Wrap c : Holder {
    type Held (Wrap c) = Wrap (Wrap c);
}

impl [c : Holder, Held c = e, e : Show] Wrap c : Show {
    show = |_| "Wrap(" + (undefined("no value") : Held c).show + ")";
}

main : IO ();
main = println(Wrap { data : Wrap { data : 42 } }.show);
```

これはコンパイルが通り、実行ファイルができていた。`Show` の根拠はどこにも無い。`Wrap (Wrap I64) : Show` を与える instance は 1 つで、その文脈は `Held (Wrap I64) : Show` を要求し、関連型の実装がそれを `Wrap (Wrap I64) : Show` に簡約する — 出発点そのものである。

関連型の実装を 1 段深くすると (`type Held (Wrap c) = Wrap (Wrap (Wrap c));`)、演繹は `Wrap (Wrap I64)`, `Wrap (Wrap (Wrap (Wrap I64)))`, ... と進んで同じ制約には二度と戻らない。RSS が毎秒 30 MB で単調に増え続け、診断もタイムアウトも無い。

なお、この形の instance 文脈 (`Held c = e, e : Show`) は正規の書き方である。制約の形の検査が要求するのは述語の主語が型変数であることで、関連型への制約は等式を経由して書く。標準ライブラリの `impl [i : Iterator, Item i = a] MapIterator i a b : Iterator` と同じ形である。

## 状態の推移

登場する関数は 4 つ。

- **`TypeCheckContext::reduce_predicates`** — 型検査が溜めた制約を全部取り出し、1 つずつ演繹する。決着しなかったものは「まだ具体化されていないので後で決まるかもしれない」制約として残す。
- **`reduce_predicate`** — 1 つの制約を、それがトレイトエイリアスなら展開してから次へ渡す。
- **`reduce_predicate_noalias`** — 1 つの制約を演繹する本体。置換を適用し、関連型を簡約し、宣言された instance の頭と照合し、合ったものの文脈が要求する制約を再帰的に演繹する。
- **`reduce_instance_context`** (この PR で新設) — 合った instance の文脈が要求する制約を順に演繹する。上の再帰をこの関数に切り出した。

### 通っていた実行

`main` の型検査は `Wrap (Wrap I64) : Show` を要求する。`reduce_predicates` がそれを取り出し、`reduce_predicate_noalias` に渡す。運ばれる状態は集合 1 つ (`skip`) である。

1. `skip = {}`。制約 `Wrap (Wrap I64) : Show` の印字形が `skip` に無いので進み、**再帰に入る前に**入れる。`skip = {"Wrap (Wrap I64) : Show"}`。
2. instance `Wrap c : Show` の頭が合う (`c := Wrap I64`)。文脈の等式 `Held c = e` を文脈に足すと、関連型の実装により `e := Wrap (Wrap I64)` が決まる。
3. 文脈の述語 `e : Show` を演繹する。置換を適用すると `Wrap (Wrap I64) : Show` — 手順 1 と同じ制約である。
4. `skip` に入っているので `Ok(())` を返す。
5. 手順 3 が成功したので手順 2 も成功し、`reduce_predicate_noalias` は `Ok(())` を返す。**`Wrap (Wrap I64) : Show` は成立したことになる。**

状態が最初に誤るのは手順 4 である。`skip` にあることが意味していたのは「手順 1 でこの制約を演繹し始めた」だけで、答えは出ていない。手順 5 はその読みの上で確定する。

### 直した実行

運ぶ状態は 2 つの集合になる。`on_path` は降りるときに入れて上がるときに外すもの、`settled` は上がるときに入れるものである。

1. `on_path = {}`, `settled = {}`。制約はどちらにも無いので進む。`settled` への追加はまだ行わない。
2. instance の頭が合う。`reduce_instance_context` を呼ぶ。この関数が `on_path` に入れる: `on_path = {"Wrap (Wrap I64) : Show"}`。
3. 文脈の述語 `e : Show` を演繹する。置換の後は `Wrap (Wrap I64) : Show`。
4. `settled` には無い。`on_path` にある。**ここで `UnificationErr::Circular` を返す**。運ぶのは経路を一周した制約の列で、報告はそれを見せる。
5. 誤りは `reduce_instance_context` に戻る。この関数は `on_path` から外してから誤りを上へ運ぶので、集合は釣り合ったままである。
6. `check_type` が、決着しなかった制約の報告を作る。

段ごとに大きくなる形は、手順 4 で `on_path` に当たらない。制約の型が毎段深くなるので、`reduce_predicate_noalias` は関連型を簡約した後に型の深さを見て、`MAX_TYPE_DEPTH` (500) を超えたら `UnificationErr::Endless` を返す。上限を「型 1 つの項の深さ」に置く根拠は #193 のときと同じで、プログラムの大きさに比例する量に上限を置くと、モジュールを足しただけでコンパイルできなくなるからである。この上限は型のレイアウトの検査がすでに持っていたので、定数を `src/ast/types.rs` の `TypeNode::depth` の隣に移して 2 か所で共有する。

**上限が届かない形が残っている。** 演繹 1 段あたりの仕事は型の深さではなく大きさに比例し、引数を 2 か所に置く関連型は 1 段で大きさを倍にする。深さ 500 に達する前にメモリを使い果たす。この PR より前のコンパイラでも同じプログラムは同じように死ぬので退行ではないが、この PR が入れた上限が塞げていない穴であり、**#266** に測定つきで書いた。

## ユーザに見える文

### 循環した演繹

上の再現に対して:

```
error: `Main::Show::show` of type `[a : Main::Show] a -> Std::String` does not match the expected
type `Main::Wrap (Main::Wrap Std::I64) -> Std::String` since
`Main::Wrap (Main::Wrap Std::I64) : Main::Show` cannot be deduced. Deducing it needs itself: the
instance that gives it asks for it again.
```

instance を 2 つ経由する循環では、通過した制約を名指す。

```fix
trait a : A {}
trait a : B {}
type Foo a = unbox struct { x : a };
impl [Foo a : B] Foo a : A {}
impl [Foo a : A] Foo a : B {}
need_a : [a : A] a -> I64;
need_a = |_| 0;
main : IO ();
main = println(need_a(Foo { x : 42 }).to_string);
```

```
error: ... since `Main::Foo Std::I64 : Main::A` cannot be deduced. Deducing it needs itself:
`Main::Foo Std::I64 : Main::A` -> `Main::Foo Std::I64 : Main::B` -> `Main::Foo Std::I64 : Main::A`.
```

### 終わらない演繹

`type Held (Wrap c) = Wrap (Wrap (Wrap c));` に変えた再現に対して:

```
error: ... since `Main::Wrap (Main::Wrap Std::I64) : Main::Show` cannot be deduced. Deducing it
asks about types nested more than 500 deep, so the deduction does not end:
`Main::Wrap (Main::Wrap Std::I64) : Main::Show` ->
`Main::Wrap (Main::Wrap (Main::Wrap Std::I64)) : Main::Show` ->
`Main::Wrap (Main::Wrap (Main::Wrap (Main::Wrap Std::I64))) : Main::Show` -> ... ->
`Main::Wrap (Main::Wrap (Main::Wrap (Main::Wrap (Main::Wrap (Main::Wrap (Main::Wr...`.
An instance whose context asks for what it gives, on a larger type, does this.
```

見せるのは先頭 3 段と最後の 1 段で、各段は 200 文字で切る。全部見せると 103,855 文字になる。

### 深さの上限に、演繹が 1 歩も進まずに当たる場合

演繹の前から制約の型が上限より深いとき、経路には 1 段も無い。この場合に上の文面を出すと、起きていない 2 つのこと (演繹が終わらないこと、大きくなる instance があること) を述べることになるので、文を分けている。

```
error: ... since `Main::W (Main::W (...)) : Main::Marker` cannot be deduced. The type it names
nests more than 500 deep, which is past the depth the compiler settles a constraint about.
```

### CHANGELOG

`### Fixed` / `#### Language` に 1 件:

> - A trait constraint that is deduced from itself is now rejected, instead of being accepted with nothing behind it. With `impl Wrap c : Holder { type Held (Wrap c) = Wrap (Wrap c); }`, the instance `impl [c : Holder, Held c = e, e : Show] Wrap c : Show` made deducing `Wrap (Wrap I64) : Show` ask for `Wrap (Wrap I64) : Show` again, and the program compiled although nothing gives `Show` to anything. Where each step asks about a larger type instead of the same one (`type Held (Wrap c) = Wrap (Wrap (Wrap c));`), the compiler used to take memory without end and report nothing; it now reports that the deduction asks about types nested more than 500 deep.

## 変更した関数

### `src/elaboration/typecheck.rs`

- **`TypeCheckContext::reduce_predicates`** — 役割は上記。集合 1 つの代わりに `PredicateDeduction` を 1 つ作って渡す。演繹 1 回ぶんの状態が 1 つの値になる。
- **`reduce_predicate`** — 役割は上記。運ぶ状態の型が変わっただけ。
- **`reduce_predicate_noalias`** — 役割は上記。`skip` への読み書きが、`settled` の参照 (当たれば `Ok`)、`on_path` の参照 (当たれば `Circular`)、決着したときの `settled` への追加、の 3 つに分かれた。関連型を簡約した後に型の深さを見る検査が加わった。instance の文脈を演繹する再帰は `reduce_instance_context` に移した。
- **`reduce_instance_context`** (新設) — 合った instance の文脈が要求する制約を順に演繹する。その間、演繹中の制約を経路に載せておくので、戻ってきた演繹がそれと分かる。誤りで抜けるときも経路から外してから運ぶ。
- **`PredicateDeduction`** (新設) — 演繹 1 回が持ち歩く状態。経路 (`path` と、その印字形の集合 `on_path`) と決着済み (`settled`)。`enter` / `leave` が経路の出入り、`way_round` / `way_down` が報告に見せる列を作る。
- **`UnificationErr`** — 型検査が決着させられなかった制約を表す。`Circular` と `Endless` の 2 つの variant が増えた。どちらも制約の列を運ぶ。
- **`UnificationErr::to_constraint_string`** — 報告が名指しする制約の印字形を返す。新しい 2 つは列の先頭の制約を返す。
- **`UnificationErr::message_with_note`** (新設) — 制約を名指す文の後ろに、演繹が何をしたかを足す。制約ではなく演繹の側が失敗している 2 つの variant でだけ足りる。報告を作る 4 か所がこれを通す。
- **`UnificationErr::note` / `way_string` / `reported_predicate`** (新設) — 足す文の組み立て。
- **`UnificationErr::free_vars_to_vec`** と **`Substitution::substitute_unification_error`** — 誤りが運ぶ型から型変数を集める / 誤りが運ぶ型に置換を適用する。新しい 2 つの variant を、運ぶ制約の列すべてについて扱う。
- **報告を作る 4 か所** — `unify_type_of_expr` の名前の候補が 1 つも残らなかったときの 2 つ (候補が 1 つのときと複数のとき)、`create_type_mismatch_error`、`check_type` の `make_error`。いずれも文を組み立てる `format!` を `message_with_note` で包む。

### `src/ast/types.rs`

- **`MAX_TYPE_DEPTH`** — 型 1 つの項がどこまで深くなってよいかの上限。`src/type_size.rs` から移した。演繹とレイアウトの 2 か所が同じ量に上限を置くので、定数と、なぜプログラムの大きさではなく型 1 つの性質に上限を置くのかという根拠を、`TypeNode::depth` の隣の 1 か所に置く。

### `src/misc.rs`

- **`shorten_for_report`** (新設) — 報告に載せるには長すぎる印字形を切り、切ったことを `...` で示す。`type_size` の報告が持っていた同じ処理を、演繹の報告と共有する。

### `src/type_size.rs`

- **`depth_message`** — 型のレイアウトが上限を超えたときの報告を作る。自前の切り詰めをやめて `shorten_for_report` を呼ぶ。定数の移動に伴う import の変更を含む。

## テスト

`src/tests/test_predicate_deduction.rs` (新設、10 件) と `src/tests/test_associated_type.rs` (5 件追加)。

演繹そのもの: 等式を経由する循環が拒否されること、その対照 (関連型が instance の外へ出る形は `Std::I64 : Main::Show` として正しく拒否される / 毎段小さくなる形は通って走る)、大きくなる形が有限時間で報告されること、値メンバを持たないトレイト・互いを要求する 2 つの instance・関連型だけを持つトレイトの循環が拒否されること。

報告の側: 2 つの instance を経由する循環が通過した制約を名指すこと、1 歩進んでから始まる循環が「入口」ではなく「輪」を見せること、終わらない演繹の報告が読める長さ (960 文字) に収まること、深さの上限の直下は演繹され直上は演繹の側が報告すること、定義の末尾で決まる循環も同じ説明を持つこと。

環境の側 (バグハントが置いていったもの): 引数 2 つの関連型への等式が具体的な引数で使えること、等式のトレイトが仮定されていない場合と同じ左辺の等式が 2 つある場合が拒否されること、値メンバを持たないトレイトの重なった instance が報告されること、等式だけが違う 2 つの候補から正しい方が選ばれること。

全 1368 テスト green。

## 測定

型検査に検査が 2 つ増えるので、コンパイル時間を命令数で測った (`perf stat -e instructions`、`-O none`)。

| | main | この PR | 差 |
|---|---|---|---|
| hello world (キャッシュ無し、`Std` を全部コンパイル) | 3.8003 G | 3.8037 G | +0.09% |
| 制約を持つ呼び出しを 900 か所並べた合成プログラム | 6.0482 G | 6.0696 G | +0.35% |

コンパイラの外のコードでも確かめた。**minilib の 16 プロジェクトを `fix test` に掛けて全部 green** (`fixlang-minilib-{app,binary,collection,common,comonad,crypto,io,json,math,media,monad,net,random,text,thread,xml}`、依存は registry から取り直し、`examples` は `[build.test]` を持たないので対象外)。トレイトと関連型を重く使うコードなので、演繹の変更が既存のプログラムを落とさないことの確認になる。

## この PR に入れなかったもの

**値メンバを持たないトレイトでは `impl` の文脈の形の検査が走らない件** (#246 本文の再現 3)。検査の入口が `Program::validate_global_value_type_constraints` のグローバル値の歩きなので、値メンバの無い `impl` はそこに現れない。この PR の修正で再現 3 の**受理**は消えている (循環した演繹として拒否される)。残るのは形の検査の適用範囲の不整合で、**#278** に分けた。揃える向きは「厳しくする」— 述語の主語は型変数に限る — で決まっている (#252 が予告する一般化は関連型の適用についての話で、変換後も主語は型変数のままである)。#278 の作業には、この PR が入れたテスト 5 本を等式経由の形へ書き換えることが含まれる。同じ入口を持つ副作用として #268 (同じ誤りが値メンバの数 x 2 個の診断になる) があり、#278 と一緒に片付くものとして書いてある。

## 付録 A: バグハントが見つけたもの

この PR に対するバグハント (finder 2 本、うち 1 本は「演繹は文脈を変えながら進む」というレンズ) が 4 件を出した。

- **#266** — 上限が深さにしか掛かっておらず、大きさが倍々に増える関連型では届かない。48.8 GiB / 173 秒で SIGKILL。修正前のコンパイラでも同じなので退行ではない。指数になっているのは、共有された部分項を経路ごとに歩き直す `reduce_type_by_equality` と、DAG を木として印字する集合の鍵の 2 か所。
- この PR の診断の誤り (**この PR で修正済み、`f2d17a25`**) — 演繹が 1 歩も進まずに上限へ当たる場合に、起きていないことを述べていた。上の「ユーザに見える文」の 3 つ目がその修正後の文面である。**報告が経路から作られている以上、経路が空の場合を読み直さないと、隣に書いたテストが誤った文面を固定する。**
- **#267** — 決着しなかった制約が、その後に現れた無関係な名前のせいにされる (`need_a("s").to_string` が `Std::String : Main::A` の理由として `to_string` を名指す)。修正前から在る。
- **#268** — `impl` の文脈の 1 つの誤りが、エディタには値メンバの数 x 2 個の診断として届く。
- **#170** に、もう 1 つの再現と language server への影響 (診断スレッドが死んだまま復帰しない) をコメントした。

発火しなかった検査も置いておく: `Substitution::compose` の「像に束縛変数を含まない」不変条件、`matching` の関連型の引数の数の一致、`reduce_type_by_equality` で 2 つ目の等式が 1 つ目と食い違うこと、経路と決着済みの釣り合い、演繹の終了時に保留された制約が陳腐化していないこと — 全 1362 テストでどれも発火しなかった。

## 付録 B: コードレビューが変えたもの

- `test-sufficiency` が出した 4 件を採用した。いずれも実装を壊して赤くなることを確認してから入れている: 2 つの instance をまたぐ循環が通過した制約を名指すこと (2 つの報告を 1 つに潰すと落ちる)、終わらない演繹の報告が 960 文字に収まること (省略を外すと 103,855 文字)、深さの上限の直下と直上 (演繹側の上限を外すとレイアウト側の文面が出る)、定義の末尾で決まる循環 (`message_with_note` を外すと落ちる)。
- `refactor-scope` が、報告の切り詰めが `type_size` の写しであることと、循環の両端が別の形で印字されうることを出した。前者は `shorten_for_report` の共有、後者は輪を経路上の祖先で閉じることで直した。
- `design-fit` が、集合の鍵が「簡約前の制約の印字形」であることを指摘した。そのまま残し、なぜそれで足りるのか (簡約を挟んで一致する循環は 1 段遅れて捕まる。新しい印字形が無限に出る場合は深さの上限が止める) をコードに書いた。
- レビューの近傍パス (この branch を土台にした `cleanup/fix-predicate-derivation-cycle`) は別の pull request にした。