### PR TITLE
レビュー清掃 (#276): 局所束縛の名前・テストモジュールの import・変更箇所の周りの doc

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -426,20 +426,26 @@ impl TyConInfo {
     }
 }
 
+/// A declaration of a type alias: the type it stands for, and the parameters it takes.
 #[derive(Clone)]
 pub struct TyAliasInfo {
+    /// The kind of the type constructor the alias names.
     pub kind: Arc<Kind>,
+    /// The type the alias stands for, written in terms of `tyvars`.
     pub value: Arc<TypeNode>,
+    /// The parameters the alias takes, in the order they are declared.
     pub tyvars: Vec<Arc<TyVar>>,
+    /// Where the declaration was written.
     pub source: Option<Span>,
 }
 
 impl TyAliasInfo {
-    // Get the document of this type alias.
+    /// The documentation comment written above this declaration.
     pub fn get_document(&self) -> Option<String> {
         self.source.as_ref().and_then(|src| src.get_document().ok())
     }
 
+    /// Resolves the namespaces of the type names in the type the alias stands for.
     pub fn resolve_namespace(&mut self, ctx: &mut NameResolutionContext) -> Result<(), Errors> {
         self.value = self.value.resolve_namespace(ctx)?;
         Ok(())
@@ -459,10 +465,12 @@ impl TyAliasInfo {
 /// reject.
 pub const MAX_TYPE_DEPTH: usize = 500;
 
-// Node of type ast tree with user defined additional information
+/// A node of a type expression, together with the information the compiler carries alongside it.
 #[derive(Serialize, Deserialize)]
 pub struct TypeNode {
+    /// The type expression, which is what equality and hashing of a node read.
     pub ty: Type,
+    /// Where the type was written, for a type read from a source file.
     pub info: TypeInfo,
     /// The hash of `ty`, kept once computed.
     ///
@@ -485,6 +493,8 @@ pub struct TypeNode {
 }
 
 impl PartialEq for TypeNode {
+    /// Compares the type expressions; the source information a node carries stays out of the
+    /// comparison.
     fn eq(&self, other: &Self) -> bool {
         self.ty == other.ty
     }

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -2771,6 +2771,10 @@ impl PredicateDeduction {
     }
 }
 
+/// A constraint that type checking required and could not settle.
+///
+/// A report names the constraint, and adds what the deduction of it did where the deduction rather
+/// than the constraint is what fails.
 #[derive(Clone)]
 pub enum UnificationErr {
     /// No instance the program declares gives the predicate.
@@ -2781,10 +2785,13 @@ pub enum UnificationErr {
     /// Deducing the predicate asks for one on a deeper type, and that one for a deeper one again, so
     /// the deduction does not end. Carries the way down, deepest last.
     Endless(Vec<Predicate>),
+    /// Two types that are required to be equal and that unification could not make equal.
     Disjoint(Arc<TypeNode>, Arc<TypeNode>),
 }
 
 impl UnificationErr {
+    /// The constraint the report names, printed: the predicate that cannot be deduced, or an
+    /// equation between the two types that cannot be made equal.
     pub fn to_constraint_string(&self) -> String {
         match self {
             UnificationErr::Unsatisfiable(p) => p.to_string(),
@@ -2831,7 +2838,7 @@ impl UnificationErr {
         }
     }
 
-    // Append free type variables to a buffer of type Vec.
+    /// Appends to `buf` the type variables free in the types this error carries.
     pub fn free_vars_to_vec(&self, buf: &mut Vec<Arc<TyVar>>) {
         match self {
             UnificationErr::Unsatisfiable(p) => p.free_vars_to_vec(buf),
@@ -2882,8 +2889,12 @@ impl UnificationErr {
     }
 }
 
+/// What a step of type checking fails with: a constraint it could not settle, or errors raised for
+/// any other reason.
 pub enum UnifOrOtherErr {
+    /// A constraint the step required and could not settle.
     UnifErr(UnificationErr),
+    /// Errors raised for any other reason, carried as they are.
     Others(Errors),
 }
 

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -240,9 +240,9 @@ impl Substitution {
                     self.substitute_predicate(predicate);
                 }
             }
-            UnificationErr::Disjoint(type_node, type_node1) => {
-                *type_node = self.substitute_type(type_node);
-                *type_node1 = self.substitute_type(type_node1);
+            UnificationErr::Disjoint(ty1, ty2) => {
+                *ty1 = self.substitute_type(ty1);
+                *ty2 = self.substitute_type(ty2);
             }
         }
     }
@@ -1158,12 +1158,12 @@ impl TypeCheckContext {
                 if ok_count == 0 {
                     let mut extra_srcs = vec![];
 
-                    let err_cnt = candidates_check_res
+                    let err_count = candidates_check_res
                         .iter()
                         .filter(|cand| cand.is_err())
                         .count();
                     let expected_type = self.substitute_type(&ty);
-                    let msg = if err_cnt == 1 {
+                    let msg = if err_count == 1 {
                         let (tc, fullname, scm, e) = candidates_check_res
                             .iter()
                             .find_map(|cand| cand.as_ref().err())
@@ -1200,11 +1200,11 @@ impl TypeCheckContext {
                             .iter()
                             .filter_map(|cand| cand.as_ref().err())
                         {
-                            let cnt = candidates_errors.len() + 1;
+                            let ref_no = candidates_errors.len() + 1;
                             let scm = tc.substitution.substitute_scheme(scm);
                             let msg = e.message_with_note(format!(
                                 "- ({}) `{}` of type `{}` does not match since `{}` cannot be deduced.",
-                                cnt,
+                                ref_no,
                                 fullname.to_string(),
                                 scm.to_string(),
                                 e.to_constraint_string(),
@@ -1213,8 +1213,9 @@ impl TypeCheckContext {
                             let mut tvs = vec![];
                             scm.free_vars_to_vec(&mut tvs);
                             e.free_vars_to_vec(&mut tvs);
-                            extra_srcs
-                                .append(&mut self.create_tyvar_location_messages(&tvs, Some(cnt)));
+                            extra_srcs.append(
+                                &mut self.create_tyvar_location_messages(&tvs, Some(ref_no)),
+                            );
                         }
                         if candidates_errors.len() > 0 {
                             msg.push_str("\n");
@@ -2183,24 +2184,24 @@ impl TypeCheckContext {
     /// Reduces predicates stored in `self.predicates` as long as possible.
     /// If a predicate is unsatisfiable, returns `Err`.
     pub(crate) fn reduce_predicates(&mut self) -> Result<(), UnifOrOtherErr> {
-        let mut irr_preds = vec![];
+        let mut irreducible_preds = vec![];
         let mut deduction = PredicateDeduction::default();
         while let Some(pred) = self.predicates.pop() {
-            self.reduce_predicate(pred, &mut irr_preds, &mut deduction)?;
+            self.reduce_predicate(pred, &mut irreducible_preds, &mut deduction)?;
         }
-        self.predicates = irr_preds;
+        self.predicates = irreducible_preds;
         Ok(())
     }
 
-    // Reduce a predicate and add reduced predicates to `irr_preds`.
+    // Reduce a predicate and add reduced predicates to `irreducible_preds`.
     fn reduce_predicate(
         &mut self,
         pred: Predicate,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         for pred in pred.resolve_trait_aliases(&self.trait_env.aliases)? {
-            self.reduce_predicate_noalias(pred, irr_preds, deduction)?;
+            self.reduce_predicate_noalias(pred, irreducible_preds, deduction)?;
         }
         Ok(())
     }
@@ -2210,7 +2211,7 @@ impl TypeCheckContext {
     fn reduce_predicate_noalias(
         &mut self,
         mut pred: Predicate,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         self.substitute_predicate(&mut pred);
@@ -2264,7 +2265,13 @@ impl TypeCheckContext {
                         ctx_pred
                     })
                     .collect();
-                self.reduce_instance_context(&pred, &pred_str, context, irr_preds, deduction)?;
+                self.reduce_instance_context(
+                    &pred,
+                    &pred_str,
+                    context,
+                    irreducible_preds,
+                    deduction,
+                )?;
                 deduction.settled.insert(pred_str);
                 return Ok(());
             } else if !unifiable {
@@ -2278,7 +2285,7 @@ impl TypeCheckContext {
         if !unifiable {
             return Err(UnificationErr::Unsatisfiable(pred).into());
         }
-        irr_preds.push(pred);
+        irreducible_preds.push(pred);
         deduction.settled.insert(pred_str);
         return Ok(());
     }
@@ -2290,13 +2297,13 @@ impl TypeCheckContext {
         pred: &Predicate,
         pred_str: &str,
         context: Vec<Predicate>,
-        irr_preds: &mut Vec<Predicate>,
+        irreducible_preds: &mut Vec<Predicate>,
         deduction: &mut PredicateDeduction,
     ) -> Result<(), UnifOrOtherErr> {
         deduction.enter(pred, pred_str);
         let deduced = context
             .into_iter()
-            .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irr_preds, deduction));
+            .try_for_each(|ctx_pred| self.reduce_predicate(ctx_pred, irreducible_preds, deduction));
         deduction.leave();
         deduced
     }
@@ -2906,12 +2913,21 @@ impl From<UnificationErr> for UnifOrOtherErr {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::TypeCheckContext;
     use crate::ast::expr::{
         expr_abs, expr_app, expr_array_lit, expr_eval, expr_ffi_call, expr_if, expr_let,
-        expr_make_struct, expr_match, expr_tyanno, expr_var, var_var,
+        expr_make_struct, expr_match, expr_tyanno, expr_var, var_var, ExprNode,
     };
+    use crate::ast::kind_scope::KindEnv;
+    use crate::ast::name::FullName;
+    use crate::ast::pattern::PatternNode;
+    use crate::ast::program::TypeEnv;
+    use crate::ast::traits::TraitEnv;
+    use crate::ast::types::TyCon;
     use crate::elaboration::typecheckcache::MemoryCache;
+    use crate::fixstd::builtin::make_bool_ty;
+    use crate::misc::Map;
+    use std::sync::Arc;
 
     /// Context over empty environments: the fallback typing reads only the
     /// fresh-type-variable counter, so no program state is needed.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -280,21 +280,26 @@ pub fn to_absolute_path(path: &Path) -> Result<PathBuf, Errors> {
     Ok(abs.unwrap())
 }
 
+/// Works deferred to the moment this value is dropped, run latest first.
 pub struct Finally {
+    /// The works deferred so far, in the order they were deferred.
     works: Vec<Box<dyn FnOnce()>>,
 }
 
 impl Finally {
+    /// A `Finally` with no work deferred.
     pub fn new() -> Self {
         Self { works: vec![] }
     }
 
+    /// Defers `work` until this value is dropped.
     pub fn defer<F: FnOnce() + 'static>(&mut self, work: F) {
         self.works.push(Box::new(work));
     }
 }
 
 impl Drop for Finally {
+    /// Runs the deferred works, latest first.
     fn drop(&mut self) {
         for work in self.works.drain(..).rev() {
             work();
@@ -310,10 +315,12 @@ pub fn disable_colored_no_tty() {
     }
 }
 
+/// Prints `msg` to standard error under an `info` label.
 pub fn info_msg(msg: &str) {
     eprintln!("{}: {}", "info".bright_blue().bold(), msg);
 }
 
+/// Prints `msg` to standard error under a `warning` label.
 pub fn warn_msg(msg: &str) {
     eprintln!("{}: {}", "warning".yellow().bold(), msg);
 }
@@ -338,7 +345,10 @@ pub fn shorten_for_report(text: String) -> String {
     }
 }
 
-// Splits a string by spaces, but keeps the words in quotes as a single word.
+/// Splits `s` at spaces, keeping a quoted run of characters as one word.
+///
+/// Single and double quotes both quote, and a backslash makes the character after it part of the
+/// word it stands in. The quotes and backslashes themselves stay out of the words returned.
 pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut current_word = String::new();
@@ -375,7 +385,9 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     words
 }
 
-// Upper CamelCase to lower_snake_case
+/// Rewrites `s`, written in `UpperCamelCase`, as `lower_snake_case`.
+///
+/// Requires `s` to be ASCII alphanumeric.
 pub fn upper_camel_to_lower_snake(s: &str) -> String {
     assert!(
         s.chars().all(|c| c.is_ascii_alphanumeric()),

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -340,7 +340,7 @@ pub fn shorten_for_report(text: String) -> String {
 
 // Splits a string by spaces, but keeps the words in quotes as a single word.
 pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
-    let mut result = Vec::new();
+    let mut words = Vec::new();
     let mut current_word = String::new();
     let mut in_quotes = None; // None if not in quotes, Some(') if in single quotes, Some(") if in double quotes
     let mut escaped = false; // true if the previous character is an escape character
@@ -355,7 +355,7 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
         match c {
             ' ' if in_quotes.is_none() => {
                 if !current_word.is_empty() {
-                    result.push(current_word.clone());
+                    words.push(current_word.clone());
                     current_word.clear();
                 }
             }
@@ -369,10 +369,10 @@ pub fn split_string_by_space_not_quated(s: &str) -> Vec<String> {
     }
 
     if !current_word.is_empty() {
-        result.push(current_word);
+        words.push(current_word);
     }
 
-    result
+    words
 }
 
 // Upper CamelCase to lower_snake_case
@@ -398,11 +398,15 @@ pub fn upper_camel_to_lower_snake(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        char_pos_to_utf16_pos, join_compiler_threads, spawn_compiler_thread, split_by_max_size,
+        split_string_by_space_not_quated, upper_camel_to_lower_snake, utf16_pos_to_utf8_byte_pos,
+    };
     use crate::error::any_to_string;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::thread::{self, JoinHandle};
     use std::time::Duration;
 
     /// Every thread has finished by the time a worker's panic is carried on, so unwinding never

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -171,15 +171,15 @@ fn depth_message(root: &Arc<TypeNode>, asked_for: &[Arc<TypeNode>]) -> String {
     /// visible, and short enough that the types printed are ones the reader can read.
     const SHOWN_STEPS: usize = 3;
 
-    let shown = asked_for
+    let steps = asked_for
         .iter()
         .take(SHOWN_STEPS)
         .map(|ty| format!("`{}`", shorten(ty)))
         .collect::<Vec<_>>();
-    let way_down = if shown.is_empty() {
+    let way_down = if steps.is_empty() {
         String::new()
     } else {
-        format!(" ({} -> ...)", shown.join(" -> "))
+        format!(" ({} -> ...)", steps.join(" -> "))
     };
     format!(
         "`{}` has no size: laying it out asks for types nested more than {} deep{}, so it needs \

--- a/src/type_size.rs
+++ b/src/type_size.rs
@@ -163,6 +163,7 @@ fn no_size_in_place(
 /// where a type reached from itself at a larger argument shows itself. The type actually at fault
 /// is one the walk built on the way, and printing that one would print a term as deep as the bound.
 fn depth_message(root: &Arc<TypeNode>, asked_for: &[Arc<TypeNode>]) -> String {
+    /// One type as the report shows it, cut short where it is too long to show whole.
     fn shorten(ty: &Arc<TypeNode>) -> String {
         shorten_for_report(ty.to_string())
     }


### PR DESCRIPTION
Refs #246

`code-review` の近傍パスが、#276 が触ったファイルの**変更箇所の外**に見つけた片付けである。変更そのものの diff を読みやすく保つため、別の pull request にしてある。マージ先は #276 の branch。

いずれも構成上ふるまいを変えない編集だけで、名前の付け替えは局所束縛に限り、残りはコメントと import である。

## 名前 — 値が何を持っているかを名前にする

`src/elaboration/typecheck.rs`

- `substitute_unification_error` の `Disjoint` の束縛 `type_node` / `type_node1` -> `ty1` / `ty2`。同じ variant を同じファイルの `to_constraint_string` と `free_vars_to_vec` が `ty1` / `ty2` で受けており、`ty` はこのファイルの確立された略語である。
- 名前の候補が 1 つも残らなかったときの報告を作る `cnt` -> `ref_no`。この値が渡される先 `create_tyvar_location_messages` の引数名が `ref_no` である。
- `err_cnt` -> `err_count`。すぐ隣に `ok_count` がある。
- `irr_preds` -> `irreducible_preds` (5 つのシグネチャ)。`irr` はこのリポジトリのどこでも使われていない略語だった。

`src/type_size.rs`

- `depth_message` の `shown` -> `steps`。報告の同じ列を、演繹側の `way_string` が `steps` と呼んでいる。

`src/misc.rs`

- `split_string_by_space_not_quated` の `result` -> `words`。

## import — テストモジュールが使うものを明示列挙する

`use super::*;` を、実際に使う名前だけの列挙に置き換えた。`src/elaboration/typecheck.rs` のテストモジュール (10 名 + `std::sync::Arc`)、`src/misc.rs` のテストモジュール (7 名 + `std::thread::{self, JoinHandle}`)。同じ規約の適用例が `src/ast/types.rs` のテストモジュールにある。

## doc コメント — 変更箇所の周りの項目に付ける

`src/elaboration/typecheck.rs` の `UnificationErr` 本体・`Disjoint` variant・`to_constraint_string`・`free_vars_to_vec` (`//` の昇格)・`UnifOrOtherErr` と 2 つの variant。`src/ast/types.rs` の `TypeNode` (`//` の昇格 + `ty` / `info` フィールド)・`TyAliasInfo` (struct + 4 フィールド)・`get_document` (`//` の昇格)・`resolve_namespace`・`PartialEq::eq`。`src/misc.rs` の `split_string_by_space_not_quated` と `upper_camel_to_lower_snake` (`//` の昇格と内容の補い)・`info_msg` / `warn_msg` / `Finally` (struct + フィールド + 3 メソッド)。`src/type_size.rs` の `depth_message` 内のネストした `shorten`。

ファイルあたり 5 か所の上限で、変更箇所に近い順に取った。上限を超えて残った doc の無い項目は `src/ast/types.rs` に約 117 件、`src/elaboration/typecheck.rs` に約 50 件、`src/misc.rs` に約 17 件ある。この branch が持ち込んだものではない。

## レビューが報告だけした項目 (この branch では直していない)

- `src/type_size.rs` の `way_down` と `no_size_in_place` の循環の報告は、型を切り詰めずに全文を出す。同じファイルの `depth_message` は `shorten_for_report` を通す。直すと出力が変わるので、ふるまいを変えない編集の枠を出る。
- `src/misc.rs` の `split_string_by_space_not_quated` は綴りが誤っている (`quated` -> `quoted`)。呼び出しは `src/preliminary_command.rs` に 2 か所。項目名の変更なので著者の判断に委ねる。
- `PredicateDeduction` の経路と決着済みの持ち回りは、`src/type_size.rs` の `no_size_in_place` + `LayoutWalk` と `src/ast/traits.rs` の `resolve_alias_internal` が同じ形を持つ。共通化には鍵の型を跨ぐ総称型が要り、3 者は当たったときのふるまいも違う。
