### PR TITLE
レビュー清掃 (#307): 局所変数の名前と doc コメント

### DIFF
--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1202,10 +1202,10 @@ impl Program {
         mut tc: TypeCheckContext,
     ) -> Result<(TypedExpr, Errors), Errors> {
         // Load type-checking cache file.
-        let cache = tc.cache.load_cache(val_name, req_scm, ver_hash);
-        if cache.is_some() {
+        let cached_te = tc.cache.load_cache(val_name, req_scm, ver_hash);
+        if cached_te.is_some() {
             // If cache is available,
-            te = cache.unwrap();
+            te = cached_te.unwrap();
             return Ok((te, Errors::empty()));
         }
 
@@ -1268,7 +1268,7 @@ impl Program {
         let target_set: Option<Set<&FullName>> = target_symbols.map(|s| s.iter().collect());
 
         // Names of global values to be checked.
-        let mut checked_names: Vec<FullName> = vec![];
+        let mut names_to_check: Vec<FullName> = vec![];
         for (name, gv) in self.global_values.iter() {
             if let Some(set) = target_set.as_ref() {
                 if !set.contains(name) {
@@ -1279,12 +1279,12 @@ impl Program {
                 SymbolExpr::Simple(_) => {
                     // Check simple values only if they are in `modules`.
                     if modules.contains(&name.module()) {
-                        checked_names.push(name.clone());
+                        names_to_check.push(name.clone());
                     }
                 }
                 SymbolExpr::Method(_) => {
                     // We filter methods by `method_impl_filter`.
-                    checked_names.push(name.clone());
+                    names_to_check.push(name.clone());
                 }
             }
         }
@@ -1296,7 +1296,7 @@ impl Program {
 
         errors.eat_err(self.resolve_namespace_and_check_type(
             tc,
-            &checked_names,
+            &names_to_check,
             method_impl_filter,
         ));
         errors.to_result()
@@ -1390,7 +1390,7 @@ impl Program {
                         let scm = member.scm.clone();
                         let scm_via_defn = member.scm_via_defn.clone();
                         let impl_src = member.expr.expr.source.clone();
-                        let def_src = gv.decl_src.clone();
+                        let decl_src = gv.decl_src.clone();
                         let val_name_clone = val_name.clone(); // For move into closure.
                         let def_mod = self.find_mod(&member.define_module).unwrap().clone();
                         let mut nrctx =
@@ -1411,7 +1411,7 @@ impl Program {
                                         &impl_src
                                             .as_ref()
                                             .map(|s| s.to_head_character()),
-                                        &def_src
+                                        &decl_src
                                             .as_ref()
                                             .map(|s| s.to_head_character()),
                                     ],

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1008,7 +1008,15 @@ impl Program {
         self.add_global_value_common(name, (expr, scm), None, None, document, true)
     }
 
-    // Add a global value.
+    /// Registers a global value whose body is `expr` and whose type is `scm`.
+    ///
+    /// # Arguments
+    /// * `decl_src` — where the value's type signature is written.
+    /// * `defn_src` — where the left hand side of the value's definition is written.
+    /// * `document` — the documentation of the value, for a value whose `decl_src` is
+    ///   unavailable; otherwise the documentation is read from the source code.
+    /// * `compiler_defined_method` — marks a method the compiler generates for a type, such as
+    ///   `@{field}` or `set_{field}`, which `fix docs` leaves out.
     fn add_global_value_common(
         &mut self,
         name: FullName,
@@ -1031,7 +1039,8 @@ impl Program {
         self.add_global_value_gv(name, gv)
     }
 
-    // Add a global value.
+    /// Registers an already-built global value under `name`, reporting an error that points at
+    /// both declarations when the name is taken.
     pub fn add_global_value_gv(&mut self, name: FullName, gv: GlobalValue) -> Result<(), Errors> {
         // Check duplicate definition.
         if self.global_values.contains_key(&name) {
@@ -1055,7 +1064,9 @@ impl Program {
         Ok(())
     }
 
-    // Add global values.
+    /// Pairs each definition with the type signature carrying the same name and registers the
+    /// pairs as global values. A name that carries two definitions, two signatures, a definition
+    /// without a signature, or a signature without a definition is reported as an error.
     pub fn add_global_values(
         &mut self,
         defns: Vec<GlobalValueDefn>,
@@ -1063,8 +1074,12 @@ impl Program {
     ) -> Result<(), Errors> {
         let mut errors = Errors::empty();
 
+        /// The two halves of one global value, collected while pairing them up by name. A half
+        /// stays `None` until it is met.
         struct GlobalValue {
+            /// The definition, e.g. `main = println("Hello World");`.
             defn: Option<GlobalValueDefn>,
+            /// The type signature, e.g. `main : IO ();`.
             decl: Option<GlobalValueDecl>,
         }
         let mut global_values: Map<FullName, GlobalValue> = Default::default();
@@ -1239,7 +1254,10 @@ impl Program {
         Ok((te, check_errors))
     }
 
-    // Create NameResolutionEnv used for symbols defined in the specified module.
+    /// Builds the program-wide table that name resolution reads: every type constructor, trait
+    /// and associated type a capitalized name can resolve to, plus each module's import
+    /// statements. A `NameResolutionContext` fixes the module a name is written in and shares
+    /// this table.
     pub fn create_name_resolution_env(&self) -> Arc<NameResolutionEnv> {
         Arc::new(NameResolutionEnv::new(
             &self.tycon_names_with_aliases(),

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -18,9 +18,9 @@ mod tests {
     /// path inside it.
     fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cases = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
+        let cases_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
         let project_dir = temp_dir.path().join(project_name);
-        copy_dir_recursive(&cases.join(project_name), &project_dir)
+        copy_dir_recursive(&cases_dir.join(project_name), &project_dir)
             .expect("Failed to copy test case");
         (temp_dir, project_dir)
     }


### PR DESCRIPTION
Refs #249, #173

#307 のレビューが、変更した hunk の**周り**で見つけたものを直す。振る舞いは変えない。

このプルリクエストは #307 のブランチに向けている。#307 の diff を読むときに、この清掃が混ざっていない状態で読めるようにするための分割である。

## 1. 局所変数を、中身を言う名前にする

### `src/ast/program.rs`

`resolve_namespace_and_check_type_sub` は、グローバル値 1 つの式を名前解決して型検査する関数である。その先頭でキャッシュを引く局所変数が `cache` という名前だった。中身はキャッシュではなく、読み込んだ型付きの式 (`Option<TypedExpr>`) である。同じ関数の中の `tc.cache` こそがキャッシュなので、1 つの名前が 2 つのものを指していた。`cached_te` にした。

`resolve_namespace_and_check_type_in_modules` は、指定されたモジュールのグローバル値を名前解決して型検査する関数である。検査する値の名前を集める変数が `checked_names` だった。中身はこれから検査する名前で、直上のコメントも "Names of global values to be checked." と言っている。`names_to_check` にした。

`resolve_namespace_and_check_type` は、名前で指定されたグローバル値を型検査する関数である。トレイトメンバの実装を検査するタスクを組み立てるところで、`gv.decl_src`（トレイトがそのメンバを宣言している位置）を `def_src` に束縛していた。このファイルは `decl`（型の宣言）と `defn`（定義）を厳密に使い分けており、同じタスクの中に実装の位置を持つ `impl_src` が並んでいる。`decl_src` にした。

### `src/tests/test_lsp/test_diagnostics.rs`

`setup_test_env` の中で、ケースのディレクトリのパスを `cases` に束縛していた。同じテストツリーの他のファイルで `cases` はテストケースの配列を指しているので、語彙が衝突していた。`cases_dir` にした。`completion_harness.rs` の `get_test_cases_dir` と揃う。

## 2. doc コメントの無い関数に doc コメントを足す

`src/ast/program.rs` の、変更した hunk に近い 5 つ。いずれも `//` で名前を言い直しているだけか、コメントが無かった。

- `add_global_value_common` — グローバル値を登録する。`decl_src` / `defn_src` / `document` / `compiler_defined_method` の 4 つは、名前と型からは役割が読めないので `# Arguments` に書いた。`// Add a global value.` という同じ 1 行が 4 つの関数の上に並んでいたのを解消している。
- `add_global_value_gv` — 組み立て済みのグローバル値を名前の下に登録し、名前が埋まっていれば両方の宣言位置を指すエラーを出す。
- `add_global_values` — 同じ名前の定義と型宣言を対にして登録する。定義が 2 つ、宣言が 2 つ、宣言の無い定義、定義の無い宣言は、それぞれエラーになる。
- `add_global_values` の中のローカルな `struct GlobalValue` — 対にしている途中のグローバル値の片割れ 2 つ。フィールドにも 1 行ずつ足した。
- `create_name_resolution_env` — 名前解決が読む、プログラム全体の表を作る。大文字で始まる名前が指しうる型構築子・トレイト・関連型と、各モジュールの import 文が入る。

`src/ast/program.rs` には、これ以外にも doc コメントの無い項目、あるいは `///` でなく `//` の項目が **68 件**残っている。1 ファイルあたり 5 件という上限で止めた。

## 振る舞いを変えていないこと

- 1 は局所変数の名前で、スコープは 1 つの関数本体に閉じている。
- 2 はコメントである。

`cargo check --tests` が通り、`cargo fmt` は差分を出さない。LSP のテスト 163 件を release で流して失敗 0。

## 落とし方

#307 を読み終えたあとは、どちらの順序でも構わない。

- この PR を `completion-diagnostics-cache` にマージしてから、そのブランチを `main` にマージする。`main` へのマージは 1 回で、両方が入る。
- `completion-diagnostics-cache` を `main` にマージしてブランチを削除する。GitHub は削除されたブランチを base に持つ PR を、そのブランチ自身の base (`main`) へ張り替えるので、この PR は `main` への PR として単独で残る。

## レビューが見つけて、ここでは直していないもの

- `resolve_namespace_and_check_type_sub` の `_sub` は、呼び出しの連鎖の中の位置（`resolve_namespace_and_check_type` の下請け）を言っていて、仕事を言っていない。`resolve_namespace_and_check_type_of_value` を提案する。項目の改名は呼び出し側に波及するので著者の判断に委ねる。
- `src/tests/test_lsp/test_diagnostics.rs` が、サーバを起動する方法を 2 つ持つ状態になった。既存のテストはファイル private の `setup_test_env` + `diagnostics_of` を使い、新しいテストは `completion_harness::LspCompletionCtx` を使う。前者は後者とほぼ同じで、待ち方だけが違う（`completion_harness` は `$/progress` の終了通知を待ち、private 版は固定時間待つ）。両方を `LspCompletionCtx` に寄せると private の 2 つが消えるが、待ち方が入れ替わるので振る舞いの保存にならない。
- `instantiate_symbol` (`src/ast/program.rs`) の

  ```rust
  let method = impls.iter().find(|method| method_type_matches(method).unwrap_or(false)).unwrap();
  ```

  は、`are_unifiable` が返した本物の `Errors`（関連型の簡約の失敗など）を「一致しない」に潰し、候補が 1 つしか無ければ続く `.unwrap()` が情報の無い panic になる。ユーザ向けの診断がコンパイラの内部エラーに化ける形である。**同じ行を 2 回のレビューが独立に挙げている**（PR #244 のレビューでも出た）。直すには `Errors` を伝播させるか、その腕が到達しないことを表明するかの判断が要る。
- CHANGELOG の `### Fixed` / `#### Tool` にある「`fix run` and `fix test` no longer crash on startup in debug builds of `fix` (released builds were unaffected)」は、項目自身が「リリース版は無影響」と述べており、最新リリースの利用者は当たれない。出荷されなかった修正を載せない規約に照らすと外す候補だが、原因が未リリースの変更に遡るかまでは判定できなかった。
