### PR TITLE
レビュー清掃 (#316): 保存と読み込みの重複・局所変数の名前・import・doc コメント

### DIFF
--- a/src/elaboration/typecheckcache.rs
+++ b/src/elaboration/typecheckcache.rs
@@ -11,20 +11,17 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+/// A type-check cache held by the threads that check a program together.
 pub type SharedTypeCheckCache = Arc<dyn TypeCheckCache + Send + Sync>;
 
-// A trait for objects which manage caching of typechecked expressions.
-//
-// `RefUnwindSafe` is a supertrait so that `Arc<dyn TypeCheckCache + Send + Sync>`
-// satisfies `UnwindSafe`. The diagnostics thread captures one such `Arc` and
-// runs the captured closure under `catch_unwind`; without this bound the
-// closure isn't unwind-safe and the caller has to wrap it in
-// `AssertUnwindSafe`. Both built-in impls (`FileCache`, `MemoryCache`) are
-// `RefUnwindSafe` for free — `FileCache` is empty and `MemoryCache`'s only
-// field is a `Mutex`, whose poisoning protocol makes it unconditionally
-// `RefUnwindSafe`.
+/// Keeps the expressions produced by type checking, so that a value asked for again under the same
+/// type and the same sources is taken back instead of checked afresh.
+///
+/// `RefUnwindSafe` is a supertrait so that `Arc<dyn TypeCheckCache + Send + Sync>` satisfies
+/// `UnwindSafe`, which a closure carrying one across a `catch_unwind` boundary requires.
 pub trait TypeCheckCache: RefUnwindSafe {
-    // Saves a typechecked expression to the cache.
+    /// Stores `expr` as the result of checking the global value `name` against `type_`, under the
+    /// hash of the sources that value depends on.
     fn save_cache(
         &self,
         expr: &TypedExpr,
@@ -32,8 +29,8 @@ pub trait TypeCheckCache: RefUnwindSafe {
         type_: &Arc<Scheme>,
         version_hash: &str,
     );
-    // Loads a typechecked expression from the cache.
-    // Returns None if the cache is not found.
+    /// Answers with the expression stored for the global value `name` checked against `type_`
+    /// under `version_hash`.
     fn load_cache(
         &self,
         name: &FullName,
@@ -64,20 +61,27 @@ fn entity_identity(name: &FullName, type_: &Arc<Scheme>) -> EntityIdentity {
     format!("{}\n{}", name, type_)
 }
 
-// A cache implementation that stores cache in files.
+/// A cache that gives every entry a file of its own, so the entries outlive the run that wrote
+/// them.
 pub struct FileCache {}
 
 impl FileCache {
+    /// Creates a handle to the cache. Every handle reaches the same entries, which live under
+    /// `TYPE_CHECK_CACHE_PATH` relative to the working directory.
     pub fn new() -> Self {
         FileCache {}
     }
 
-    // Determine the filename for a cache file.
-    //
-    // The digest is what identifies the entry: it is taken over the entity and the version hash at
-    // once, so two entries meet in one file only when both agree. The part in front of it names
-    // the value for someone reading the cache directory, and is filename-safe because it keeps
-    // only alphanumeric characters; several values can wear the same one.
+    /// The name of the file that holds the cache entry for a value.
+    ///
+    /// The digest is what identifies the entry: it is taken over the entity and the version hash at
+    /// once, so two entries meet in one file only when both agree. The part in front of it names
+    /// the value for someone reading the cache directory, and is filename-safe because it keeps
+    /// only alphanumeric characters; several values can wear the same one.
+    ///
+    /// # Examples
+    ///
+    /// The entries of `Main::hole_val` are filed under names of the form `Main__hole_val_<digest>`.
     fn cache_file_name(&self, name: &FullName, type_: &Arc<Scheme>, version_hash: &str) -> String {
         let key = format!("{}\n{}", entity_identity(name, type_), version_hash);
         let digest = format!("{:x}", md5::compute(key));
@@ -88,8 +92,8 @@ impl FileCache {
         format!("{}_{}", readable_name, digest)
     }
 
-    // The path of the file that holds the cache entry for a value, creating the cache directory if
-    // it is absent.
+    /// The path of the file that holds the cache entry for a value, creating the cache directory if
+    /// it is absent.
     fn cache_file_path(&self, name: &FullName, type_: &Arc<Scheme>, version_hash: &str) -> PathBuf {
         let cache_file_name = self.cache_file_name(name, type_, version_hash);
         touch_directory(TYPE_CHECK_CACHE_PATH).join(cache_file_name)
@@ -97,6 +101,8 @@ impl FileCache {
 }
 
 impl TypeCheckCache for FileCache {
+    /// Writes the expression into the entry's own file. A file that cannot be created or written
+    /// is reported as a warning and leaves the entry absent.
     fn save_cache(
         &self,
         expr: &TypedExpr,
@@ -128,6 +134,8 @@ impl TypeCheckCache for FileCache {
         }
     }
 
+    /// Reads the entry's own file and answers with the expression it holds. A file that cannot be
+    /// read or parsed is reported as a warning and answers as an absent entry does.
     fn load_cache(
         &self,
         name: &FullName,
@@ -170,14 +178,19 @@ impl TypeCheckCache for FileCache {
     }
 }
 
+/// How many versions of one entity `MemoryCache` keeps. Storing a further version drops the one
+/// stored longest ago.
 const CACHE_GENERATION: u64 = 3;
 
-// Memory Cache.
+/// A cache that holds its entries in memory, so they last as long as the process that filled it.
 pub struct MemoryCache {
+    /// The stored expressions, grouped by the entity they belong to. Within a group the version
+    /// stored most recently comes first, and at most `CACHE_GENERATION` versions are held.
     data: Mutex<BTreeMap<EntityIdentity, VecDeque<(VersionHash, TypedExpr)>>>,
 }
 
 impl MemoryCache {
+    /// Creates a cache holding no entries.
     pub fn new() -> Self {
         MemoryCache {
             data: Mutex::new(BTreeMap::default()),
@@ -186,6 +199,8 @@ impl MemoryCache {
 }
 
 impl TypeCheckCache for MemoryCache {
+    /// Puts the expression at the front of the entity's versions, dropping the versions stored
+    /// longest ago to stay within `CACHE_GENERATION`.
     fn save_cache(
         &self,
         expr: &TypedExpr,
@@ -204,6 +219,7 @@ impl TypeCheckCache for MemoryCache {
         entries.push_front((version_hash, expr.clone()));
     }
 
+    /// Searches the entity's versions for the one stored under `version_hash`.
     fn load_cache(
         &self,
         name: &FullName,

--- a/src/elaboration/typecheckcache.rs
+++ b/src/elaboration/typecheckcache.rs
@@ -226,9 +226,11 @@ impl TypeCheckCache for MemoryCache {
 #[cfg(test)]
 mod tests {
     use super::FileCache;
-    use crate::ast::name::FullName;
-    use crate::ast::types::{type_tyvar_star, Scheme};
-    use crate::fixstd::builtin::{make_bool_ty, make_i64_ty};
+    use crate::{
+        ast::name::FullName,
+        ast::types::{type_tyvar_star, Scheme},
+        fixstd::builtin::{make_bool_ty, make_i64_ty},
+    };
 
     /// A field accessor and a value the user writes are two entities whose names differ only in a
     /// character a file name cannot carry. Their cache files must stay apart: a shared file hands

--- a/src/elaboration/typecheckcache.rs
+++ b/src/elaboration/typecheckcache.rs
@@ -104,13 +104,13 @@ impl TypeCheckCache for FileCache {
         type_: &Arc<Scheme>,
         version_hash: &str,
     ) {
-        let cache_file = self.cache_file_path(name, type_, version_hash);
-        let cache_file_str = cache_file.to_string_lossy().to_string();
-        let mut cache_file = match File::create(&cache_file) {
+        let cache_file_path = self.cache_file_path(name, type_, version_hash);
+        let cache_file_path_str = cache_file_path.to_string_lossy().to_string();
+        let mut cache_file = match File::create(&cache_file_path) {
             Err(_) => {
                 warn_msg(&format!(
                     "Failed to create cache file \"{}\".",
-                    cache_file_str
+                    cache_file_path_str
                 ));
                 return;
             }
@@ -122,7 +122,7 @@ impl TypeCheckCache for FileCache {
             Err(_) => {
                 warn_msg(&format!(
                     "Failed to write cache file \"{}\".",
-                    cache_file_str
+                    cache_file_path_str
                 ));
             }
         }
@@ -134,12 +134,12 @@ impl TypeCheckCache for FileCache {
         type_: &Arc<Scheme>,
         version_hash: &str,
     ) -> Option<TypedExpr> {
-        let cache_file = self.cache_file_path(name, type_, version_hash);
-        let cache_file_str = cache_file.to_string_lossy().to_string();
-        if !cache_file.exists() {
+        let cache_file_path = self.cache_file_path(name, type_, version_hash);
+        let cache_file_path_str = cache_file_path.to_string_lossy().to_string();
+        if !cache_file_path.exists() {
             return None;
         }
-        let mut cache_file = match File::open(&cache_file) {
+        let mut cache_file = match File::open(&cache_file_path) {
             Err(_) => {
                 return None;
             }
@@ -151,7 +151,7 @@ impl TypeCheckCache for FileCache {
             Err(why) => {
                 warn_msg(&format!(
                     "Failed to read cache file \"{}\": {}.",
-                    cache_file_str, why
+                    cache_file_path_str, why
                 ));
                 return None;
             }
@@ -161,7 +161,7 @@ impl TypeCheckCache for FileCache {
             Err(why) => {
                 warn_msg(&format!(
                     "Failed to parse content of cache file \"{}\": {}.",
-                    cache_file_str, why
+                    cache_file_path_str, why
                 ));
                 return None;
             }
@@ -196,12 +196,12 @@ impl TypeCheckCache for MemoryCache {
         let mut data = self.data.lock().unwrap();
         let entity_id = entity_identity(name, type_);
         let version_hash = version_hash.to_string();
-        let entry = data.entry(entity_id).or_insert_with(|| VecDeque::new());
+        let entries = data.entry(entity_id).or_insert_with(|| VecDeque::new());
         // If the cache is full, remove the oldest entry.
-        while entry.len() >= CACHE_GENERATION as usize {
-            entry.pop_back();
+        while entries.len() >= CACHE_GENERATION as usize {
+            entries.pop_back();
         }
-        entry.push_front((version_hash, expr.clone()));
+        entries.push_front((version_hash, expr.clone()));
     }
 
     fn load_cache(
@@ -213,8 +213,8 @@ impl TypeCheckCache for MemoryCache {
         let data = self.data.lock().unwrap();
         let entity_id = entity_identity(name, type_);
         let version_hash = version_hash.to_string();
-        let entry = data.get(&entity_id)?;
-        let expr = entry
+        let entries = data.get(&entity_id)?;
+        let expr = entries
             .iter()
             .find(|(hash, _)| hash == &version_hash)?
             .1

--- a/src/elaboration/typecheckcache.rs
+++ b/src/elaboration/typecheckcache.rs
@@ -87,6 +87,13 @@ impl FileCache {
             .replace(|c: char| !c.is_alphanumeric(), "_");
         format!("{}_{}", readable_name, digest)
     }
+
+    // The path of the file that holds the cache entry for a value, creating the cache directory if
+    // it is absent.
+    fn cache_file_path(&self, name: &FullName, type_: &Arc<Scheme>, version_hash: &str) -> PathBuf {
+        let cache_file_name = self.cache_file_name(name, type_, version_hash);
+        touch_directory(TYPE_CHECK_CACHE_PATH).join(cache_file_name)
+    }
 }
 
 impl TypeCheckCache for FileCache {
@@ -97,9 +104,7 @@ impl TypeCheckCache for FileCache {
         type_: &Arc<Scheme>,
         version_hash: &str,
     ) {
-        let cache_file_name: String = self.cache_file_name(name, type_, version_hash);
-        let cache_dir = touch_directory(TYPE_CHECK_CACHE_PATH);
-        let cache_file = cache_dir.join(cache_file_name);
+        let cache_file = self.cache_file_path(name, type_, version_hash);
         let cache_file_str = cache_file.to_string_lossy().to_string();
         let mut cache_file = match File::create(&cache_file) {
             Err(_) => {
@@ -129,9 +134,7 @@ impl TypeCheckCache for FileCache {
         type_: &Arc<Scheme>,
         version_hash: &str,
     ) -> Option<TypedExpr> {
-        let cache_file_name: String = self.cache_file_name(name, type_, version_hash);
-        let cache_dir: PathBuf = touch_directory(TYPE_CHECK_CACHE_PATH);
-        let cache_file = cache_dir.join(cache_file_name);
+        let cache_file = self.cache_file_path(name, type_, version_hash);
         let cache_file_str = cache_file.to_string_lossy().to_string();
         if !cache_file.exists() {
             return None;

--- a/src/tests/test_hole_cache.rs
+++ b/src/tests/test_hole_cache.rs
@@ -66,13 +66,13 @@ mod integration_tests {
     /// name begins with the given prefix.
     ///
     /// # Arguments
-    /// * `value_prefix` — the head of a cache file name, which holds the value's
-    ///   full name with each non-alphanumeric character replaced by `_`:
+    /// * `file_name_prefix` — the head of a cache file name, which holds the
+    ///   value's full name with each non-alphanumeric character replaced by `_`:
     ///   `Main::hole_val` is written `Main__hole_val`.
-    fn has_cache_entry_for(project_dir: &Path, value_prefix: &str) -> bool {
+    fn has_cache_entry_for(project_dir: &Path, file_name_prefix: &str) -> bool {
         list_cache_files(project_dir)
             .iter()
-            .any(|name| name.starts_with(value_prefix))
+            .any(|file_name| file_name.starts_with(file_name_prefix))
     }
 
     /// A hole-bearing value must not have a typecheck cache file

--- a/src/tests/test_hole_cache.rs
+++ b/src/tests/test_hole_cache.rs
@@ -18,6 +18,7 @@ mod integration_tests {
     use crate::tests::test_util::{copy_dir_recursive, fix_command};
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::process;
     use tempfile::TempDir;
 
     /// Absolute path to the `cases/` directory shipped alongside this
@@ -41,7 +42,7 @@ mod integration_tests {
 
     /// Run `fix check` in `project_dir` and return the full process
     /// output.
-    fn run_check(project_dir: &Path) -> std::process::Output {
+    fn run_check(project_dir: &Path) -> process::Output {
         fix_command()
             .arg("check")
             .current_dir(project_dir)

--- a/src/tests/test_hole_cache.rs
+++ b/src/tests/test_hole_cache.rs
@@ -140,8 +140,9 @@ mod integration_tests {
     }
 
     /// Once the user fills in the hole, `fix check` succeeds and a
-    /// cache file appears for the now-clean value (i.e. the cache
-    /// suppression is gated on having errors, not permanent).
+    /// cache file appears for the now-clean value: the cache is
+    /// withheld for as long as the value reports an error, and written
+    /// again once it type-checks cleanly.
     #[test]
     fn fixed_value_is_cached_after_edit() {
         let (_temp_dir, project_dir) = setup_test_env("with_hole");


### PR DESCRIPTION
Refs #297

#316 のレビューが、変更した hunk の**周り**で見つけたものを直す。振る舞いは変えない。

このプルリクエストは `typecheck-cache-name` に向けている。#316 の diff を読むときに、この清掃が混ざっていない状態で読めるようにするための分割である。

対象は `src/elaboration/typecheckcache.rs` と `src/tests/test_hole_cache.rs` の 2 ファイル、いずれも #316 が触れたファイルの、触れていない部分である。

## 1. 保存と読み込みが同じ 3 文を書いていたので、1 つにした

`FileCache::save_cache` と `FileCache::load_cache` は、どちらも先頭で同じ手順を踏んでいた。ファイル名を作り、キャッシュディレクトリを作り、その 2 つを繋ぐ。

```rust
let cache_file_name: String = self.cache_file_name(name, type_, version_hash);
let cache_dir = touch_directory(TYPE_CHECK_CACHE_PATH);
let cache_file = cache_dir.join(cache_file_name);
```

`FileCache::cache_file_path` を足し、両方をそこへ移した。文の順序はそのままなので、ディレクトリを作るのが名前を作った後であることも変わらない。

## 2. 局所変数を、中身を言う名前にする

### `src/elaboration/typecheckcache.rs`

`save_cache` と `load_cache` で、`cache_file` がパス (`PathBuf`) を束縛し、その数行後に開いた `File` が同じ名前で束縛し直されていた。1 つの語が数行のうちに 2 つのものを指していた。パスの側を `cache_file_path` に、それから作る文字列を `cache_file_path_str` にした。

`MemoryCache::save_cache` と `load_cache` の `entry` は、1 つの実体について保持している `(version_hash, expr)` の列全体を束縛している。直後のコメント（「キャッシュが一杯なら最も古い entry を落とす」）が言う entry はその列の要素の方なので、1 つの語が容れ物と中身の両方を指していた。`entries` にした。

### `src/tests/test_hole_cache.rs`

`has_cache_entry_for` の引数 `value_prefix` は、値の名前の接頭辞ではなく、値の名前から作られる**ファイル名**の接頭辞である（呼び出し側が渡すのは `"Main__hole_val_"`）。`file_name_prefix` にした。中のクロージャの束縛 `name` も `file_name` にした。

## 3. 修飾を短くする

`src/tests/test_hole_cache.rs` の `run_check` の戻り値が `std::process::Output` と書かれていた。このファイルは `use std::fs;` を置いて `fs::read_dir` と書く形なので、`use std::process;` を足して `process::Output` にした。`Output` だけでは何のことか分からないので、モジュールの 1 段は残す。

`src/elaboration/typecheckcache.rs` の新しい `mod tests` が `use crate::…` を 3 行に分けて書いていたので、ファイル冒頭の書き方に合わせて 1 つの `use crate::{…}` にまとめた。

## 4. doc コメントを足し、`//` を `///` にする

`src/elaboration/typecheckcache.rs` はファイル全体が `//` で、doc コメントの無い項目が並んでいた。すべてに `///` の doc コメントを付けた。対象は `SharedTypeCheckCache`、`TypeCheckCache` とその 2 つのメソッド、`FileCache` とその `new`、`cache_file_name`、`MemoryCache` とその `new` とフィールド、`CACHE_GENERATION`、および 2 つの `impl TypeCheckCache for …` にある 4 つの実装である。

そのうち、書き直しになったものを挙げる。

- `TypeCheckCache::load_cache` の `// Returns None if the cache is not found.` を落とした。戻り値の型が `Option` である以上、「見つからなければ `None`」は型が既に言っている。
- `// Memory Cache.` は名前を言い直しているだけだったので、何であるかを述べる形にした（エントリをメモリに持つので、それを埋めたプロセスと同じだけ生きる）。
- `TypeCheckCache` に付いていた `RefUnwindSafe` の説明から、`AssertUnwindSafe` で包む羽目になるという反実仮想と、2 つの実装がそれぞれなぜ `RefUnwindSafe` になるかの列挙を落とした。前者は現在の設計を説明していないし、後者は実装が増えると古くなる。要件そのもの（`Arc<dyn TypeCheckCache + Send + Sync>` が `UnwindSafe` を満たす必要があり、それを `catch_unwind` を跨ぐクロージャが要求する）は残した。
- `cache_file_name` に `# Examples` を 1 行足した。この関数の中身は結果の形そのものなので、例が 1 つあると説明 1 文より正確に伝わる。

`src/tests/test_hole_cache.rs` では、`fixed_value_is_cached_after_edit` の doc が「キャッシュの抑止はエラーがあることに紐づいていて、恒久的なものではない」と否定形で述べていたので、肯定形（値がエラー無しで型検査できた時点でキャッシュが書かれる）に直した。`has_cache_entry_for` の doc は、`cache_file_name` の命名規則の解説になっていたので、自身の入出力を述べる形に書き直し、規則は `# Arguments` に移した。

## 振る舞いを変えていないこと

- 1 は同じ 3 文を関数に括り出しただけで、両方の呼び出し元で順序も引数も変わらない。
- 2 は局所変数と 1 つの private 関数の引数の名前で、スコープは 1 つの関数本体に閉じている。
- 3 は import である。
- 4 はコメントである。

`cargo check --tests` が通り、`cargo fmt` は差分を出さない。全テストを `FIX_MAX_OPT_LEVEL=none` で流して 1390 件、失敗 0。

## 落とし方

#316 を読み終えたあとは、どちらの順序でも構わない。

- この PR を `typecheck-cache-name` にマージしてから、そのブランチを `main` にマージする。`main` へのマージは 1 回で、両方が入る。
- `typecheck-cache-name` を `main` にマージしてブランチを削除する。GitHub は削除されたブランチを base に持つ PR を、そのブランチ自身の base (`main`) へ張り替えるので、この PR は `main` への PR として単独で残る。

## レビューが見つけて、ここでは直していないもの

いずれも項目の名前・型・位置を変えるか、振る舞いを変えるものなので、著者の判断に委ねる。

- `FileCache::load_cache` の `File::open` の Err 腕だけが、理由を捨てて黙って `None` を返す。直前で `exists()` を確かめているので、ここに来るのは「ファイルは在るのに開けない」場合だけである。隣の読み込みと逆シリアライズの Err 腕はどちらも `warn_msg` で理由を出す。あわせて、`exists()` のガードは `File::open` が同じことを報告するので冗長で、2 つを 1 つにすれば open の失敗理由がそのまま使える。**#313 の一部**として登録済み。
- `const CACHE_GENERATION: u64` は `entries.len() >= CACHE_GENERATION as usize` としてしか使われない。`usize` で宣言すればキャストが消える。また、この定数は `FileCache` の impl と `MemoryCache` の間に置かれているが、読むのは `MemoryCache` だけである。名前も、実体が「1 実体あたり保持する版の上限数」なのに単数形の `generation` なので、「キャッシュ形式の世代（上げると既存エントリを無効化する印）」という別概念を連想させる。`MAX_VERSIONS_PER_ENTITY` を提案する。
- `MemoryCache` のフィールド `data` は置き場を名指しているだけで、読み手に期待を作らない。`entries_by_entity` を提案する。
- `MemoryCache::save_cache` の追い出しが `while entries.len() >= …` である。毎回 1 つ足す設計なので長さが上限を 2 以上超えることはなく、`while` は「起きないはずの超過」を黙って修復する形になっている。`if` + `assert!` が素直である。
- `TypeCheckCache::save_cache` / `load_cache` は、キャッシュそのものである型のメソッドなので呼び出し側で `cache.save_cache(...)` と重なる。Rust の作法では `save` / `load` になる。呼び出し元がこの 2 ファイルの外にもあるので、著者の判断に委ねる。
- `MemoryCache::save_cache` の `data.entry(entity_id).or_insert_with(|| VecDeque::new())` は `or_default()` で足りる。
- `format!("{:x}", md5::compute(...))` が `src/` に 16 か所ある。共有のヘルパ（`crate::misc` の `md5_hex` のようなもの）が無い。加えて「複数の成分を 1 つの md5 に畳む」書き方が `Configuration` の `push_list_hash`（個数を先頭に置く）、`Symbol::hash`（タグ区切り）、この PR（改行結合）と 3 通りある。統合すると既存 2 か所のハッシュ値が変わり、対応するキャッシュが 1 回無効化されるので、この清掃には混ぜていない。
- `src/tests/test_hole_cache.rs` の `has_cache_entry_for` は単なる前方一致なので、`Main__hole_val_` は `Main__hole_val_x_<digest>` にも当たる。いまのケースには該当する値が無いので実害は無いが、テストが別の理由で通り得る形である。接頭辞の後ろが「`_` + 16 進 32 文字ちょうど」であることまで見るか、`cache_file_name` からファイル名そのものを組み立てるかで締まる。
- 同ファイルの `list_cache_files` は `entry.ok().and_then(|e| e.file_name().into_string().ok())` で、`read_dir` のエントリ失敗と非 UTF-8 のファイル名を飲む。飲まれると `has_cache_entry_for` が誰にも見えない理由で `false` を返し、`hole_value_is_not_cached` はその `false` を根拠に成功してしまう。`expect` で落とすのが正しい。
- 同ファイルのモジュール doc が、テストの守る契約を `resolve_namespace_and_check_type_sub` という関数名で指している。改名されると古くなるが、いまのところこれが契約のいちばん明確な述べ方である。
- `get_test_cases_dir` は、Rust の作法では単なるアクセサから `get_` を落とす。
