### PR TITLE
レビュー清掃 (#325): 変更の隣のコメントとローカル名

### DIFF
--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -317,7 +317,6 @@ pub fn build_object_files<'c>(
 
         let entry_io_value = program.entry_io_value.clone();
         threads.push(spawn_compiler_thread(move || {
-            // Create GenerationContext.
             let context = Context::create();
             let target_machine = get_target_machine(config.get_llvm_opt_level(), &config);
             let module = Generator::create_module(
@@ -364,7 +363,6 @@ pub fn build_object_files<'c>(
                 }
             }
 
-            // If debug info is generated, finalize it.
             gc.finalize_di();
 
             gc.assert_defined_symbols_fit_a_symbol_table();
@@ -379,7 +377,6 @@ pub fn build_object_files<'c>(
                 emit_llvm(gc.module, &config, false);
             }
 
-            // LLVM level optimization.
             optimize_instrument_and_verify(gc.module, &target_machine, &config);
 
             if config.emit_llvm {
@@ -387,7 +384,6 @@ pub fn build_object_files<'c>(
                 emit_llvm(gc.module, &config, true);
             }
 
-            // Generate object file.
             write_to_object_file(gc.module, &target_machine, &unit.object_file_path());
         }));
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,6 +74,8 @@ pub const ARRAY_CHECK_SIZE: &str = "_check_size";
 pub const ARRAY_UNSAFE_EMPTY_NAME: &str = "_unsafe_empty_capacity_unchecked";
 
 // Structure methods.
+/// The head of the name of a struct field's getter, which reads the field out of a value: the
+/// getter of the field `x` is named `@x`, in the namespace of the struct the field belongs to.
 pub const STRUCT_GETTER_SYMBOL: &str = "@";
 pub const STRUCT_SETTER_SYMBOL: &str = "set_";
 pub const STRUCT_MODIFIER_SYMBOL: &str = "mod_";

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -2,16 +2,20 @@ use crate::configuration::FixOptimizationLevel;
 use crate::misc::warn_msg;
 use std::env;
 
