### PR TITLE
レビュー清掃 (#318): 変更の周りの項目に doc を付ける

### DIFF
--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -197,7 +197,8 @@ impl TypeEnv {
         }
     }
 
-    // Resolve type aliases in type constructors.
+    /// Replace every type alias written in the definition of a type constructor of this environment
+    /// by the type it stands for, so that a stage reading a field or variant type meets no alias.
     pub fn resolve_type_aliases_in_tycons(&mut self) -> Result<(), Errors> {
         let mut errors = Errors::empty();
         let type_env = self.clone();
@@ -211,13 +212,22 @@ impl TypeEnv {
     }
 }
 
-// Symbols are Fix values that are instantiated:
-// their types are fixed to concrete types, and given unique names.
+/// A Fix value at one concrete type, under a name of its own. A generic definition becomes one
+/// symbol per type it is used at, and the program that reaches code generation is made of these.
 #[derive(Clone)]
 pub struct Symbol {
+    /// The name this symbol is known by, unique across the program. Instantiation builds it from
+    /// `generic_name` and a hash of `ty` (`determine_symbol_name`); a pass that mints a symbol
+    /// appends a segment of its own.
     pub name: FullName,
+    /// The name of the global value this symbol is an instantiation of, shared by the instantiations
+    /// of it at every type.
     pub generic_name: FullName,
+    /// The type this symbol stands at. It holds no type variable: a value whose type is still open
+    /// after instantiation is an error.
     pub ty: Arc<TypeNode>,
+    /// The expression computing the value, specialized to `ty`. `None` between the moment the
+    /// instantiation is required and the moment `instantiate_symbol` fills it in.
     pub expr: Option<Arc<ExprNode>>,
     /// Whether the back end is asked to inline every call of this global. Written by
     /// `inline::request_inline_into_callers`, which runs once the optimization passes have left the
@@ -1819,7 +1829,9 @@ impl Program {
         Ok(ret)
     }
 
-    // Require instantiating a generic value such to a specified type.
+    /// Ask that the generic value `name` be instantiated at type `ty`, and return the name that
+    /// instantiation is known by. Asking twice for the same name and type yields that one name and
+    /// queues one symbol, whose expression is filled in when the queue is drained.
     pub fn require_instantiation(
         &mut self,
         name: &FullName,
@@ -1843,8 +1855,9 @@ impl Program {
         Ok(inst_name)
     }
 
-    // Determine the name of instantiated generic value so that it has a specified type.
-    // tc: a typechecker (substituion) under which ty should be interpreted.
+    /// The name the instantiation of the generic value `name` at type `ty` is known by: `name` with
+    /// a hash of `ty` appended. Two requests for the same type therefore name one symbol, and
+    /// requests for different types name different ones.
     fn determine_symbol_name(
         &self,
         name: &FullName,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -662,6 +662,8 @@ impl Configuration {
         self.fix_opt_level
     }
 
+    /// The effort the LLVM pass pipeline is asked for. Every Fix level above `None` asks for the
+    /// same default effort, so the levels above it differ in the compiler's own passes alone.
     pub fn get_llvm_opt_level(&self) -> OptimizationLevel {
         match self.fix_opt_level {
             FixOptimizationLevel::None => OptimizationLevel::None,
@@ -682,10 +684,17 @@ impl Configuration {
         false
     }
 
+    /// Split the program's symbols into several compilation units, each hashed and cached on its
+    /// own, so that a rebuild regenerates only the units whose inputs changed. A function of a unit
+    /// is externally visible, since another unit calls it. Runs at `Basic` and below; above that the
+    /// program is one unit, which is what lets a pass see all of it at once.
     pub fn enable_separated_compilation(&self) -> bool {
         !self.force_all_optimizations() && self.fix_opt_level <= FixOptimizationLevel::Basic
     }
 
+    /// Give each global function a version taking one, two, ... arguments at once, and send every
+    /// call to the version matching the number of arguments it supplies, so that a saturated call
+    /// passes them directly instead of building a closure per argument. Runs at `Basic` and above.
     pub fn enable_uncurry_optimization(&self) -> bool {
         self.force_all_optimizations() || self.fix_opt_level >= FixOptimizationLevel::Basic
     }
@@ -792,8 +801,8 @@ impl Configuration {
         }
     }
 
-    // Check if frame pointers should not be eliminated.
-    // This is necessary on macOS when backtrace is enabled, as backtrace() relies on frame pointers.
+    /// Whether the generated code must keep its frame pointers. macOS's `backtrace()` walks them, so
+    /// a build that prints a backtrace there keeps them.
     pub fn no_elim_frame_pointers(&self) -> bool {
         self.backtrace && env::consts::OS == "macos"
     }

--- a/src/optimization/defunctionalize_fix.rs
+++ b/src/optimization/defunctionalize_fix.rs
@@ -46,6 +46,7 @@ use crate::{
     tool::stopwatch::StopWatch,
 };
 use std::cell::RefCell;
+use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -103,7 +104,7 @@ fn run_one(
     // trivial variable-aliasing lets makes every self-reference name the parameter directly, so the
     // single substitution below reaches them all.
     let arity_map = let_elimination::create_global_lambda_to_arity_map(prg);
-    let symbols = std::mem::take(&mut prg.symbols);
+    let symbols = mem::take(&mut prg.symbols);
     let mut global_names: Set<FullName> = symbols.keys().cloned().collect();
     let mut new_symbols: Map<FullName, Symbol> = Map::default();
     let mut new_tycons: Map<TyCon, TyConInfo> = Map::default();

--- a/src/optimization/defunctionalize_fix.rs
+++ b/src/optimization/defunctionalize_fix.rs
@@ -175,6 +175,8 @@ struct LiftedFix {
 }
 
 impl LiftedFix {
+    /// The global symbol the lifted function becomes. It is its own generic origin, nothing having
+    /// instantiated it, and it stands at the type its expression carries.
     fn into_symbol(self) -> Symbol {
         Symbol {
             name: self.func_name.clone(),

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -21,7 +21,7 @@ use std::{mem, sync::Arc};
 /// What the count weighs is what a copy of the body costs at a call site against the call it saves.
 /// It measures the expression the optimizer holds; the instructions the body finally generates
 /// exceed it, as reference counting and the bounds checks still to be inserted feed them too.
-pub const INLINE_COST_THRESHOLD: i32 = 30;
+const INLINE_COST_THRESHOLD: i32 = 30;
 
 /// How many times `run` rewrites the program before it stops asking for more.
 ///
@@ -44,11 +44,6 @@ const MAX_ROUNDS: usize = 10;
 /// occurs; a lambda small enough (`INLINE_COST_THRESHOLD`) and one wrapping an inline-LLVM operation
 /// go into the calls of it. A body that calls itself stays where it is.
 pub fn run(prg: &mut Program) {
-    // Calculate free variables of all symbols.
-    for (_name, sym) in &mut prg.symbols {
-        sym.expr = Some(sym.expr.as_ref().unwrap().clone());
-    }
-
     let mut skip_symbols = Set::default();
     for _ in 0..MAX_ROUNDS {
         if !run_one(prg, &mut skip_symbols) {
@@ -96,7 +91,7 @@ pub fn request_inline_into_callers(prg: &mut Program) {
 /// * `stable_symbols` — the symbols with nothing left to substitute into them, carried from round to
 ///   round: a symbol listed here is passed through untouched, and a symbol this round leaves
 ///   unchanged joins it.
-pub fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
+fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
     let mut changed = false;
 
     let costs = calculate_inline_costs(prg);
@@ -154,7 +149,7 @@ pub fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
     changed
 }
 
-pub fn calculate_inline_costs(prg: &Program) -> InlineCosts {
+fn calculate_inline_costs(prg: &Program) -> InlineCosts {
     let mut costs = InlineCosts::new();
     for (name, sym) in &prg.symbols {
         let mut cost_calculator = InlineCostCalculator::new(name.clone());
@@ -186,8 +181,9 @@ pub fn calculate_inline_costs(prg: &Program) -> InlineCosts {
     costs
 }
 
-// A struct to store information about the cost of inlining a symbol.
-pub struct InlineCost {
+/// What one symbol costs to inline, and the shapes of its expression that decide where it may
+/// be inlined at all.
+struct InlineCost {
     // The number of times the symbol is called.
     call_count: usize,
     // The complexity of the expression.
@@ -225,7 +221,11 @@ impl InlineCost {
         }
     }
 
-    // Returns true if the symbol can be inlined even at a non-call site.
+    /// Whether the symbol's expression may be substituted wherever the symbol is named, and not
+    /// only where it is called.
+    ///
+    /// What qualifies is what costs nothing to hold in several places: a literal, a body that is
+    /// one inline-LLVM operation, and a name that stands for another name.
     fn inline_at_non_call_site(&self) -> bool {
         if self.is_std_fix {
             return false;
@@ -250,8 +250,12 @@ impl InlineCost {
         // * Boxed types and Strings also increase memory allocation when inlined, such as string literals.
     }
 
-    // Returns true if the symbol can be inlined at a call site.
-    pub fn inline_at_call_site(&self) -> bool {
+    /// Whether the symbol's expression may be substituted where the symbol is called.
+    ///
+    /// A body that calls itself is left alone, since substituting it leaves the call it makes to
+    /// itself; so is `Std::fix`, whose defunctionalization matches the shape it is written in. What
+    /// is left is judged by size, against `INLINE_COST_THRESHOLD`.
+    fn inline_at_call_site(&self) -> bool {
         if self.is_std_fix {
             return false;
         }
@@ -269,9 +273,9 @@ impl InlineCost {
 }
 
 /// What each symbol of a program costs to inline, and how often the program names it.
-pub struct InlineCosts {
+struct InlineCosts {
     /// One entry per symbol of the program walked, and one per global name those symbols use.
-    pub costs: Map<FullName, InlineCost>,
+    costs: Map<FullName, InlineCost>,
 }
 
 impl InlineCosts {
@@ -298,7 +302,7 @@ impl InlineCosts {
     }
 
     /// How many times the program names the symbol, counted over every expression the walk covered.
-    pub fn get_call_count(&self, name: &FullName) -> usize {
+    fn get_call_count(&self, name: &FullName) -> usize {
         self.get(name).call_count
     }
 

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -36,6 +36,13 @@ pub const INLINE_COST_THRESHOLD: i32 = 30;
 /// left here is a term twice as large to finish with.
 const MAX_ROUNDS: usize = 10;
 
+/// Substitute the definitions of globals into the places that name them, round after round until the
+/// program stops changing or `MAX_ROUNDS` rounds have passed. A global that nothing names, and that
+/// is neither the entry point nor exported, is dropped along the way.
+///
+/// A primitive literal, and a global that is one name standing for another, go wherever the name
+/// occurs; a lambda small enough (`INLINE_COST_THRESHOLD`) and one wrapping an inline-LLVM operation
+/// go into the calls of it. A body that calls itself stays where it is.
 pub fn run(prg: &mut Program) {
     // Calculate free variables of all symbols.
     for (_name, sym) in &mut prg.symbols {
@@ -82,7 +89,13 @@ pub fn request_inline_into_callers(prg: &mut Program) {
     }
 }
 
-// Run inlining optimization once.
+/// One round of `run`: substitute into each symbol once and discard the symbols nothing names.
+/// Returns whether the program changed.
+///
+/// # Arguments
+/// * `stable_symbols` — the symbols with nothing left to substitute into them, carried from round to
+///   round: a symbol listed here is passed through untouched, and a symbol this round leaves
+///   unchanged joins it.
 pub fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
     let mut changed = false;
 
@@ -255,8 +268,9 @@ impl InlineCost {
     }
 }
 
-// The map from each symbol to the cost of inlining it.
+/// What each symbol of a program costs to inline, and how often the program names it.
 pub struct InlineCosts {
+    /// One entry per symbol of the program walked, and one per global name those symbols use.
     pub costs: Map<FullName, InlineCost>,
 }
 
@@ -267,6 +281,8 @@ impl InlineCosts {
         }
     }
 
+    /// Give `name` an entry of its own if it has none yet, with nothing counted and every flag
+    /// false, for the walks to fill in as they meet the name.
     fn insert_cost_if_absent(&mut self, name: &FullName) {
         if !self.costs.contains_key(name) {
             self.costs.insert(name.clone(), InlineCost::new());
@@ -291,7 +307,9 @@ impl InlineCosts {
         self.get(name).complexity
     }
 
-    // After `InlineCostCalculator` has been executed, add its result to `InlineCosts`.
+    /// Take in what the walk of one symbol found: every global name that symbol uses has its call
+    /// count raised, and the symbol itself gets the size, the self-reference and the lambda shape the
+    /// walk measured.
     fn add_cost_calculation_result(&mut self, cost: InlineCostCalculator) {
         // For each global symbol called from the symbol where `InlineCostCalculator` has been executed, add the call count.
         for (sym, count) in cost.call_count {

--- a/src/rc_ir/ast.rs
+++ b/src/rc_ir/ast.rs
@@ -45,6 +45,9 @@ pub struct RcProgram {
 /// uncurried funptr versions.
 #[derive(Clone)]
 pub struct RcFunc {
+    /// The name this function is defined and called under, unique across the program: lowering mints
+    /// a fresh one for each lambda it lifts, and a pass that copies a function appends a segment of
+    /// its own.
     pub name: FuncRef,
     /// The lambda's arrow type (funptr or closure). It determines the LLVM function signature and
     /// distinguishes the funptr and closure ABIs.
@@ -55,8 +58,14 @@ pub struct RcFunc {
     /// `Some` for the closure ABI: the trailing capture-pointer parameter, from which the body
     /// projects the captured values. `None` for the funptr ABI, which has no captures.
     pub capture: Option<RcVar>,
+    /// The type of the value the body returns, which for a funptr-ABI function is the result after
+    /// all of its parameters rather than the arrow taking the rest of them.
     pub ret_ty: Arc<TypeNode>,
+    /// The body, evaluated with the parameters and the capture in scope. Its `Ret` returns the
+    /// function's value.
     pub body: RcExprNode,
+    /// The source the lambda this function came from was written at, which code generation records
+    /// as the function's debug location. `None` where no source spells the function out.
     pub source: Option<Span>,
     /// The reference-counting units this version borrows among its parameters and capture — the units
     /// it does not own, one `(parameter-name, unit-path)` each. Everything not listed is owned, so the

--- a/src/rc_ir/lower.rs
+++ b/src/rc_ir/lower.rs
@@ -211,6 +211,8 @@ impl<'a> Lowerer<'a> {
             })
     }
 
+    /// The `Ret` terminating a body with the value of `var`, placed at the source the variable came
+    /// from, so a return is shown at the value it returns.
     fn ret_node(var: RcVar) -> RcExprNode {
         let source = var.source.clone();
         RcExprNode {
@@ -221,6 +223,10 @@ impl<'a> Lowerer<'a> {
 
     // --- symbols ---
 
+    /// Lower one instantiated symbol: a funptr symbol becomes a top-level function under the
+    /// symbol's own name, and a symbol of any other type becomes the initializer of a global value.
+    /// The counter naming the lambdas lifted out restarts here, so they are numbered within the
+    /// symbol they were written in.
     fn lower_symbol(&mut self, sym: &Symbol) -> LoweredSymbol {
         self.current_symbol = Some(sym.name.clone());
         self.closure_counter = 0;
@@ -339,6 +345,9 @@ impl<'a> Lowerer<'a> {
 
     // --- expressions (A-normalization: lower to an atom, appending bindings) ---
 
+    /// Lower `expr` to the single variable holding its value, appending to `bindings` everything
+    /// that must be evaluated to reach it. An expression that is already an atom — a local variable,
+    /// a global name — becomes that atom and appends nothing.
     fn lower_to_var(&mut self, expr: &ExprNode, bindings: &mut Vec<PendingBinding>) -> RcVar {
         // A deeply nested expression recurses deeply here (as it does in RC insertion and code
         // generation); grow the stack on demand so a large program does not overflow it.
@@ -470,6 +479,9 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower a lambda written in place to a closure value: its body becomes a top-level function
+    /// under a fresh name, and the binding appended builds the closure from that function and the
+    /// values it captures, in the order the closure stores them.
     fn lower_lam(
         &mut self,
         expr: &ExprNode,

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -211,6 +211,7 @@ pub fn emitted_llvm_ir(dir: &Path, which: EmittedIr) -> String {
         .collect::<Vec<_>>()
         .join("\n")
 }
+
 /// The functions `ir` defines, each paired with whether it carries the function attribute
 /// `attribute`.
 ///


### PR DESCRIPTION
Refs #221

PR #318 のレビューが、変更した各ファイルの**差分の外**に見つけた整理。項目に doc を付け、修飾されたパスを import にし、書き戻すだけのループを消し、このモジュールの中だけで使う項目の可視性を絞る。PR #318 の差分を読みやすく保つために分けてある。

# 1. 項目に doc コメントを付ける (`comment-style`)

プロジェクトの規約は「`pub` かどうかによらず、すべての Rust の項目が `///` を持つ。名前と型が明らかにしていることは書かず、それらが言い残している意味を書く」。差分が触れたファイルのうち、変更箇所の近くにある未文書の項目に付けた。1 ファイルにつき 5 件までという上限があるので、近い順に取っている。

**`src/optimization/inline.rs` (5 件、上限まで)** — `run` / `run_one` / `InlineCosts` とその `costs` / `insert_cost_if_absent` / `add_cost_calculation_result`。`// Run inlining optimization once.` のような名前の言い直しと、内部ヘルパの実行順を語る文 ("After `InlineCostCalculator` has been executed…") を、入出力の説明に書き換えた。

**`src/ast/program.rs` (4 件)** — `Symbol` 本体 (`//` ブロックだった) と全フィールド、`require_instantiation`、`determine_symbol_name`、`resolve_type_aliases_in_tycons`。`determine_symbol_name` の旧コメントは、**既に存在しない引数 `tc`** を説明していた。

**`src/configuration.rs` (4 件)** — `get_llvm_opt_level` / `enable_separated_compilation` / `enable_uncurry_optimization` / `no_elim_frame_pointers`。最後のものは "should not be eliminated" という二重否定を肯定形に直した。

**`src/rc_ir/ast.rs` (2 件)** — `RcFunc` の `name` / `ret_ty` / `body` / `source`。

**`src/rc_ir/lower.rs` (4 件)** — `ret_node` / `lower_symbol` / `lower_to_var` / `lower_lam`。

**`src/optimization/defunctionalize_fix.rs` (1 件)** — `LiftedFix::into_symbol`。

**`src/tests/test_util.rs` (1 件)** — 追加された doc コメントの前に空行を入れた (直前の `}` に密着していた)。

# 2. 修飾されたパスを import にする (`shorten-qualifiers`)

**`src/optimization/defunctionalize_fix.rs`** — `std::mem::take(&mut prg.symbols)` を `use std::mem;` + `mem::take(...)` にした。`inline.rs` / `uncurry.rs` / `closure_specialization.rs` / `rc_ir/lower.rs` がすべて取っている書き方に揃う。

この 15 ファイルを全走査して、直すべきものは他に無かった。ワイルドカード import は 3 件あるが、いずれも `#[cfg(test)] mod tests` 直下の `use super::*;` で、プロジェクト全体で一様なイディオムなので据え置いた。`optimization.rs` のパス表 (`inline::run`、`uncurry::run` など) は、`run` が総称名でモジュール名が「どのパスか」を担っているので、修飾を残すのが正しい。

# 3. 書き戻すだけのループを消す

`inline::run` の先頭にある、`// Calculate free variables of all symbols.` と書かれたループを消した。

```rust
for (_name, sym) in &mut prg.symbols {
    sym.expr = Some(sym.expr.as_ref().unwrap().clone());
}
```

`ExprNode` は `Clone` を実装していないので、この `.clone()` の受け手は `&Arc<ExprNode>` であり、**`Arc` の複製 — 同じポインタ**である。それを同じフィールドに書き戻している。自由変数は `ExprNode::with_free_vars` が `Mutex<Option<Set<FullName>>>` に初回参照時に計算してキャッシュするので、事前に計算しておく必要も無い。コメントが述べていることは、このループが行っていることではない。

削除の後、コーパスの `fannkuch` / `sort_stable` / `cp_lib_lsegtree` が同じ命令数を出すことを確かめてある。

# 4. `inline.rs` の可視性を絞る

このモジュールの外から使われているのは `run` と `request_inline_into_callers` の 2 つだけで、他はすべて内部の道具である。`INLINE_COST_THRESHOLD` / `run_one` / `calculate_inline_costs` / `InlineCost` / `InlineCosts` (とその `costs` フィールド) / `get_call_count` / `inline_at_call_site` を private にした。

`InlineCosts::costs` が `pub` でなくなることで、記録の集合を外から直に読む経路も閉じる。

# 5. 2 つの述語が何を決めているかを書く

`inline_at_non_call_site` と `inline_at_call_site` に付いていた `// Returns true if the symbol can be inlined at a call site.` は名前の言い直しだった。何を決めているかに書き換えた。

> 呼び出された場所にその式を置き換えてよいか。自分を呼ぶ本体は、置き換えても自分への呼び出しが残るので対象外。`Std::fix` も、その defunctionalize が書かれた形に依存するので対象外。残ったものは `INLINE_COST_THRESHOLD` に対する大きさで判断する。

# 6. 振る舞い

コメントの追加・書き換え、import 1 つ、書き戻すだけのループの削除、可視性の縮小だけである。テストスイートは **1389 + 139 passed / 0 failed**。

---

# 付録: 作者の判断に上げた項目 (この PR では直していない)

**`uncurry.rs` の `use std::{mem, sync::Arc, usize};` の `usize`** は効いていない (`usize::MAX` はプリミティブ型の関連定数として解決される)。削除は安全だが、このアスペクトが列挙する 3 つの整理には入らないので判断に上げる。

**`src/tests/test_util.rs` の `use crate::commands::run::run;`** — 呼び出し側 (`run(config, false)`) だけを読んでも何が走るのか分からない。ただし `test_signal.rs` など兄弟ファイルが同じ書き方で統一されているので、変えるならプロジェクト全体の慣行としての判断になる。

**上限を超えて残っている未文書の項目** (ファイル全体が `//` 様式のものを含む): `closure_specialization.rs` 103、`program.rs` 69、`inline.rs` 58 (うち 48 は `ExprVisitor` の自明な override)、`defunctionalize_fix.rs` 33 (同様に約 24 が override)、`configuration.rs` 30、`rc_ir/lower.rs` 17、`rc_ir/validate.rs` 9 (すべて `#[test]`)。広げるかどうかは作者の判断。
