### PR TITLE
補完が別のファイルの型エラーをエディタから消す件を直す (#249, #173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Building a project after upgrading `fix` no longer hangs. The type-checking cache is now regenerated when the compiler itself changes, where before it was reused as long as the source was unchanged and a newer `fix` could misread a cache an older one wrote.
 - LSP: A completion request no longer makes the language server exit when the file annotates an expression with an unknown type variable, such as `let x = (3 : b);`. The request now answers with type-aware candidates, including when the cursor is inside the annotated expression itself.
 - An internal compiler error is now reported on its own. The message used to be followed by a second error, or by a crash that buried it.
+- LSP: A completion request no longer clears the errors reported for another file. The check a completion runs tolerates type errors and reports none of them; its result was kept and answered the next diagnostics run, so a project that did not compile could show no error in the editor until the file holding the error was edited again.
 
 ## [1.4.0] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Building a project after upgrading `fix` no longer hangs. The type-checking cache is now regenerated when the compiler itself changes, where before it was reused as long as the source was unchanged and a newer `fix` could misread a cache an older one wrote.
 - LSP: A completion request no longer makes the language server exit when the file annotates an expression with an unknown type variable, such as `let x = (3 : b);`. The request now answers with type-aware candidates, including when the cursor is inside the annotated expression itself.
 - An internal compiler error is now reported on its own. The message used to be followed by a second error, or by a crash that buried it.
-- LSP: A completion request no longer clears the errors reported for another file. The check a completion runs tolerates type errors and reports none of them; its result was kept and answered the next diagnostics run, so a project that did not compile could show no error in the editor until the file holding the error was edited again.
+- LSP: A completion request no longer clears the errors reported for another file. A project that did not compile could show no error in the editor until the file holding the error was edited again.
 
 ## [1.4.0] - 2026-06-22
 

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1202,10 +1202,10 @@ impl Program {
         mut tc: TypeCheckContext,
     ) -> Result<(TypedExpr, Errors), Errors> {
         // Load type-checking cache file.
-        let cache = tc.cache.load_cache(val_name, req_scm, ver_hash);
-        if cache.is_some() {
+        let cached_te = tc.cache.load_cache(val_name, req_scm, ver_hash);
+        if cached_te.is_some() {
             // If cache is available,
-            te = cache.unwrap();
+            te = cached_te.unwrap();
             return Ok((te, Errors::empty()));
         }
 
@@ -1268,7 +1268,7 @@ impl Program {
         let target_set: Option<Set<&FullName>> = target_symbols.map(|s| s.iter().collect());
 
         // Names of global values to be checked.
-        let mut checked_names: Vec<FullName> = vec![];
+        let mut names_to_check: Vec<FullName> = vec![];
         for (name, gv) in self.global_values.iter() {
             if let Some(set) = target_set.as_ref() {
                 if !set.contains(name) {
@@ -1279,12 +1279,12 @@ impl Program {
                 SymbolExpr::Simple(_) => {
                     // Check simple values only if they are in `modules`.
                     if modules.contains(&name.module()) {
-                        checked_names.push(name.clone());
+                        names_to_check.push(name.clone());
                     }
                 }
                 SymbolExpr::Method(_) => {
                     // We filter methods by `method_impl_filter`.
-                    checked_names.push(name.clone());
+                    names_to_check.push(name.clone());
                 }
             }
         }
@@ -1296,7 +1296,7 @@ impl Program {
 
         errors.eat_err(self.resolve_namespace_and_check_type(
             tc,
-            &checked_names,
+            &names_to_check,
             method_impl_filter,
         ));
         errors.to_result()
@@ -1390,7 +1390,7 @@ impl Program {
                         let scm = member.scm.clone();
                         let scm_via_defn = member.scm_via_defn.clone();
                         let impl_src = member.expr.expr.source.clone();
-                        let def_src = gv.decl_src.clone();
+                        let decl_src = gv.decl_src.clone();
                         let val_name_clone = val_name.clone(); // For move into closure.
                         let def_mod = self.find_mod(&member.define_module).unwrap().clone();
                         let mut nrctx =
@@ -1411,7 +1411,7 @@ impl Program {
                                         &impl_src
                                             .as_ref()
                                             .map(|s| s.to_head_character()),
-                                        &def_src
+                                        &decl_src
                                             .as_ref()
                                             .map(|s| s.to_head_character()),
                                     ],

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1186,8 +1186,8 @@ impl Program {
     ///   carry tolerated diagnostics from `check_type` (holes,
     ///   cannot-infer, unsatisfied predicates, disjoint equalities).
     ///   The caller should always save `te` (so the LSP can hover on
-    ///   it) and propagate `errors`. The cache is only written when
-    ///   `errors` is empty.
+    ///   it) and propagate `errors`. The cache is written only for a
+    ///   strict check that produced no `errors`.
     /// * `Err(errs)` — a hard failure happened before substitution
     ///   completed (e.g. resolve_namespace, resolve_type_aliases, or
     ///   the substitution itself blew up). No useful typed expression
@@ -1223,11 +1223,14 @@ impl Program {
         tc.fill_opaque_concrete_types(&mut te.opaque_types);
         te.equalities = tc.local_assumed_eqs;
 
-        // Save the result to cache file only when there are no
-        // tolerated errors. Otherwise the cached typed expression
-        // would mask the diagnostics on the next run (cache load
-        // bypasses check_type entirely).
-        if !check_errors.has_diagnostics() {
+        // A run that finds the expression in the cache returns it without checking it (see the
+        // cache lookup above), so the cache may hold only what a strict check accepted. Two things
+        // disqualify a result:
+        //
+        // - a tolerated diagnostic, which the next run owes the user and would not produce again;
+        // - an `error_tolerant` check, which swallows every type error and reports none, so its
+        //   result would enter as a clean entry and the value would be published as type-correct.
+        if !tc.error_tolerant && !check_errors.has_diagnostics() {
             tc.cache.save_cache(&te, val_name, req_scm, ver_hash);
         }
 

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1223,9 +1223,8 @@ impl Program {
         tc.fill_opaque_concrete_types(&mut te.opaque_types);
         te.equalities = tc.local_assumed_eqs;
 
-        // A run that finds the expression in the cache returns it without checking it (see the
-        // cache lookup above), so the cache may hold only what a strict check accepted. Two things
-        // disqualify a result:
+        // A run whose `load_cache` finds the expression returns it without checking it, so the
+        // cache may hold only what a strict check accepted. Two things disqualify a result:
         //
         // - a tolerated diagnostic, which the next run owes the user and would not produce again;
         // - an `error_tolerant` check, which swallows every type error and reports none, so its

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1008,7 +1008,15 @@ impl Program {
         self.add_global_value_common(name, (expr, scm), None, None, document, true)
     }
 
-    // Add a global value.
+    /// Registers a global value whose body is `expr` and whose type is `scm`.
+    ///
+    /// # Arguments
+    /// * `decl_src` — where the value's type signature is written.
+    /// * `defn_src` — where the left hand side of the value's definition is written.
+    /// * `document` — the documentation of the value, for a value whose `decl_src` is
+    ///   unavailable; otherwise the documentation is read from the source code.
+    /// * `compiler_defined_method` — marks a method the compiler generates for a type, such as
+    ///   `@{field}` or `set_{field}`, which `fix docs` leaves out.
     fn add_global_value_common(
         &mut self,
         name: FullName,
@@ -1031,7 +1039,8 @@ impl Program {
         self.add_global_value_gv(name, gv)
     }
 
-    // Add a global value.
+    /// Registers an already-built global value under `name`, reporting an error that points at
+    /// both declarations when the name is taken.
     pub fn add_global_value_gv(&mut self, name: FullName, gv: GlobalValue) -> Result<(), Errors> {
         // Check duplicate definition.
         if self.global_values.contains_key(&name) {
@@ -1055,7 +1064,9 @@ impl Program {
         Ok(())
     }
 
-    // Add global values.
+    /// Pairs each definition with the type signature carrying the same name and registers the
+    /// pairs as global values. A name that carries two definitions, two signatures, a definition
+    /// without a signature, or a signature without a definition is reported as an error.
     pub fn add_global_values(
         &mut self,
         defns: Vec<GlobalValueDefn>,
@@ -1063,8 +1074,12 @@ impl Program {
     ) -> Result<(), Errors> {
         let mut errors = Errors::empty();
 
+        /// The two halves of one global value, collected while pairing them up by name. A half
+        /// stays `None` until it is met.
         struct GlobalValue {
+            /// The definition, e.g. `main = println("Hello World");`.
             defn: Option<GlobalValueDefn>,
+            /// The type signature, e.g. `main : IO ();`.
             decl: Option<GlobalValueDecl>,
         }
         let mut global_values: Map<FullName, GlobalValue> = Default::default();
@@ -1239,7 +1254,10 @@ impl Program {
         Ok((te, check_errors))
     }
 
-    // Create NameResolutionEnv used for symbols defined in the specified module.
+    /// Builds the program-wide table that name resolution reads: every type constructor, trait
+    /// and associated type a capitalized name can resolve to, plus each module's import
+    /// statements. A `NameResolutionContext` fixes the module a name is written in and shares
+    /// this table.
     pub fn create_name_resolution_env(&self) -> Arc<NameResolutionEnv> {
         Arc::new(NameResolutionEnv::new(
             &self.tycon_names_with_aliases(),

--- a/src/tests/test_hole_cache.rs
+++ b/src/tests/test_hole_cache.rs
@@ -167,4 +167,39 @@ mod integration_tests {
             list_cache_files(&project_dir),
         );
     }
+
+    /// A test build and a plain build over one project directory share the type-check cache, and
+    /// each still produces its own program.
+    ///
+    /// The two builds see different sets of tuple sizes, so the trait implementations the compiler
+    /// generates for tuples differ between them; those generated sources reach no module's
+    /// dependency hash, which is what makes the two builds' entries meet under one key.
+    #[test]
+    fn a_test_build_and_a_plain_build_share_the_cache_without_corrupting_it() {
+        let (_temp_dir, project_dir) = setup_test_env("test_and_build");
+
+        let test_run = fix_command()
+            .arg("test")
+            .current_dir(&project_dir)
+            .output()
+            .expect("Failed to execute fix test");
+        assert_eq!(
+            String::from_utf8_lossy(&test_run.stdout).trim(),
+            "(1, 2, 3, 4, 5, 6, 7)",
+            "the test entry point prints the seven-tuple.\nstderr: {}",
+            String::from_utf8_lossy(&test_run.stderr),
+        );
+
+        let build_run = fix_command()
+            .arg("run")
+            .current_dir(&project_dir)
+            .output()
+            .expect("Failed to execute fix run");
+        assert_eq!(
+            String::from_utf8_lossy(&build_run.stdout).trim(),
+            "(1, 2)",
+            "the main entry point prints the pair.\nstderr: {}",
+            String::from_utf8_lossy(&build_run.stderr),
+        );
+    }
 }

--- a/src/tests/test_hole_cache/cases/test_and_build/fixproj.toml
+++ b/src/tests/test_hole_cache/cases/test_and_build/fixproj.toml
@@ -1,0 +1,9 @@
+[general]
+name = "test-and-build"
+version = "0.1.0"
+
+[build]
+files = ["main.fix"]
+
+[build.test]
+files = ["main.fix", "test.fix"]

--- a/src/tests/test_hole_cache/cases/test_and_build/main.fix
+++ b/src/tests/test_hole_cache/cases/test_and_build/main.fix
@@ -1,0 +1,4 @@
+module Main;
+
+main : IO ();
+main = println $ (1, 2).to_string;

--- a/src/tests/test_hole_cache/cases/test_and_build/test.fix
+++ b/src/tests/test_hole_cache/cases/test_and_build/test.fix
@@ -1,0 +1,4 @@
+module Test;
+
+test : IO ();
+test = println $ (1, 2, 3, 4, 5, 6, 7).to_string;

--- a/src/tests/test_lsp/cases/diagnostics-after-completion/fixproj.toml
+++ b/src/tests/test_lsp/cases/diagnostics-after-completion/fixproj.toml
@@ -1,0 +1,6 @@
+[general]
+name = "diagnostics-after-completion"
+version = "0.1.0"
+
+[build]
+files = ["main.fix", "lib.fix"]

--- a/src/tests/test_lsp/cases/diagnostics-after-completion/lib.fix
+++ b/src/tests/test_lsp/cases/diagnostics-after-completion/lib.fix
@@ -1,0 +1,13 @@
+module Lib;
+
+trait a : MyShow {
+    show : a -> String;
+}
+
+type LibType = unbox struct { x : I64 };
+
+// The body has the type `I64` where the declaration promises `String`, so the
+// project has one error, and it is in this file.
+impl LibType : MyShow {
+    show = |v| v.@x;
+}

--- a/src/tests/test_lsp/cases/diagnostics-after-completion/main.fix
+++ b/src/tests/test_lsp/cases/diagnostics-after-completion/main.fix
@@ -1,0 +1,12 @@
+module Main;
+
+import Lib;
+
+type MainType = unbox struct { y : I64 };
+
+impl MainType : MyShow {
+    show = |v| v.@y.to_string;
+}
+
+main : IO ();
+main = println(MainType { y : 1 }.show);

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -1224,4 +1224,71 @@ mod tests {
 
         ctx.shutdown();
     }
+
+    /// The receiver of a dot completion is found on a line whose earlier text is multi-byte, where
+    /// the protocol's UTF-16 column and the buffer's byte offset differ.
+    #[test]
+    fn test_completion_dot_sort_after_multibyte_text_on_the_line() {
+        let (_temp_dir, project_dir) = setup_test_env("completion-dot-sort-array");
+        let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
+        client
+            .initialize(&project_dir, Duration::from_secs(5))
+            .expect("Failed to initialize LSP");
+        client
+            .open_document(Path::new("main.fix"))
+            .expect("open main.fix");
+        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+
+        let abs_path = project_dir.join("main.fix");
+        let with_multibyte = fs::read_to_string(&abs_path)
+            .expect("read main.fix")
+            .replace(
+                "    let _ = arr.",
+                "    let _ = /* \u{65e5}\u{672c}\u{8a9e} */ arr.",
+            );
+        let uri = format!("file://{}", abs_path.display());
+        client
+            .send_notification(
+                "textDocument/didChange",
+                json!({
+                    "textDocument": { "uri": uri, "version": 2 },
+                    "contentChanges": [ { "text": with_multibyte } ]
+                }),
+            )
+            .expect("send didChange");
+
+        // The cursor sits right after the dot, whose UTF-16 column is six less than its byte
+        // offset in the line.
+        let line = with_multibyte
+            .lines()
+            .position(|l| l.trim_end().ends_with("arr."))
+            .expect("find the receiver line") as u32;
+        let col = with_multibyte
+            .lines()
+            .nth(line as usize)
+            .unwrap()
+            .chars()
+            .count() as u32;
+        let id = client
+            .send_request(
+                "textDocument/completion",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": col }
+                }),
+            )
+            .expect("send completion");
+        let items = collect_completion_items(&mut client, id, Duration::from_secs(60))
+            .expect("completion did not respond within 60s");
+
+        let sort_push_back = find_sort_text(&items, "Std::Array::push_back")
+            .expect("`Std::Array::push_back` is expected among the candidates");
+        assert!(
+            sort_push_back.starts_with("0a"),
+            "`Std::Array::push_back` is expected in tier 0, sub-tier `a`, for an `Array I64` receiver, but its sort key is {:?}",
+            sort_push_back
+        );
+
+        let _ = client.shutdown(Duration::from_millis(500));
+    }
 }

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -90,7 +90,7 @@ mod tests {
     /// its result be kept, the next strict run would answer from it and publish that file as
     /// clean — the project would not compile while the editor showed nothing.
     #[test]
-    fn test_a_completion_leaves_another_files_error_reported() {
+    fn test_a_completion_leaves_the_error_of_another_file_reported() {
         let mut ctx =
             LspCompletionCtx::setup("diagnostics-after-completion", &["lib.fix", "main.fix"]);
         let lib_file = Path::new("lib.fix");

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -18,9 +18,9 @@ mod tests {
     /// path inside it.
     fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cases = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
+        let cases_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
         let project_dir = temp_dir.path().join(project_name);
-        copy_dir_recursive(&cases.join(project_name), &project_dir)
+        copy_dir_recursive(&cases_dir.join(project_name), &project_dir)
             .expect("Failed to copy test case");
         (temp_dir, project_dir)
     }

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -6,6 +6,7 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::LspCompletionCtx;
     use super::super::lsp_client::LspClient;
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::Value;
@@ -80,5 +81,45 @@ mod tests {
             "the related location is in `main.fix`, but the report is {:?}",
             diag
         );
+    }
+
+    /// A completion request leaves the error of another file reported.
+    ///
+    /// A completion re-checks the program in error-tolerant mode, which reports no diagnostic
+    /// whatever it finds. Should such a run reach an entity of a file the user is not editing and
+    /// its result be kept, the next strict run would answer from it and publish that file as
+    /// clean — the project would not compile while the editor showed nothing.
+    #[test]
+    fn test_a_completion_leaves_another_files_error_reported() {
+        let mut ctx =
+            LspCompletionCtx::setup("diagnostics-after-completion", &["lib.fix", "main.fix"]);
+        let lib = Path::new("lib.fix");
+
+        let before = ctx.client.get_diagnostics(lib);
+        assert_eq!(
+            before.len(),
+            1,
+            "`lib.fix` is expected to be reported before any completion, but its diagnostics are {:?}",
+            before
+        );
+
+        // The dot of `v.@y.to_string`. The cursor sits in the body of a trait-implementation
+        // member, whose symbol the completion cannot narrow its check to — the symbol is built
+        // during elaboration, later than the narrowing reads the parsed buffer — so the tolerant
+        // run covers every value of the project, the broken implementation in `lib.fix` among
+        // them.
+        let _ = ctx.complete_with_timeout("main.fix", 7, 20, Duration::from_secs(60));
+
+        ctx.client
+            .trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        let after = ctx.client.get_diagnostics(lib);
+        assert_eq!(
+            after.len(),
+            before.len(),
+            "the report on `lib.fix` is still expected, but its diagnostics are {:?}",
+            after
+        );
+
+        ctx.shutdown();
     }
 }

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -93,14 +93,14 @@ mod tests {
     fn test_a_completion_leaves_another_files_error_reported() {
         let mut ctx =
             LspCompletionCtx::setup("diagnostics-after-completion", &["lib.fix", "main.fix"]);
-        let lib = Path::new("lib.fix");
+        let lib_file = Path::new("lib.fix");
 
-        let before = ctx.client.get_diagnostics(lib);
+        let diagnostics_before = ctx.client.get_diagnostics(lib_file);
         assert_eq!(
-            before.len(),
+            diagnostics_before.len(),
             1,
             "`lib.fix` is expected to be reported before any completion, but its diagnostics are {:?}",
-            before
+            diagnostics_before
         );
 
         // The dot of `v.@y.to_string`. The cursor sits in the body of a trait-implementation
@@ -121,11 +121,11 @@ mod tests {
 
         ctx.client
             .trigger_and_wait_for_diagnostics(Path::new("main.fix"));
-        let after = ctx.client.get_diagnostics(lib);
+        let diagnostics_after = ctx.client.get_diagnostics(lib_file);
         assert_eq!(
-            after, before,
+            diagnostics_after, diagnostics_before,
             "the same report on `lib.fix` is still expected, but its diagnostics are {:?}",
-            after
+            diagnostics_after
         );
 
         ctx.shutdown();

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -108,15 +108,23 @@ mod tests {
         // during elaboration, later than the narrowing reads the parsed buffer — so the tolerant
         // run covers every value of the project, the broken implementation in `lib.fix` among
         // them.
-        let _ = ctx.complete_with_timeout("main.fix", 7, 20, Duration::from_secs(60));
+        let items = ctx.complete_with_timeout("main.fix", 7, 20, Duration::from_secs(60));
+
+        // A dot completion ranks its candidates, and the tolerant re-check is what ranks them: a
+        // reply whose candidates carry no sort key was answered without that run, and says
+        // nothing about what such a run leaves behind.
+        assert!(
+            items.iter().any(|item| item.get("sortText").is_some()),
+            "the completion after the dot is expected to rank its candidates, but none of its {} items carries a sort key",
+            items.len()
+        );
 
         ctx.client
             .trigger_and_wait_for_diagnostics(Path::new("main.fix"));
         let after = ctx.client.get_diagnostics(lib);
         assert_eq!(
-            after.len(),
-            before.len(),
-            "the report on `lib.fix` is still expected, but its diagnostics are {:?}",
+            after, before,
+            "the same report on `lib.fix` is still expected, but its diagnostics are {:?}",
             after
         );
 


### PR DESCRIPTION
Closes #249
Closes #173

エディタで補完を 1 回使うと、**別のファイルにある本物の型エラーが診断から消える**。消えたままになるのは、そのファイル自身を編集し直すまでである。ユーザから見ると、コンパイルの通らないプロジェクトがエディタ上では無傷に見える。

原因は、補完が走らせる型検査の結果が型検査キャッシュに入り、次の診断走行がそれを答えることである。本 PR は、その走行の結果をキャッシュに入れないようにする。

## 前提: 補完はエラーを許すモードで型検査をやり直す

ドットの後ろの補完は、候補を受け手の型で順位付けするために、カーソルの周りを修復したソースを作ってプログラムを型検査し直す。書きかけの式のせいで型が付かないと候補を絞れないので、この走行は**エラーを許すモード** (`error_tolerant`) で行う。

このモードでは `TypeCheckContext::check_type` (`src/elaboration/typecheck.rs`) が、握り潰した型の不一致を 1 つも報告せずに戻る。

```rust
if self.error_tolerant {
    return Ok((expr, Errors::empty()));
}
```

型が合わなかったという事実は、ここで捨てられる。ホール・推論不能・未解決の制約・両立しない等式を報告する 4 段の層は、すべて飛ばされる。

## 前提: 型検査キャッシュ

`Program::resolve_namespace_and_check_type_sub` (`src/ast/program.rs`) は、グローバル値 1 つについて、名前解決・型エイリアスの解決・型検査を行う関数である。この関数は先頭でキャッシュを引き、当たれば**型検査を一切せずに**その結果を返す。

```rust
let cached_te = tc.cache.load_cache(val_name, req_scm, ver_hash);
if cached_te.is_some() {
    te = cached_te.unwrap();
    return Ok((te, Errors::empty()));
}
```

キャッシュの鍵は `(値の名前, 型スキーム, モジュールの依存ハッシュ)` である。language server は、診断のための走行と補完のための走行で**同じキャッシュ** (`MemoryCache`) を共有する。

## 壊れていた走り

`lib.fix` の `show` の本体は型が合っていない（`@x` は `I64` なのに宣言は `String` を返すと言っている）。`main.fix` は同じトレイトを別の型に実装しており、そちらは正しい。

1. サーバが起動し、診断が走る。`Lib::MyShow::show` の `lib.fix` の実装は `check_type` が `Err` を返すので、`resolve_namespace_and_check_type_sub` はキャッシュに何も書かない。エディタには診断が 1 件出る。ここまでは正しい。
2. ユーザが `main.fix` のトレイト実装の本体、`v.@y.to_string` のドットの位置で補完を要求する。
3. `run_completion_elaborate` が `error_tolerant` を立ててエラボレーションを呼ぶ。カーソルがトレイト実装のメンバの本体にあるので対象の絞り込みは失敗し（#306）、プロジェクトの全モジュールの全グローバル値が検査対象になる。`lib.fix` の壊れた実装もその中に入る。
4. その実装を検査する `check_type` は、型の不一致を握り潰して `Errors::empty()` を返す。
5. `resolve_namespace_and_check_type_sub` の保存の条件は「診断が無いこと」だけだった。

   ```rust
   if !check_errors.has_diagnostics() {
       tc.cache.save_cache(&te, val_name, req_scm, ver_hash);
   }
   ```

   `check_errors` は必ず空なので、**型の合っていない式がキャッシュに入る**。鍵に使う `ver_hash` は `Lib` モジュールの依存ハッシュであり、編集中の `main.fix` の内容には左右されないので、厳密な走行が使う鍵とぴったり一致する。
6. 次の診断走行が同じ値を検査しようとして、キャッシュに当たる。関数は `Ok((te, Errors::empty()))` を返す。診断は 0 件になり、`lib.fix` はエラーの無いファイルとして publish される。

消えたままになるのは、`lib.fix` 自身を編集して依存ハッシュが動くか、`MemoryCache` の 3 世代の窓からエントリが押し出されるまでである。

## 直した走り

保存の条件に、走行のモードを加えた。

```rust
if !tc.error_tolerant && !check_errors.has_diagnostics() {
    tc.cache.save_cache(&te, val_name, req_scm, ver_hash);
}
```

上の 5 で分岐する。`tc.error_tolerant` が真なので保存は行われず、キャッシュには何も入らない。6 の診断走行はキャッシュに当たらず、`lib.fix` の実装を厳密に検査し直し、型の不一致を報告する。エディタの診断は 1 件のまま残る。

述べている規則は 1 つである。**キャッシュが答えてよいのは、厳密に検査して通ったものだけである。** 2 つのものがその資格を失う。1 つは握り潰された診断で、これは次の走行がユーザに返す義務があるのに、キャッシュから答えると二度と出てこない。もう 1 つがエラーを許す検査そのもので、こちらはあらゆる型エラーを飲み込んで何も報告しないので、その結果は「エラーの無いもの」として入り、値は型が付いたものとして publish される。

## 触れた関数

### `Program::resolve_namespace_and_check_type_sub` (`src/ast/program.rs`)

**役割**: グローバル値 1 つの式について、名前解決・型エイリアスの解決・型検査を行い、型の付いた式と、許容された診断を返す。先頭でキャッシュを引き、当たればその結果を返して以降を飛ばす。末尾で、資格のある結果だけをキャッシュに保存する。

**変更**: 保存の条件に `!tc.error_tolerant` を加えた。合わせて、条件の上のコメントを、保存の資格を失う 2 つの場合を述べる形に書き直し、戻り値の doc コメントの「`errors` が空のときだけ書かれる」を「診断を出さなかった**厳密な**検査のときだけ書かれる」に直した。

**目的**: この関数はキャッシュへの唯一の書き込み口である。ここに条件を置くと、モードを立てるすべての呼び出し元に効く。補完の側で読み取り専用のキャッシュを渡す案も検討したが、それでは language server の経路しか守れない。

### `test_a_completion_leaves_the_error_of_another_file_reported` (`src/tests/test_lsp/test_diagnostics.rs`、新規)

**役割**: 上の再現をそのまま行う LSP 統合テスト。2 つのファイルを開き、`lib.fix` に診断が 1 件出ることを確かめ、`main.fix` のトレイト実装の本体で補完を 1 回要求し、次の診断走行の後も `lib.fix` の診断が**値として同じ 1 件**であることを確かめる。

補完の応答も読む。ドットの補完は候補に並べ替えの鍵を付けるので、鍵を持つ候補が 1 つも無い応答は、エラーを許す再検査が走らなかったということであり、その走行が何を残すかについて何も言えない。この確認が無いと、ドットの経路に入らなくなったときテストが空振りのまま緑になる。

### `test_completion_dot_sort_after_multibyte_text_on_the_line` (`src/tests/test_lsp/test_completion.rs`、新規)

**役割**: 行の手前に多バイト文字（コメント）がある位置でドット補完を要求し、`Array I64` の受け手に対して `Std::Array::push_back` が最上位の層に入ることを確かめる。プロトコルの列は UTF-16 の符号単位で数え、バッファはバイトで数えるので、この行では 2 つの数が食い違う。

### `a_test_build_and_a_plain_build_share_the_cache_without_corrupting_it` (`src/tests/test_hole_cache.rs`、新規)

**役割**: 1 つのプロジェクトディレクトリで `fix test` と `fix run` を続けて実行し、それぞれが自分のプログラムを作ることを確かめる。2 つのビルドは使うタプルのサイズが違うので、コンパイラが生成するタプルのトレイト実装のソースが違う。そのソースはどのモジュールの依存ハッシュにも入らないので (#305)、両者のエントリが 1 つの鍵の下で出会う。このテストは、その軸がプログラムの意味までは壊さないことを固定する。

### テストのケース

`src/tests/test_lsp/cases/diagnostics-after-completion/`（`fixproj.toml` と 2 つの `.fix`）と `src/tests/test_hole_cache/cases/test_and_build/` を足した。前者の `lib.fix` は、実装の本体が宣言と合わない形を意図して持っている。

## ユーザが読む文

CHANGELOG の `### Fixed` / `#### Tool` に 1 行足した。

> - LSP: A completion request no longer clears the errors reported for another file. A project that did not compile could show no error in the editor until the file holding the error was edited again.

## 確かめたこと

- 追加したテストは、修正を外す（保存の条件から `!tc.error_tolerant` を落とす）と赤くなる。そのときの表示は、期待した診断 1 件に対して実際が `[]` である。
- 全テストを `FIX_MAX_OPT_LEVEL=none` で流して 1385 件、失敗 0。この変更は最適化レベルに届かないので、1 水準で足りる。
- `cargo fmt` は差分を出さない。

## この PR が扱わないもの

- **補完の対象の絞り込み** (#306)。カーソルがトレイト実装のメンバの本体にあるとき、絞り込みは必ず失敗してプロジェクト全体が型検査される。#173 が併記していた項目で、値 1500 個のプロジェクトで補完 1 回あたり 229.9 ms 対 202.2 ms（中央値、低負荷時の 1 回の測定）。正しさの問題ではなくなったので分けた。
- **保存の粒度**。エラーを許す走行でも、何も握り潰さずに検査できた値は本来キャッシュに入れてよい。いまの実装は値ごとに「握り潰したか」を記録していないので、走行ごとに一律で落としている。この代償は小さい。エラーを許す走行が新たに書けたはずのエントリは、直前の厳密な診断走行が既にキャッシュしているか、編集中のバッファ由来で依存ハッシュが打鍵のたびに動くものかのどちらかで、後者は二度と読まれない。

## 付録: レビューとバグハント

`code-review` を通し、`test-sufficiency` の指摘でテストを 2 か所強化した（上の「補完の応答も読む」がそれである）。近傍の清掃は別 PR に分けてある。

`bug-hunt` をこのサブシステムに対して走らせ、既存バグを 9 件見つけて #297-#305 として登録した。最も重いのは #297 で、型検査キャッシュのファイル名が値の名前の記号を潰すため、フィールドのアクセサ `@b` とユーザの値 `_b` が同じエントリを共有し、有効なプログラムが黙って誤った答えを出す。この PR が触れた関数のすぐ隣にある欠陥だが、原因も直し方も独立している。