-/// Get the maximum optimization level from the FIX_MAX_OPT_LEVEL environment variable.
-/// Returns None if the environment variable is not set or has an invalid value.
+/// The environment variable holding the highest optimization level a build works at. It also
+/// decides the level of a build that asks for none.
+pub const MAX_OPT_LEVEL_VAR: &str = "FIX_MAX_OPT_LEVEL";
+
+/// The highest optimization level a build works at, as `MAX_OPT_LEVEL_VAR` gives it. A value the
+/// variable does not hold, and a value it holds that names no level, both give `Max`.
 pub fn get_max_opt_level() -> FixOptimizationLevel {
-    if let Ok(var) = env::var("FIX_MAX_OPT_LEVEL") {
+    if let Ok(var) = env::var(MAX_OPT_LEVEL_VAR) {
         if let Some(level) = FixOptimizationLevel::from_str(&var) {
             return level;
         }
         warn_msg(&format!(
-            "Invalid value for FIX_MAX_OPT_LEVEL: \"{}\". Using default value.",
-            var
+            "Invalid value for {}: \"{}\". Using default value.",
+            MAX_OPT_LEVEL_VAR, var
         ));
     }
     FixOptimizationLevel::Max

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2482,13 +2482,13 @@ impl<'c, 'm> Generator<'c, 'm> {
         } else {
             embedded_ty.fn_type(&[], false)
         };
-        let func = self.module.add_function(
+        let acc_fn = self.module.add_function(
             &acc_fn_name,
             acc_fn_ty,
             Some(self.config.external_if_separated()),
         );
-        self.add_global_object(name.clone(), func, ty);
-        Some(func)
+        self.add_global_object(name.clone(), acc_fn, ty);
+        Some(acc_fn)
     }
 
     // Give `func`, whose body is about to be emitted, its debug-info subprogram and open that

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2491,13 +2491,13 @@ impl<'c, 'm> Generator<'c, 'm> {
         Some(acc_fn)
     }
 
-    // Give `func`, whose body is about to be emitted, its debug-info subprogram and open that
-    // subprogram as the debug scope the body is generated under. The returned guard closes the scope
-    // when it is dropped; it is `None` when the build carries no debug info.
-    //
-    // Attaching the subprogram here, where the body is created, is what keeps it off a function that
-    // has none: LLVM's verifier rejects a `!dbg` attachment on a bodyless declaration, and a module
-    // declares every global it refers to but defines only its own.
+    /// Give `func`, whose body is about to be emitted, its debug-info subprogram and open that
+    /// subprogram as the debug scope the body is generated under. The returned guard closes the
+    /// scope when it is dropped; it is `None` when the build carries no debug info.
+    ///
+    /// Attaching the subprogram here, where the body is created, is what keeps it off a function
+    /// that has none: LLVM's verifier rejects a `!dbg` attachment on a bodyless declaration, and a
+    /// module declares every global it refers to but defines only its own.
     pub fn push_debug_subprogram(
         &mut self,
         func: FunctionValue<'c>,
@@ -2699,11 +2699,11 @@ impl<'c, 'm> Generator<'c, 'm> {
         }
     }
 
-    // A debug-info subprogram belongs to a function this module defines. LLVM's verifier rejects one
-    // attached to a function this module only declares, reporting every offending function at once
-    // and naming no cause; this says which function took a subprogram it should not have, at the
-    // point the attachment is still attributable to the code that made it. See
-    // `push_debug_subprogram`, which is where a subprogram is attached.
+    /// A debug-info subprogram belongs to a function this module defines. LLVM's verifier rejects
+    /// one attached to a function this module only declares, reporting every offending function at
+    /// once and naming no cause; this says which function took a subprogram it should not have, at
+    /// the point the attachment is still attributable to the code that made it. See
+    /// `push_debug_subprogram`, which is where a subprogram is attached.
     fn assert_no_subprogram_on_declaration(&self) {
         for func in self.module.get_functions() {
             if func.count_basic_blocks() == 0 && func.get_subprogram().is_some() {
@@ -2744,8 +2744,8 @@ impl<'c, 'm> Generator<'c, 'm> {
         }
     }
 
-    // The debug info record of the file `src` lives in. A source that is unknown is recorded as the
-    // file `<unknown source>`, so every debug entity has a file to point at.
+    /// The debug info record of the file `src` lives in. A source that is unknown is recorded as
+    /// the file `<unknown source>`, so every debug entity has a file to point at.
     pub fn create_di_file(&self, src: Option<SourceFile>) -> DIFile<'c> {
         if let Some(src) = src {
             self.get_di_builder()
@@ -2903,8 +2903,8 @@ pub(crate) fn enum_attribute_kind_id(name: &str) -> u32 {
     kind_id
 }
 
-// Whether `v` is the constant integer 1. Used where a retain-by-`amount` reproduces the ordinary
-// single retain when the amount is exactly 1, so that path stays byte-identical.
+/// Whether `v` is the integer constant 1. An integer the program computes at run time answers
+/// `false`, whatever it turns out to hold.
 pub(crate) fn is_const_one(v: IntValue) -> bool {
     v.get_zero_extended_constant() == Some(1)
 }
@@ -2932,9 +2932,9 @@ pub(crate) fn object_file_symbol_name(name: &FullName) -> String {
     name.replace(STRUCT_GETTER_SYMBOL, SYMBOL_TABLE_GETTER_SYMBOL)
 }
 
-// The name of the LLVM function through which the global `name`, of a type other than funptr, is
-// obtained. It is the name every module — the one defining the global and the ones calling into it —
-// declares and looks the accessor up under.
+/// The name of the LLVM function through which the global `name`, of a type other than funptr, is
+/// obtained. It is the name every module — the one defining the global and the ones calling into
+/// it — declares and looks the accessor up under.
 pub(crate) fn global_accessor_name(name: &FullName) -> String {
     format!("Get#{}", object_file_symbol_name(name))
 }

--- a/src/rc_ir/codegen.rs
+++ b/src/rc_ir/codegen.rs
@@ -595,7 +595,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         );
         init_flag.set_initializer(&flag_init_val);
         init_flag.set_linkage(Linkage::Internal);
-        let init_flag = init_flag.as_basic_value_enum().into_pointer_value();
+        let init_flag_ptr = init_flag.as_basic_value_enum().into_pointer_value();
 
         let _builder_guard = self.push_builder();
         let entry_bb = self.context.append_basic_block(acc_fn, "entry");
@@ -606,7 +606,7 @@ impl<'c, 'm> Generator<'c, 'm> {
         let (init_bb, end_bb, mut init_fn_di_guard) = if !self.config.threaded {
             let flag = self
                 .builder()
-                .build_load(flag_ty, init_flag, "load_init_flag")
+                .build_load(flag_ty, init_flag_ptr, "load_init_flag")
                 .unwrap()
                 .into_int_value();
             let is_zero = self
@@ -634,7 +634,7 @@ impl<'c, 'm> Generator<'c, 'm> {
             self.call_runtime(
                 RUNTIME_PTHREAD_ONCE,
                 &[
-                    init_flag.into(),
+                    init_flag_ptr.into(),
                     init_fn.as_global_value().as_pointer_value().into(),
                 ],
             );
@@ -659,7 +659,7 @@ impl<'c, 'm> Generator<'c, 'm> {
 
         if !self.config.threaded {
             self.builder()
-                .build_store(init_flag, self.context.i8_type().const_int(1, false))
+                .build_store(init_flag_ptr, self.context.i8_type().const_int(1, false))
                 .unwrap();
             self.builder().build_unconditional_branch(end_bb).unwrap();
         } else {

--- a/src/rc_ir/codegen.rs
+++ b/src/rc_ir/codegen.rs
@@ -1,10 +1,9 @@
 //! Code generation from the RC IR to LLVM.
 //!
-//! The LLVM back end consumes the RC IR (with its explicit `Retain`/`Release` nodes). Reference
-//! counting is driven entirely by the RC nodes: variable reads are plain and the read-getters do not
-//! release their container — the explicit `Release` nodes dispose it. Non-reference-counting work
-//! (closure layout, FFI, struct/array construction, the inline-LLVM builtins) reuses the existing
-//! `Generator` helpers unchanged.
+//! Every retain and release the generated code performs comes from a `Retain` or `Release` node of
+//! the RC IR: a variable read yields the value alone, and a read-getter leaves its container to the
+//! `Release` node that disposes it. The work outside reference counting — closure layout, FFI,
+//! struct and array construction, the inline-LLVM builtins — is done by the `Generator` helpers.
 
 use crate::ast::name::FullName;
 use crate::ast::types::TypeNode;

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -9615,6 +9615,9 @@ pub fn test_type_wildcard_applied_without_kind_is_error() {
     test_source_fail(&source, Configuration::develop_mode(), "Kind mismatch");
 }
 
+/// A type annotation inside a definition that names the type variables of the definition's own
+/// signature, one of them of a higher kind: `let reader : ReaderT e m e = ...` in a value of type
+/// `[m : Monad] e -> m e` annotates with the `e` and the `m` the signature bound.
 #[test]
 pub fn test_regression_higher_kinded_type_variable_in_type_annotation() {
     let source = r##"
@@ -9670,6 +9673,9 @@ pub fn test_regression_higher_kinded_type_variable_in_type_annotation() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// `match` on an `Option`, over the representations its payload takes: unboxed, boxed, and a
+/// closure. The boxed and the closure payload are also read out of the matched `Option` after the
+/// match, where the arm has to have left them alive.
 #[test]
 pub fn test_match_option() {
     let source = r##"

--- a/src/tests/test_closure_specialization.rs
+++ b/src/tests/test_closure_specialization.rs
@@ -12,7 +12,7 @@
 #[cfg(test)]
 mod integration_tests {
     use crate::constants::{CLOSURE_LAM_SUFFIX, CLOSURE_SPEC_SUFFIX};
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
+    use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -123,17 +123,15 @@ mod integration_tests {
     /// that is known to answer correctly.
     ///
     /// # Arguments
-    /// * `opt_level` - pinned through `FIX_MAX_OPT_LEVEL`, so the level is the one this test asks
-    ///   for whatever the level the suite is being run at.
+    /// * `opt_level` - the level the case is built at, which decides which specializations exist.
     /// * `expected_output` - what the case prints on stdout.
     fn build_run_and_read_rc_ir(
         project_dir: &Path,
         opt_level: &str,
         expected_output: &str,
     ) -> String {
-        let build = fix_command()
-            .args(["build", "-O", opt_level, "--emit-rc-ir", "all"])
-            .env("FIX_MAX_OPT_LEVEL", opt_level)
+        let build = fix_command_at_opt_level("build", opt_level)
+            .args(["--emit-rc-ir", "all"])
             .current_dir(project_dir)
             .output()
             .expect("Failed to execute fix build");

--- a/src/tests/test_debug_info.rs
+++ b/src/tests/test_debug_info.rs
@@ -15,7 +15,7 @@
 
 #[cfg(test)]
 mod debug_info_tests {
-    use crate::tests::test_util::fix_command;
+    use crate::tests::test_util::fix_command_at_opt_level;
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -25,17 +25,13 @@ mod debug_info_tests {
 
     // Build an inline Fix `source` with `-g` at optimization level `opt_level`, passing `extra_args`
     // to `fix build` as well, assert the build succeeds, and return the directory holding the built
-    // `prog`. `FIX_MAX_OPT_LEVEL` is pinned to the level asked for, because the suite runs under a
-    // level taken from that variable and it caps the `-O` given here.
+    // `prog`.
     fn build_with_g(source: &str, opt_level: &str, extra_args: &[&str]) -> TempDir {
         let temp = TempDir::new().expect("Failed to create temp directory");
         fs::write(temp.path().join("main.fix"), source).expect("Failed to write main.fix");
-        let build = fix_command()
-            .args([
-                "build", "-g", "-O", opt_level, "-f", "main.fix", "-o", "prog",
-            ])
+        let build = fix_command_at_opt_level("build", opt_level)
+            .args(["-g", "-f", "main.fix", "-o", "prog"])
             .args(extra_args)
-            .env("FIX_MAX_OPT_LEVEL", opt_level)
             .current_dir(temp.path())
             .output()
             .expect("Failed to execute `fix build`");

--- a/src/tests/test_dynamic_library.rs
+++ b/src/tests/test_dynamic_library.rs
@@ -9,7 +9,9 @@
 //! line, and the case projects here cover one each.
 
 use crate::configuration::{Configuration, FixOptimizationLevel, OutputFileType};
-use crate::tests::test_util::{assert_succeeded, fix_command, setup_case_projects, test_source};
+use crate::tests::test_util::{
+    assert_succeeded, fix_command_at_opt_level, setup_case_projects, test_source,
+};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -24,13 +26,8 @@ const DRIVER_ARGUMENT: i64 = 10;
 const DRIVER_OUTPUT: &str = "21";
 
 /// Builds `project_dir` as a dynamic library at `opt_level` and returns the path of the library.
-///
-/// The suite runs under an optimization level taken from `FIX_MAX_OPT_LEVEL`, which caps the level
-/// `-O` asks for, so the variable is pinned here to the level under test.
 fn build_library(project_dir: &Path, opt_level: &str) -> PathBuf {
-    let output = fix_command()
-        .args(["build", "-O", opt_level])
-        .env("FIX_MAX_OPT_LEVEL", opt_level)
+    let output = fix_command_at_opt_level("build", opt_level)
         .current_dir(project_dir)
         .output()
         .expect("Failed to execute `fix build`");

--- a/src/tests/test_locality.rs
+++ b/src/tests/test_locality.rs
@@ -16,7 +16,7 @@
 
 #[cfg(test)]
 mod integration_tests {
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
+    use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
     use std::fs;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
@@ -38,14 +38,12 @@ mod integration_tests {
     }
 
     /// Build the case project with `--emit-rc-ir Main` and return the dumped RC IR of the `Main`
-    /// module. The build is pinned to the `max` optimization level, the only one the locality pass
-    /// runs at, so the dump is the same whatever ambient `FIX_MAX_OPT_LEVEL` the suite runs under.
+    /// module. The build works at the `max` optimization level, the only one the locality pass runs
+    /// at.
     fn emit_main_rc_ir(project_dir: &Path) -> String {
-        let output = fix_command()
-            .arg("build")
+        let output = fix_command_at_opt_level("build", "max")
             .arg("--emit-rc-ir")
             .arg("Main")
-            .env("FIX_MAX_OPT_LEVEL", "max")
             .current_dir(project_dir)
             .output()
             .expect("Failed to execute fix build --emit-rc-ir");

--- a/src/tests/test_provenance.rs
+++ b/src/tests/test_provenance.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod integration_tests {
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
+    use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
     use std::fs;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
@@ -30,17 +30,14 @@ mod integration_tests {
     }
 
     /// Build the case project with `--emit-rc-ir Main` and return the dumped RC IR of the `Main`
-    /// module. The build is pinned to the `max` optimization level: the borrow versions and the
-    /// routing these tests assert on exist only for uncurried funptr functions, which the higher
+    /// module. The build works at the `max` optimization level: the borrow versions and the routing
+    /// these tests assert on exist only for uncurried funptr functions, which the higher
     /// optimization levels produce — at `none` the same code stays as closures with no funptr
-    /// version to borrow. Pinning makes the dumped structure the same regardless of the ambient
-    /// `FIX_MAX_OPT_LEVEL` the test suite runs under.
+    /// version to borrow.
     fn emit_main_rc_ir(project_dir: &Path) -> String {
-        let output = fix_command()
-            .arg("build")
+        let output = fix_command_at_opt_level("build", "max")
             .arg("--emit-rc-ir")
             .arg("Main")
-            .env("FIX_MAX_OPT_LEVEL", "max")
             .current_dir(project_dir)
             .output()
             .expect("Failed to execute fix build --emit-rc-ir");

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod integration_tests {
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
+    use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
@@ -30,11 +30,9 @@ mod integration_tests {
     // the dumped RC IR of every module. The `range.fold` driver is a specialized `Std::Iterator`
     // symbol, so the whole-program dump is needed to see it. Also leaves a runnable executable.
     fn emit_all_rc_ir(project_dir: &Path) -> String {
-        let output = fix_command()
-            .arg("build")
+        let output = fix_command_at_opt_level("build", "max")
             .arg("--emit-rc-ir")
             .arg("all")
-            .env("FIX_MAX_OPT_LEVEL", "max")
             .current_dir(project_dir)
             .output()
             .expect("Failed to execute fix build --emit-rc-ir");

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -2,6 +2,7 @@ use crate::{
     commands::run::run,
     configuration::Configuration,
     constants::COMPILER_TEST_WORKING_PATH,
+    env_vars::MAX_OPT_LEVEL_VAR,
     error::{panic_if_err, panic_with_msg, Errors},
     misc::save_temporary_source,
     parse::parser::check_grammar_accepts,
@@ -81,6 +82,22 @@ pub fn fix_command() -> Command {
     build_fix();
     let mut command = Command::new(fix_binary_path());
     command.env("PATH", path_env_with_fix_binary_dir());
+    command
+}
+
+/// A `fix <subcommand>` command that works at `opt_level`, whatever level the suite is being run
+/// at. Use this for a test whose subject is a level: an optimization the compiler performs there, a
+/// program shape only that level produces, or a build that has to be reachable at it.
+///
+/// The suite runs under the level `MAX_OPT_LEVEL_VAR` names, and that level caps the one `-O` asks
+/// for, so the variable is pinned to `opt_level` beside the argument. `-O` belongs to the
+/// subcommand, which is why the subcommand is given here rather than by the caller.
+pub fn fix_command_at_opt_level(subcommand: &str, opt_level: &str) -> Command {
+    let mut command = fix_command();
+    command
+        .arg(subcommand)
+        .args(["-O", opt_level])
+        .env(MAX_OPT_LEVEL_VAR, opt_level);
     command
 }
 


### PR DESCRIPTION
Refs #152
Refs #284

PR #325 のレビューが、変更のすぐ隣で見つけた清掃をまとめたもの。振る舞いは変わらない。基点は #325 の枝なので、読む順序は「#325 を読んでから、この差分」になる。

## 何を直したか

**ローカルの名前 2 つ**（`naming` の規約: 名前から中身が予測できること）

- `src/generator.rs` の `declare_program_global`: `func` -> `acc_fn`。同じ関数の中に `acc_fn_name` と `acc_fn_ty` があり、`rc_ir/codegen.rs` の対応する箇所も `acc_fn` と呼んでいる。`func` はそれがアクセサ関数であることを隠していた。
- `src/rc_ir/codegen.rs` の `implement_rc_global`: `init_flag` の再束縛を `init_flag_ptr` へ。同じ名前で束縛し直すことで「値がポインタになった」ことが隠れていた。数行上の `global_var_ptr` と綴りが揃う。

どちらもローカル束縛なので、関数の外へは何も伝わらない。

**コメント 13 件**（`comment-style` の規約）

- `src/generator.rs`: 項目コメントが `//` だった 4 つ（`push_debug_subprogram`、`assert_no_subprogram_on_declaration`、`create_di_file`、`global_accessor_name`）を `///` に。`is_const_one` のコメントは呼び手を列挙し、「以前の版と byte-identical」という経緯を述べていたので、関数が何を答えるかだけを述べる形に書き直した。
- `src/build/build_object_files.rs`: 直下の呼び出しを言い換えるだけのインラインコメントを 4 つ削除。うち 1 つ（`// Create GenerationContext.`）は既に存在しない型を名指していた。
- `src/rc_ir/codegen.rs`: モジュールの doc から「既存の `Generator` helpers をそのまま再利用する」という経緯を落とし、「read-getters は解放しない」という否定形を肯定形に書き直した。
- `src/constants.rs`: `STRUCT_GETTER_SYMBOL` に doc コメント。#325 が足した `SYMBOL_TABLE_GETTER_SYMBOL` がこの定数を基準に定義されているので、対になる説明が要る。
- `src/tests/test_basic.rs`: #325 が移動させたテストの両隣 2 つに、何を確かめるテストかを述べる doc コメント。

**ビルドのレベルを述べる組み立て**（`code-quality` の規約: 同じ意図の 2 つ目の複製で関数にする）

6 つのテストモジュールが、それぞれ「このビルドはこのレベルで働く」を 2 つの断片で書いていた: `-O <level>` の引数と、スイートが走るレベルが `-O` の上限を決めるために要る `FIX_MAX_OPT_LEVEL` の固定である。`src/tests/test_util.rs` の `fix_command()` の隣に `fix_command_at_opt_level(subcommand, opt_level)` を置き、6 か所をそれに載せた。`-O` はサブコマンドの引数なので、サブコマンドもこの関数が受け取る。

環境変数の名前も 1 か所にした。`"FIX_MAX_OPT_LEVEL"` という文字列は `src/env_vars.rs` と 6 モジュールに散っていたので、`env_vars::MAX_OPT_LEVEL_VAR` を作り、読む側（`get_max_opt_level`）と固定する側（上のヘルパ）の両方がそれを読む。

`test_provenance` / `test_locality` / `test_simplify` は環境変数だけを固定していた（既定のレベルがその値になるので `-O` は要らなかった）。ヘルパに載せたことで `-O max` も渡るが、レベルは同じである。読み手には、呼び出し 1 行でそのテストが働くレベルが分かるようになる。

## なぜ振る舞いが変わらないか

コメントとローカル束縛の名前は、項目の名前・シグネチャ・制御フローのどれにも触れない。テストの組み立ての抽出は、6 か所が渡していた引数と環境変数をそのまま渡す（環境変数だけを固定していた 3 か所には `-O max` が加わるが、環境変数が既にその値を決めているのでレベルは同じ）。全テストは #325 の枝でも、この枝でも 1401 passed / 0 failed。

## 報告のみで直さなかったもの

レビューが挙げて、この枝の範囲（触れたファイルの、変更の近傍）を超えるもの。

- `Configuration::no_elim_frame_pointers()` は否定形の述語で、呼び出し側が `if config.no_elim_frame_pointers() { add_frame_pointer_attribute_to_all_functions() }` という二重否定になる。提案は `keeps_frame_pointers()`。項目名の変更なので著者の判断。
- `src/generator.rs` には doc コメントの無い項目が 112 ある（この枝の予算 5 件で届いたのは 5 件）。
- `src/tests/test_util.rs` の `fix_build_source_command` は `-O <level>` を渡すが `FIX_MAX_OPT_LEVEL` を固定しない。上のヘルパと同じ関心の 7 つ目だが、固定すると `FIX_MAX_OPT_LEVEL` を振ってスイートを回したときにこれらのテストが掃引に従わなくなる。掃引に従わせるか、引数どおりのレベルを保証するかは設計判断なので触っていない。
