### PR TITLE
レビュー清掃 (#344): パターンの重複除去、未使用項目の削除、doc コメント

### DIFF
--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -185,24 +185,9 @@ impl PatternNode {
                         );
                         continue;
                     };
-                    let unify_res = UnifOrOtherErr::extract_others(
-                        typechecker.unify(&pat.info.type_.as_ref().unwrap(), field_ty),
-                    )?;
-                    if unify_res.is_err() && !typechecker.error_tolerant {
-                        return Err(Errors::from_msg_srcs(
-                            format!(
-                                "Inappropriate pattern `{}` for a value of field `{}` of struct `{}`.",
-                                pat.pattern.to_string(),
-                                field_name,
-                                tc.to_string(),
-                            ),
-                            &[&pat.info.source],
-                        ));
-                    }
-                    // In error_tolerant mode the unify mismatch is
-                    // swallowed; the sub-pattern keeps its inferred
-                    // type so the body that references its bindings
-                    // can still be elaborated.
+                    pat.unify_with_expected_type(typechecker, field_ty, || {
+                        format!("field `{}` of struct `{}`", field_name, tc.to_string())
+                    })?;
                 }
                 Ok((
                     self.set_type(ty).set_struct_field_to_pat(field_to_pat),
@@ -242,30 +227,48 @@ impl PatternNode {
 
                 // Unify the type of the subpattern with the type of the variant.
                 if let Some((tc, variant_ty)) = union_tc_and_variant_ty {
-                    let unify_res = UnifOrOtherErr::extract_others(
-                        typechecker.unify(&subpat.info.type_.as_ref().unwrap(), &variant_ty),
-                    )?;
-                    if unify_res.is_err() && !typechecker.error_tolerant {
-                        return Err(Errors::from_msg_srcs(
-                            format!(
-                                "Inappropriate pattern `{}` for a value of variant `{}` of union `{}`.",
-                                subpat.pattern.to_string(),
-                                variant_name.to_string(),
-                                tc.to_string(),
-                            ),
-                            &[&subpat.info.source],
-                        ));
-                    }
-                    // In error_tolerant mode the unify mismatch is
-                    // swallowed; the sub-pattern keeps its inferred type
-                    // so the body that references its bindings can still
-                    // be elaborated.
+                    subpat.unify_with_expected_type(typechecker, &variant_ty, || {
+                        format!(
+                            "variant `{}` of union `{}`",
+                            variant_name.to_string(),
+                            tc.to_string()
+                        )
+                    })?;
                 }
 
                 // Return the typed pattern.
                 Ok((self.set_type(ty).set_union_pat(subpat), var_ty))
             }
         }
+    }
+
+    /// Unify the type inferred for this sub-pattern with `expected_ty`, the type of the value it is
+    /// matched against.
+    ///
+    /// On a mismatch, strict mode reports the sub-pattern as inappropriate for the place it sits in,
+    /// which `position` names as ``field `x` of struct `S` `` or ``variant `v` of union `U` ``. In
+    /// `error_tolerant` mode the mismatch is swallowed and the sub-pattern keeps its inferred type,
+    /// so the body that references its bindings can still be elaborated.
+    fn unify_with_expected_type(
+        &self,
+        typechecker: &mut TypeCheckContext,
+        expected_ty: &Arc<TypeNode>,
+        position: impl FnOnce() -> String,
+    ) -> Result<(), Errors> {
+        let unify_res = UnifOrOtherErr::extract_others(
+            typechecker.unify(self.info.type_.as_ref().unwrap(), expected_ty),
+        )?;
+        if unify_res.is_err() && !typechecker.error_tolerant {
+            return Err(Errors::from_msg_srcs(
+                format!(
+                    "Inappropriate pattern `{}` for a value of {}.",
+                    self.pattern.to_string(),
+                    position()
+                ),
+                &[&self.info.source],
+            ));
+        }
+        Ok(())
     }
 
     // For every `Pattern::Var` in this pattern tree, return its name and

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -793,7 +793,11 @@ impl Pattern {
                     }
                     uncovered_variants.remove(&variant.name);
                 }
-                _ => {
+                // A variable binds the matched value whatever it is, and a struct pattern
+                // destructures every value of its type, so either covers the variants the arms
+                // above leave. Naming both forms is what makes the compiler ask this question
+                // again of a pattern that can fail to match.
+                Pattern::Var(_, _) | Pattern::Struct(_, _) => {
                     found_otherwise = true;
                 }
             }

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -273,11 +273,10 @@ impl PatternNode {
             }
             Pattern::Union(variant, variant_src, subpat) => {
                 if let Some(variant_name_span) = variant_src {
-                    if variant_name_span.includes_pos_lsp(pos)
-                        && !variant.namespace.names.is_empty()
-                    {
-                        let tc = TyCon::new(variant.namespace.clone().to_fullname());
-                        return Some(EndNode::Variant(tc, variant.name.clone()));
+                    if variant_name_span.includes_pos_lsp(pos) {
+                        if let Some(tc) = Pattern::variant_union_tycon(variant) {
+                            return Some(EndNode::Variant(tc, variant.name.clone()));
+                        }
                     }
                 }
                 let node = subpat.find_node_at_pos(pos);
@@ -729,6 +728,23 @@ impl Pattern {
         }
     }
 
+    /// The union a variant name belongs to, which is the type constructor its namespace names.
+    ///
+    /// `validate_variant_name` gives the variant name of a union pattern that namespace, and every
+    /// reader of the name gets the union back through here. Until validation has accepted the
+    /// name, it carries whatever namespace the source wrote before it, which is `None` here when
+    /// the source wrote none at all.
+    ///
+    /// # Examples
+    /// The variant name `Std::Option::some` belongs to `Std::Option`, and the bare `some` to no
+    /// union.
+    pub fn variant_union_tycon(variant_name: &FullName) -> Option<TyCon> {
+        if variant_name.namespace.is_local() {
+            return None;
+        }
+        Some(TyCon::new(variant_name.namespace.clone().to_fullname()))
+    }
+
     /// From a variant name, gets the variant index and the type constructor of the union.
     ///
     /// The name's namespace is the union's, as `validate_variant_name` leaves it, and this reads
@@ -737,10 +753,7 @@ impl Pattern {
         variant_name: &FullName,
         type_env: &TypeEnv,
     ) -> Option<(usize, TyCon)> {
-        if variant_name.namespace.is_local() {
-            return None;
-        }
-        let tc: TyCon = TyCon::new(variant_name.namespace.clone().to_fullname());
+        let tc = Pattern::variant_union_tycon(variant_name)?;
         let ti = type_env.tycons().get(&tc)?;
         let variant_idx = ti
             .fields

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -23,92 +23,6 @@ pub struct PatternNode {
 }
 
 impl PatternNode {
-    /// Assign `type_` to this pattern and, to each sub-pattern, the type of the field or variant
-    /// payload it matches.
-    ///
-    /// All types must have their type aliases resolved and associated types expanded.
-    ///
-    /// A type annotation the user wrote is overwritten: given the pattern `v : A` and the type `B`,
-    /// `v` is typed `B` even where `A != B`. This must therefore not be used for type checking; it
-    /// runs once type checking has succeeded.
-    ///
-    /// # Returns
-    /// `None` where the pattern and `type_` disagree — the head of a struct or union pattern names
-    /// another type constructor than `type_`'s, or names a field or variant that type does not
-    /// declare.
-    #[allow(dead_code)]
-    pub fn get_typed_matching(
-        &self,
-        type_: &Arc<TypeNode>,
-        type_env: &TypeEnv,
-    ) -> Option<Arc<PatternNode>> {
-        match &self.pattern {
-            Pattern::Var(_v, _ty) => {
-                // IGNORES user-provided type annotation!
-                let pat = self.set_type(type_.clone());
-                Some(pat)
-            }
-            Pattern::Struct(tc, field_to_pat) => {
-                let type_tc = type_.toplevel_tycon();
-                if type_tc.is_none() {
-                    return None;
-                }
-                let type_tc = type_tc.unwrap();
-                if type_tc.as_ref() != tc.as_ref() {
-                    return None;
-                }
-
-                let type_ti = type_env.tycons().get(&type_tc)?;
-                let mut field_name_to_idx = Map::default();
-                for (i, field) in type_ti.fields.iter().enumerate() {
-                    field_name_to_idx.insert(field.name.clone(), i);
-                }
-
-                // Recursively match each field pattern with its expected type
-                let field_types = type_.field_types(type_env);
-                let mut field_to_pat = field_to_pat.clone();
-                for (field_name, _, pat) in field_to_pat.iter_mut() {
-                    let field_idx = *field_name_to_idx.get(field_name)?;
-                    let field_ty = &field_types[field_idx];
-                    let matched_pat = pat.get_typed_matching(field_ty, type_env)?;
-                    *pat = matched_pat;
-                }
-
-                Some(
-                    self.set_type(type_.clone())
-                        .set_struct_field_to_pat(field_to_pat),
-                )
-            }
-            Pattern::Union(variant_name, _, subpat) => {
-                let tc = TyCon::new(variant_name.namespace.clone().to_fullname());
-                let variant_name = &variant_name.name;
-
-                let type_tc = type_.toplevel_tycon();
-                if type_tc.is_none() {
-                    return None;
-                }
-                let type_tc = type_tc.unwrap();
-                if type_tc.as_ref() != &tc {
-                    return None;
-                }
-
-                let type_ti = type_env.tycons().get(&type_tc)?;
-                let mut variant_name_to_idx = Map::default();
-                for (i, field) in type_ti.fields.iter().enumerate() {
-                    variant_name_to_idx.insert(field.name.clone(), i);
-                }
-
-                // Recursively match each field pattern with its expected type
-                let variant_types = type_.field_types(type_env);
-                let variant_idx = *variant_name_to_idx.get(variant_name)?;
-                let variant_ty = &variant_types[variant_idx];
-                let subpat = subpat.get_typed_matching(variant_ty, type_env)?;
-
-                Some(self.set_type(type_.clone()).set_union_pat(subpat))
-            }
-        }
-    }
-
     /// Assign a type to the pattern and to each of its sub-patterns, taking a
     /// fresh type variable wherever the source leaves the type open.
     ///
@@ -703,37 +617,9 @@ impl PatternNode {
         Arc::new(node)
     }
 
-    /// Render this pattern as source text. With `with_type`, every node of the tree is followed by
-    /// the type assigned to it in angle brackets, `na` where no type has been assigned yet.
-    ///
-    /// # Examples
-    /// A variable pattern `x` typed `I64` renders as `x`, and as `x<I64>` with `with_type`.
-    fn to_string_internal(&self, with_type: bool) -> String {
-        let pat_str = self.pattern.to_string_internal(with_type);
-        if with_type {
-            format!(
-                "{}<{}>",
-                pat_str,
-                self.info
-                    .type_
-                    .as_ref()
-                    .map_or("na".to_string(), |t| t.to_string())
-            )
-        } else {
-            pat_str
-        }
-    }
-
     /// This pattern as it is written in the source.
     pub fn to_string(&self) -> String {
-        self.to_string_internal(false)
-    }
-
-    /// This pattern as it is written in the source, each node followed by the type assigned to it,
-    /// for inspecting the result of type assignment.
-    #[allow(dead_code)]
-    pub fn to_string_with_type(&self) -> String {
-        self.to_string_internal(true)
+        self.pattern.to_string()
     }
 }
 
@@ -763,12 +649,6 @@ pub enum Pattern {
 }
 
 impl Pattern {
-    /// A pattern binding the matched value to `var`, with no type written for it.
-    #[allow(dead_code)]
-    pub fn var_pattern(var: Arc<Var>) -> Arc<Pattern> {
-        Arc::new(Pattern::Var(var, None))
-    }
-
     /// Whether one name is bound twice in this pattern, which makes the pattern invalid.
     ///
     /// # Examples
@@ -808,15 +688,9 @@ impl Pattern {
     }
 
     /// This pattern as it is written in the source, its variant and field names carrying the
-    /// namespaces they have been resolved to.
+    /// namespaces they have been resolved to. A tuple type at the head prints as `(a, b)`, and any
+    /// other struct as `S {f: p}`.
     pub fn to_string(&self) -> String {
-        self.to_string_internal(false)
-    }
-
-    /// Render this pattern as source text, a tuple type at the head printing as `(a, b)` and any
-    /// other struct as `S {f: p}`. With `with_type`, each sub-pattern is followed by the type
-    /// assigned to it.
-    fn to_string_internal(&self, with_type: bool) -> String {
         let mut ret = "".to_string();
         match self {
             Pattern::Var(v, t) => {
@@ -834,7 +708,7 @@ impl Pattern {
                 if let Some(n) = get_tuple_n(&tc.name) {
                     let pats = fields
                         .iter()
-                        .map(|(_, _, pat)| pat.to_string_internal(with_type))
+                        .map(|(_, _, pat)| pat.to_string())
                         .collect::<Vec<_>>();
                     if n == 1 {
                         format!("({},)", pats[0])
@@ -844,19 +718,13 @@ impl Pattern {
                 } else {
                     let pats = fields
                         .iter()
-                        .map(|(name, _, pat)| {
-                            format!("{}: {}", name, pat.to_string_internal(with_type))
-                        })
+                        .map(|(name, _, pat)| format!("{}: {}", name, pat.to_string()))
                         .collect::<Vec<_>>();
                     format!("{} {{{}}}", tc.to_string(), pats.join(", "))
                 }
             }
             Pattern::Union(variant, _, pat) => {
-                format!(
-                    "{}({})",
-                    variant.to_string(),
-                    pat.to_string_internal(with_type)
-                )
+                format!("{}({})", variant.to_string(), pat.to_string())
             }
         }
     }

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -169,10 +169,11 @@ impl PatternNode {
                     // type mismatch, …) substitutes a fresh-tyvar
                     // typed sub-pattern with no bindings, so the
                     // sibling fields are still walked.
-                    let typed = pat.get_typed(typechecker);
-                    let (typed_pat, var_ty) = typechecker.tolerate_pattern_typed(typed, pat)?;
+                    let typed_res = pat.get_typed(typechecker);
+                    let (typed_pat, sub_var_to_ty) =
+                        typechecker.tolerate_pattern_typed(typed_res, pat)?;
                     *pat = typed_pat;
-                    var_to_ty.extend(var_ty);
+                    var_to_ty.extend(sub_var_to_ty);
                     // No field type to unify against: the head names no struct, or the
                     // struct has no such field. `validate_pattern` rejects both in strict
                     // mode and tolerates them in `error_tolerant` mode.
@@ -222,8 +223,8 @@ impl PatternNode {
                 // fresh-tyvar typed sub-pattern with no bindings — the
                 // surrounding union pattern still gets its type
                 // assigned, so the match arm can proceed.
-                let typed = subpat.get_typed(typechecker);
-                let (subpat, var_ty) = typechecker.tolerate_pattern_typed(typed, subpat)?;
+                let typed_res = subpat.get_typed(typechecker);
+                let (subpat, var_to_ty) = typechecker.tolerate_pattern_typed(typed_res, subpat)?;
 
                 // Unify the type of the subpattern with the type of the variant.
                 if let Some((tc, variant_ty)) = union_tc_and_variant_ty {
@@ -237,7 +238,7 @@ impl PatternNode {
                 }
 
                 // Return the typed pattern.
-                Ok((self.set_type(ty).set_union_pat(subpat), var_ty))
+                Ok((self.set_type(ty).set_union_pat(subpat), var_to_ty))
             }
         }
     }
@@ -246,14 +247,14 @@ impl PatternNode {
     /// matched against.
     ///
     /// On a mismatch, strict mode reports the sub-pattern as inappropriate for the place it sits in,
-    /// which `position` names as ``field `x` of struct `S` `` or ``variant `v` of union `U` ``. In
+    /// which `place_desc` names as ``field `x` of struct `S` `` or ``variant `v` of union `U` ``. In
     /// `error_tolerant` mode the mismatch is swallowed and the sub-pattern keeps its inferred type,
     /// so the body that references its bindings can still be elaborated.
     fn unify_with_expected_type(
         &self,
         typechecker: &mut TypeCheckContext,
         expected_ty: &Arc<TypeNode>,
-        position: impl FnOnce() -> String,
+        place_desc: impl FnOnce() -> String,
     ) -> Result<(), Errors> {
         let unify_res = UnifOrOtherErr::extract_others(
             typechecker.unify(self.info.type_.as_ref().unwrap(), expected_ty),
@@ -263,7 +264,7 @@ impl PatternNode {
                 format!(
                     "Inappropriate pattern `{}` for a value of {}.",
                     self.pattern.to_string(),
-                    position()
+                    place_desc()
                 ),
                 &[&self.info.source],
             ));
@@ -333,9 +334,9 @@ impl PatternNode {
                             return Some(EndNode::Field(tc.as_ref().clone(), name.clone()));
                         }
                     }
-                    let res = pat.find_node_at_pos(pos);
-                    if res.is_some() {
-                        return res;
+                    let node = pat.find_node_at_pos(pos);
+                    if node.is_some() {
+                        return node;
                     }
                 }
                 Some(EndNode::Type(tc.as_ref().clone()))
@@ -614,11 +615,11 @@ impl PatternNode {
         cond_tycon: &TyCon,
         cond_ti: &TyConInfo,
     ) -> Result<Arc<PatternNode>, Errors> {
-        let name_space = cond_tycon.name.to_namespace();
+        let union_namespace = cond_tycon.name.to_namespace();
         match &self.pattern {
             Pattern::Union(variant, variant_src, subpat) => {
                 // Check the variant name.
-                let is_ns_ok = variant.namespace.is_suffix_of(&name_space);
+                let is_ns_ok = variant.namespace.is_suffix_of(&union_namespace);
                 let is_name_ok = cond_ti.fields.iter().any(|f| &f.name == &variant.name);
                 if !is_ns_ok || !is_name_ok {
                     return Err(Errors::from_msg_srcs(
@@ -633,7 +634,7 @@ impl PatternNode {
 
                 // Then, complete the namespace of the variant name.
                 let mut variant = variant.clone();
-                variant.namespace = name_space;
+                variant.namespace = union_namespace;
                 Ok(Arc::new(PatternNode {
                     pattern: Pattern::Union(variant, variant_src.clone(), subpat.clone()),
                     info: self.info.clone(),

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -12,21 +12,30 @@ use crate::parse::sourcefile::{SourcePos, Span};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+/// One node of a pattern tree: the pattern written at this position, together with what
+/// elaboration has learned about it.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PatternNode {
+    /// The form this pattern takes, holding its sub-patterns.
     pub pattern: Pattern,
+    /// The type of the value this pattern matches, and where the pattern is written.
     pub info: PatternInfo,
 }
 
 impl PatternNode {
-    // Assign types to the pattern so that it has the given type.
-    //
-    // All types must have their type aliases resolved and associated types expanded.
-    //
-    // Note:
-    // This function ignores user-provided type annotations.
-    // Specifically, if the pattern is `v : A` and the type `B` is given, then type `B` is assigned to `v` even if `A != B`.
-    // Therefore, this function must not be used for type checking. It is used in a process after type checking has succeeded.
+    /// Assign `type_` to this pattern and, to each sub-pattern, the type of the field or variant
+    /// payload it matches.
+    ///
+    /// All types must have their type aliases resolved and associated types expanded.
+    ///
+    /// A type annotation the user wrote is overwritten: given the pattern `v : A` and the type `B`,
+    /// `v` is typed `B` even where `A != B`. This must therefore not be used for type checking; it
+    /// runs once type checking has succeeded.
+    ///
+    /// # Returns
+    /// `None` where the pattern and `type_` disagree — the head of a struct or union pattern names
+    /// another type constructor than `type_`'s, or names a field or variant that type does not
+    /// declare.
     #[allow(dead_code)]
     pub fn get_typed_matching(
         &self,
@@ -272,16 +281,17 @@ impl PatternNode {
         Ok(())
     }
 
-    // For every `Pattern::Var` in this pattern tree, return its name and
-    // the `PatternInfo` of the `PatternNode` wrapping it — so callers get
-    // the binder's type and source span alongside the name. Sub-patterns
-    // of `Struct` / `Union` are walked left-to-right.
+    /// The name every `Pattern::Var` in this pattern tree binds, each paired with the
+    /// `PatternInfo` of the `PatternNode` wrapping it, which carries that binder's type and source
+    /// span. Sub-patterns of `Struct` / `Union` are walked left to right, so the binders come in
+    /// the order they are written.
     pub fn var_infos(&self) -> Vec<(FullName, PatternInfo)> {
         let mut out = vec![];
         self.collect_var_infos(&mut out);
         out
     }
 
+    /// Append this pattern tree's binders to `out`, in the order they are written.
     fn collect_var_infos(&self, out: &mut Vec<(FullName, PatternInfo)>) {
         match &self.pattern {
             Pattern::Var(v, _) => out.push((v.name.clone(), self.info.clone())),
@@ -294,7 +304,13 @@ impl PatternNode {
         }
     }
 
-    // Find the node at the specified position.
+    /// The element of this pattern the cursor at `pos` is on — the variable a `Var` binds, a field
+    /// name or the head type constructor of a `Struct`, the variant name of a `Union`, or a type
+    /// written in an annotation — for an editor to answer hover and goto-definition there.
+    ///
+    /// # Arguments
+    /// * `pos` — a position as an editor sends it, so the position just past the last character of
+    ///   a name counts as being on that name.
     pub fn find_node_at_pos(self: &Arc<PatternNode>, pos: &SourcePos) -> Option<EndNode> {
         if self.info.source.is_none() {
             return None;
@@ -359,6 +375,10 @@ impl PatternNode {
         }
     }
 
+    /// A copy of this pattern whose names are resolved against the namespaces in scope: the type
+    /// constructor at the head of a struct pattern, and the types written in a variable's
+    /// annotation. A union pattern's variant name is resolved during type checking instead, against
+    /// the union being matched (`validate_variant_name`).
     pub fn resolve_namespace(
         self: &PatternNode,
         ctx: &mut NameResolutionContext,
@@ -390,6 +410,8 @@ impl PatternNode {
         }
     }
 
+    /// A copy of this pattern with the type aliases in its type annotations expanded. The head of a
+    /// struct pattern names the struct itself, so an alias written there is reported as an error.
     pub fn resolve_type_aliases(
         self: &PatternNode,
         type_env: &TypeEnv,
@@ -421,7 +443,9 @@ impl PatternNode {
         }
     }
 
-    // Convert all global FullNames to absolute paths.
+    /// A copy of this pattern in which every global name it writes — the types of an annotation, a
+    /// struct pattern's head, a union pattern's variant — is marked absolute, so it names the same
+    /// entity read from any namespace and prints with a leading `::`.
     pub fn global_to_absolute(&self) -> Arc<PatternNode> {
         let mut node = self.clone();
         match &self.pattern {
@@ -517,10 +541,12 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// Whether this pattern matches one variant of a union.
     pub fn is_union(&self) -> bool {
         matches!(&self.pattern, Pattern::Union(_, _, _))
     }
 
+    /// Whether this pattern binds the matched value whole to a variable, matching every value.
     pub fn is_var(&self) -> bool {
         matches!(&self.pattern, Pattern::Var(_, _))
     }
@@ -537,24 +563,30 @@ impl PatternNode {
         }
     }
 
+    /// A copy of this pattern written at `src`, the span covering the whole pattern.
     pub fn set_source(self: &PatternNode, src: Span) -> Arc<PatternNode> {
         let mut node = self.clone();
         node.info.source = Some(src);
         Arc::new(node)
     }
 
+    /// A copy of this pattern carrying `src` as its auxiliary span, which covers the part of the
+    /// pattern named by `PatternInfo::aux_src`.
     pub fn set_aux_src(self: &PatternNode, src: Span) -> Arc<PatternNode> {
         let mut node = self.clone();
         node.info.aux_src = Some(src);
         Arc::new(node)
     }
 
+    /// A copy of this pattern typed `ty`, the type of the value it matches.
     pub fn set_type(self: &PatternNode, ty: Arc<TypeNode>) -> Arc<PatternNode> {
         let mut node = self.clone();
         node.info.type_ = Some(ty);
         Arc::new(node)
     }
 
+    /// A pattern binding the matched value to `var`, with `anno_ty` as the type written for it and
+    /// no source span.
     pub fn make_var(var: Arc<Var>, anno_ty: Option<Arc<TypeNode>>) -> Arc<PatternNode> {
         Arc::new(PatternNode {
             pattern: Pattern::Var(var, anno_ty),
@@ -562,9 +594,8 @@ impl PatternNode {
         })
     }
 
-    // Construct a struct destructuring pattern from `(field name,
-    // sub-pattern)` pairs, with no per-field-name source spans (the
-    // entries get `None` spans).
+    /// A struct destructuring pattern matching each `(field name, sub-pattern)` pair of `fields`,
+    /// with no source span recorded for any of the field names.
     pub fn make_struct(
         tycon: Arc<TyCon>,
         fields: Vec<(Name, Arc<PatternNode>)>,
@@ -573,8 +604,8 @@ impl PatternNode {
         PatternNode::make_struct_with_spans(tycon, fields)
     }
 
-    // Construct a struct destructuring pattern from `(field name,
-    // optional field-name source span, sub-pattern)` triples.
+    /// A struct destructuring pattern matching each `(field name, span of that name in the source,
+    /// sub-pattern)` triple of `fields`.
     pub fn make_struct_with_spans(
         tycon: Arc<TyCon>,
         fields: Vec<(Name, Option<Span>, Arc<PatternNode>)>,
@@ -585,7 +616,11 @@ impl PatternNode {
         })
     }
 
-    // Construct a union match pattern with the variant name's source span.
+    /// A pattern matching the `variant` of a union and its payload against `subpat`.
+    ///
+    /// # Arguments
+    /// * `variant_src` — the span of the bare variant name in the source, without any namespace
+    ///   prefix written before it.
     pub fn make_union_with_span(
         variant: FullName,
         variant_src: Option<Span>,
@@ -597,19 +632,17 @@ impl PatternNode {
         })
     }
 
-    // Validate the variant name of a `Union` pattern against the union
-    // type being matched, and return a normalized copy of the pattern.
-    //
-    // Validation: the parsed variant name's namespace must be a suffix of
-    // the union's namespace, and the bare variant name must be one of the
-    // union's variants.
-    //
-    // Normalization (the reason this returns a new pattern rather than
-    // just `Result<(), Errors>`): the user may have written the variant
-    // unqualified (e.g. `some(v)`) or partially qualified (e.g.
-    // `Maybe::some(v)`); we replace its namespace with the union's full
-    // namespace so downstream code can treat the variant as a single,
-    // fully-qualified `FullName` without re-resolving it.
+    /// Check that this union pattern names a variant of the union being matched, and give the name
+    /// that union's namespace. Panics unless this is a union pattern.
+    ///
+    /// The name is accepted when the namespace written before it is a suffix of the union's
+    /// namespace and the bare name is one of the union's variants. The variant is then written out
+    /// under the union's full namespace, whether the source wrote it unqualified (`some(v)`) or
+    /// partially qualified (`Maybe::some(v)`), so that the rest of the compiler reads one
+    /// fully-qualified `FullName` and resolves it no further.
+    ///
+    /// # Arguments
+    /// * `cond_tycon`, `cond_ti` — the union the matched value has, and its declaration.
     pub fn validate_variant_name(
         self: &PatternNode,
         cond_tycon: &TyCon,
@@ -647,7 +680,8 @@ impl PatternNode {
         }
     }
 
-    // Rename names in the pattern.
+    /// A copy of this pattern in which each variable whose name `rename` maps binds the mapped name
+    /// instead. A binder absent from the map keeps its name.
     pub fn rename_by_map(&self, rename: &Map<FullName, FullName>) -> Arc<PatternNode> {
         let mut node = self.clone();
         match &mut node.pattern {
@@ -669,6 +703,11 @@ impl PatternNode {
         Arc::new(node)
     }
 
+    /// Render this pattern as source text. With `with_type`, every node of the tree is followed by
+    /// the type assigned to it in angle brackets, `na` where no type has been assigned yet.
+    ///
+    /// # Examples
+    /// A variable pattern `x` typed `I64` renders as `x`, and as `x<I64>` with `with_type`.
     fn to_string_internal(&self, with_type: bool) -> String {
         let pat_str = self.pattern.to_string_internal(with_type);
         if with_type {
@@ -685,50 +724,60 @@ impl PatternNode {
         }
     }
 
+    /// This pattern as it is written in the source.
     pub fn to_string(&self) -> String {
         self.to_string_internal(false)
     }
 
+    /// This pattern as it is written in the source, each node followed by the type assigned to it,
+    /// for inspecting the result of type assignment.
     #[allow(dead_code)]
     pub fn to_string_with_type(&self) -> String {
         self.to_string_internal(true)
     }
 }
 
+/// What elaboration attaches to a pattern node beyond the pattern itself.
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct PatternInfo {
+    /// The type of the value the pattern matches, once type assignment has reached it.
     pub type_: Option<Arc<TypeNode>>,
+    /// The span the pattern occupies in the source.
     pub source: Option<Span>,
-    // Auxiliary source span that depends on the pattern variant.
-    // For Struct patterns: the source span of the type constructor name only.
+    /// A second span covering one part of the pattern, the part depending on the pattern's form.
+    /// For a struct pattern it covers the type constructor name alone.
     pub aux_src: Option<Span>,
 }
 
+/// The forms a pattern can take, each holding its sub-patterns.
 #[derive(Clone, Serialize, Deserialize)]
 pub enum Pattern {
+    /// Binds the matched value to a variable, under the type annotation written for it.
     Var(Arc<Var>, Option<Arc<TypeNode>>),
-    // Struct destructuring pattern. Each entry is (field name, optional
-    // source span of just the field name, sub-pattern).
+    /// Destructures a struct or tuple. Each entry is a field name, the span of just that name in
+    /// the source, and the sub-pattern its value is matched against.
     Struct(Arc<TyCon>, Vec<(Name, Option<Span>, Arc<PatternNode>)>),
-    // Union match pattern. The optional Span is the source span of just the
-    // variant name (without any namespace prefix).
+    /// Matches one variant of a union and its payload against the sub-pattern. The span covers the
+    /// bare variant name, without any namespace prefix written before it.
     Union(FullName, Option<Span>, Arc<PatternNode>),
 }
 
 impl Pattern {
-    // Make basic variable pattern.
+    /// A pattern binding the matched value to `var`, with no type written for it.
     #[allow(dead_code)]
     pub fn var_pattern(var: Arc<Var>) -> Arc<Pattern> {
         Arc::new(Pattern::Var(var, None))
     }
 
-    // Check if variables defined in this pattern is duplicated or not.
-    // For example, pattern (x, y) is ok, but (x, x) is invalid.
+    /// Whether one name is bound twice in this pattern, which makes the pattern invalid.
+    ///
+    /// # Examples
+    /// `(x, y)` binds each of its names once, and `(x, x)` binds `x` twice.
     pub fn has_duplicate_vars(&self) -> bool {
         (self.vars().len() as u32) < self.count_vars()
     }
 
-    // Count variables defined in this pattern.
+    /// How many variables this pattern binds, counting a name written twice once per occurrence.
     fn count_vars(&self) -> u32 {
         match self {
             Pattern::Var(_, _) => 1,
@@ -743,7 +792,7 @@ impl Pattern {
         }
     }
 
-    // Calculate the set of variables that appears in this pattern.
+    /// The names this pattern binds, a name written twice appearing once.
     pub fn vars(&self) -> Set<FullName> {
         match self {
             Pattern::Var(var, _) => make_set([var.name.clone()]),
@@ -758,10 +807,15 @@ impl Pattern {
         }
     }
 
+    /// This pattern as it is written in the source, its variant and field names carrying the
+    /// namespaces they have been resolved to.
     pub fn to_string(&self) -> String {
         self.to_string_internal(false)
     }
 
+    /// Render this pattern as source text, a tuple type at the head printing as `(a, b)` and any
+    /// other struct as `S {f: p}`. With `with_type`, each sub-pattern is followed by the type
+    /// assigned to it.
     fn to_string_internal(&self, with_type: bool) -> String {
         let mut ret = "".to_string();
         match self {
@@ -827,7 +881,14 @@ impl Pattern {
         Some((variant_idx, tc))
     }
 
-    // Checks if patterns which are used in `match` syntax are exhaustive.
+    /// Check that the arms of a `match` cover every variant of the union being matched, each of
+    /// them once. A pattern that names no variant catches whatever the union patterns leave, so one
+    /// arm of that shape covers the rest.
+    ///
+    /// # Arguments
+    /// * `cond_tc`, `cond_ti` — the union the matched value has, and its declaration.
+    /// * `match_src` — the span of the whole `match`, where a report of uncovered variants points.
+    /// * `pats` — the arm patterns, in the order they are written.
     pub fn validate_match_cases_exhaustiveness(
         cond_tc: &TyCon,
         cond_ti: &TyConInfo,

--- a/src/commands/lsp/references.rs
+++ b/src/commands/lsp/references.rs
@@ -914,20 +914,14 @@ fn collect_pattern_bare_field_occs(
             }
         }
         Pattern::Union(variant, variant_src, sub) => {
-            // The variant FullName has the namespace `tc.name::*`.
-            // Compare via the TyCon constructed from the variant's namespace.
-            // After elaboration the namespace is populated (validate_variant_name
-            // sets it from the matched union); guard against the unresolved
-            // pre-elaboration shape just in case.
-            if !variant.namespace.names.is_empty() {
-                let variant_tc = TyCon::new(variant.namespace.clone().to_fullname());
-                if &variant_tc == tc && &variant.name == name {
-                    if let Some(span) = variant_src {
-                        occs.push(FieldOccurrence {
-                            span: span.clone(),
-                            prefix: "",
-                        });
-                    }
+            // The variant name carries the union it belongs to, which a pattern the type checker
+            // has yet to accept leaves unresolved.
+            if Pattern::variant_union_tycon(variant).as_ref() == Some(tc) && &variant.name == name {
+                if let Some(span) = variant_src {
+                    occs.push(FieldOccurrence {
+                        span: span.clone(),
+                        prefix: "",
+                    });
                 }
             }
             collect_pattern_bare_field_occs(sub, tc, name, occs);

--- a/src/rc_ir/lower.rs
+++ b/src/rc_ir/lower.rs
@@ -279,7 +279,7 @@ impl<'a> Lowerer<'a> {
         let src_tys = lam_ty.get_lambda_srcs();
         assert_eq!(params.len(), src_tys.len());
 
-        let saved_env = mem::take(&mut self.scope);
+        let saved_scope = mem::take(&mut self.scope);
 
         let mut param_vars = vec![];
         for (p, ty) in params.iter().zip(src_tys.iter()) {
@@ -328,7 +328,7 @@ impl<'a> Lowerer<'a> {
         let ret_var = self.lower_to_var(&body, &mut bindings);
         let body_expr = Self::fold_bindings(bindings, Self::ret_node(ret_var));
 
-        self.scope = saved_env;
+        self.scope = saved_scope;
 
         RcFunc {
             name: func_ref,

--- a/src/rc_ir/lower.rs
+++ b/src/rc_ir/lower.rs
@@ -122,6 +122,12 @@ impl<'a> Lowerer<'a> {
 
     // --- fresh names ---
 
+    /// A variable named `<hint>#<n>` with an `n` no other minted name carries, so the name alone
+    /// identifies the binding wherever the program reads it.
+    ///
+    /// # Arguments
+    /// * `hint` — the readable part of the name, shown in an RC IR dump.
+    /// * `source` — where the value the variable holds is written, for diagnostics and debug info.
     fn fresh_var(&mut self, hint: &str, ty: Arc<TypeNode>, source: Option<Span>) -> RcVar {
         self.fresh_counter += 1;
         let name = FullName::local(&format!("{}#{}", hint, self.fresh_counter));
@@ -151,6 +157,8 @@ impl<'a> Lowerer<'a> {
 
     // --- environment ---
 
+    /// Make `var` what `ast_name` resolves to, over whatever it resolved to before; the covered
+    /// binding comes back when `unbind` closes this one.
     fn bind(&mut self, ast_name: &FullName, var: RcVar) {
         self.scope
             .entry(ast_name.clone())
@@ -158,6 +166,7 @@ impl<'a> Lowerer<'a> {
             .push(var);
     }
 
+    /// Close the innermost binding of `ast_name`, uncovering the binding it shadowed.
     fn unbind(&mut self, ast_name: &FullName) {
         // Every `unbind` closes a `bind`, so both the name and a binding for it are there. An unbind
         // with nothing to undo means the two have gone out of step, and every later `resolve` in the
@@ -176,6 +185,10 @@ impl<'a> Lowerer<'a> {
         });
     }
 
+    /// The RC IR variable `ast_name` is currently bound to.
+    ///
+    /// # Returns
+    /// `None` for a name the scope holds no binding for; such a name is a top-level symbol.
     fn resolve(&self, ast_name: &FullName) -> Option<RcVar> {
         self.scope
             .get(ast_name)
@@ -354,6 +367,7 @@ impl<'a> Lowerer<'a> {
         grow_stack(|| self.lower_to_var_inner(expr, bindings))
     }
 
+    /// Lower `expr` by its form, with the stack already grown for the recursion this enters.
     fn lower_to_var_inner(&mut self, expr: &ExprNode, bindings: &mut Vec<PendingBinding>) -> RcVar {
         let ty = expr.type_.clone().unwrap();
         let source = expr.source.clone();
@@ -375,6 +389,9 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// Lower a variable reference to the atom holding its value: a local is the RC IR variable
+    /// currently bound to it, and a global is an atom carrying the symbol's name, which code
+    /// generation materializes.
     fn lower_var(&mut self, v: &Arc<Var>, ty: &Arc<TypeNode>, source: &Option<Span>) -> RcVar {
         match self.resolve(&v.name) {
             // A local: reuse the variable already bound (it is already an atom).
@@ -399,6 +416,8 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// Lower an inline-LLVM operation: its free variables become its operands, in the fixed order
+    /// the generator reads them, and the appended binding holds the value the operation produces.
     fn lower_llvm(
         &mut self,
         inline: &Arc<InlineLLVM>,
@@ -455,6 +474,8 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower a function application: the callee and then the arguments become variables, and the
+    /// appended binding calls the one on the others.
     fn lower_app(
         &mut self,
         fun: &ExprNode,
@@ -525,6 +546,9 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower a `let`: the bound expression becomes a variable, the pattern binds that value (a
+    /// struct or tuple pattern destructuring it), and the body is lowered under those bindings,
+    /// which are closed once it is lowered. The result variable is the body's.
     fn lower_let(
         &mut self,
         pat: &PatternNode,
@@ -541,6 +565,8 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower an `if` to a match on the two variants of the `Bool` union, the branches becoming its
+    /// arms. Each arm's payload holds the variant's unit contents.
     fn lower_if(
         &mut self,
         cond: &ExprNode,
@@ -574,6 +600,9 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower a `match`: the matched value becomes a variable, each arm is lowered against it, and
+    /// the appended binding selects one arm on that value. The result variable holds the value of
+    /// whichever arm is taken.
     fn lower_match(
         &mut self,
         cond: &ExprNode,
@@ -596,6 +625,11 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower one arm of a match on `scrutinee`. A union pattern gives an arm the variant's tag
+    /// selects, whose payload variable holds that variant's contents; a variable or struct pattern
+    /// gives the default arm, taken for every value the tagged arms leave, and its payload is the
+    /// whole scrutinee. The pattern's variables are bound while the arm's body is lowered and
+    /// closed after it, so each body is lowered under its own pattern's bindings alone.
     fn lower_match_arm(
         &mut self,
         scrutinee: &RcVar,
@@ -672,6 +706,9 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// Lower a struct or tuple literal: the field expressions are lowered in declaration order,
+    /// which is the order they are evaluated in, and the appended binding builds the value from
+    /// them.
     fn lower_make_struct(
         &mut self,
         fields: &[(Name, Option<Span>, Arc<ExprNode>)],
@@ -696,6 +733,8 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower an array literal: the elements are lowered left to right, and the appended binding
+    /// builds an array holding them in that order.
     fn lower_array_lit(
         &mut self,
         elems: &[Arc<ExprNode>],
@@ -719,6 +758,16 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower a call to a foreign function: the arguments are lowered left to right, and the
+    /// appended binding calls `fun_name` on them.
+    ///
+    /// # Arguments
+    /// * `ret_tycon`, `param_tycons` — the C types the call is made under, which decide how the
+    ///   result and the arguments cross the boundary.
+    /// * `is_var_args` — the C function is declared variadic, so it accepts arguments past
+    ///   `param_tycons`.
+    /// * `is_io` — the last of `args` is the IOState token, which orders this call against the
+    ///   other effects and is not passed to C.
     fn lower_ffi_call(
         &mut self,
         fun_name: &Name,
@@ -754,6 +803,8 @@ impl<'a> Lowerer<'a> {
         result
     }
 
+    /// Lower `eval side; main`: `side` is evaluated for its effect and discarded, then `main` is
+    /// lowered, and the result variable is `main`'s.
     fn lower_eval(
         &mut self,
         side: &ExprNode,


### PR DESCRIPTION
`code-review` スキルの neighborhood パスが、#309 の修正が触れた 2 つのファイル — `src/ast/pattern.rs` と `src/rc_ir/lower.rs` — の、変更の周りに残していた分を清掃したもの。修正そのものの差分を読みやすく保つために、別のブランチに分けてある。

以下は 3 つのコミットの中身と、それぞれがどの規約から来ていて、なぜ振る舞いを変えないかである。

## 部分パターンの型検査を 1 つにまとめた

`PatternNode::get_typed` は、パターンとその部分パターンに型を割り当てる関数である。struct パターンの枝と union パターンの枝が、同じ形のブロックを 1 つずつ持っていた。

- 部分パターンに割り当てた型を、その部分パターンが置かれている場所の型（struct のフィールドの型、union の variant の型）と単一化する。
- 食い違ったとき、通常の型検査なら `Inappropriate pattern ... for a value of ...` というエラーを返す。エラーに寛容なモードでは、その食い違いを握り潰して、部分パターンに推論した型を持たせたまま先へ進む。アームの本体がその束縛を読めるようにするためである。

2 つのブロックは、エラーの文言のうち「場所」を述べる部分だけが違っていた。これを private メソッド `PatternNode::unify_with_expected_type` にまとめ、場所を述べる部分をクロージャで受け取るようにした。

```rust
fn unify_with_expected_type(
    &self,
    typechecker: &mut TypeCheckContext,
    expected_ty: &Arc<TypeNode>,
    place_desc: impl FnOnce() -> String,
) -> Result<(), Errors>
```

呼び出し側は `|| format!("field `{}` of struct `{}`", field_name, tc.to_string())` と
`|| format!("variant `{}` of union `{}`", variant_name.to_string(), tc.to_string())` を渡す。

**振る舞いを変えない根拠**: 組み立てるエラーの文言は、前置き `Inappropriate pattern `{}` for a value of ` と場所の記述の連結で、元の 2 つの `format!` と同じ文字列になる。クロージャなので、単一化が通った走行では `format!` 自体が実行されない。実際に両方の文言を出させて確認した。

```
$ fix check   # let A { f : B { g : y } } = A { f : 1 };
error: Inappropriate pattern `Main::B {g: y}` for a value of field `f` of struct `Main::A`.

$ fix check   # match (u : U) { a(B { g : v }) => v, b(_) => 1 }   -- U::a の中身は I64
error: Inappropriate pattern `Main::B {g: v}` for a value of variant `Main::U::a` of union `Main::U`.
```

規約: *Extract a function on the second copy*。

## 1 つの概念に 1 つの語を使う

局所束縛の改名だけで、どれも 1 つの関数本体の中で閉じている。

| ファイル・関数 | 旧 -> 新 | 旧名が隠していたもの |
| --- | --- | --- |
| `pattern.rs` `get_typed` | `typed` -> `typed_res` | 中身は `Result<(パターン, 束縛表), Errors>` なのに、名前は型付き済みのパターンを予告していた。同じ関数の `unify_res` に揃う |
| `pattern.rs` `get_typed` (struct の枝) | `var_ty` -> `sub_var_to_ty` | 集約側が `var_to_ty` と呼んでいる `Map<FullName, Arc<TypeNode>>` と同じもの。1 つの関数の中で 2 語になっていた |
| `pattern.rs` `get_typed` (union の枝) | `var_ty` -> `var_to_ty` | 同上 |
| `pattern.rs` `get_typed` (union の枝) | `variant_ty` -> `union_tc_and_variant_ty` | 中身は `Option<(TyCon, Arc<TypeNode>)>` の対で、26 行下で本来の意味の `variant_ty` に shadow されていた |
| `pattern.rs` `find_node_at_pos` | `res` -> `node` | 同じ関数の他の 3 か所が、同じ `Option<EndNode>` を `node` と呼んでいた |
| `pattern.rs` `validate_variant_name` | `name_space` -> `union_namespace` | プロジェクトの綴りは `namespace`。この関数には namespace が 2 つ（variant 側と union 側）あり、どちらか判らなかった |
| `pattern.rs` `unify_with_expected_type` | `position` -> `place_desc` | このコードベースの position はソース上の位置を指す。この引数が返すのは「値が置かれている場所」の説明文 |
| `lower.rs` `lower_lambda_as_function` | `saved_env` -> `saved_scope` | 退避先のフィールドは `scope`。同じファイルの `env` は `type_env` を指す |

**振る舞いを変えない根拠**: 局所束縛の改名は、その束縛のスコープの中でのすべての出現を同時に書き換えるので、構成上、意味が変わらない。

規約: *naming*（局所名は適用、項目名は報告）。

## 項目に doc コメントを付けた

`src/ast/pattern.rs` の全項目 — `PatternNode` / `PatternInfo` / `Pattern` とそのフィールド・バリアント、および各メソッド — に `///` の doc コメントを付けた。`//` で書かれていた項目コメント 14 個は doc の形に直した。`src/rc_ir/lower.rs` は、変更が触れた `lower_match_arm` を起点に外側へ、`lower_*` の各関数と環境操作 (`fresh_var` / `bind` / `unbind` / `resolve`) に付けた。

肯定形の規約に触れていた 1 文も直した。

- 前: `Normalization (the reason this returns a new pattern rather than just `Result<(), Errors>`): the user may have written the variant unqualified ...`
- 後: 退けた戻り値の型を持ち出さず、「合格した名前を union の完全名の下に書き出すので、コンパイラの残りは完全修飾された `FullName` を 1 つ読めばよい」と述べる形にした。

**振る舞いを変えない根拠**: 散文だけの変更である。

規約: *Every Rust item must have a doc comment*、*Write in the affirmative*。

## 呼び出し元のない 3 項目を削除した

`PatternNode::get_typed_matching`、`PatternNode::to_string_with_type`、`Pattern::var_pattern` は、いずれも `#[allow(dead_code)]` が付いていて、`src/` 全体で自身の再帰以外の呼び出しが無かった。CLAUDE.md は `#[allow(dead_code)]` を新たに付けることを禁じている — 警告は段階的な作業がまだ残っているという合図だから — が、この 3 つは付いたまま残っていたので、作者の判断で削除した。

`to_string_with_type` を消すと、パターンの各節点にその型を添えて印字する仕組みが誰にも使われなくなる。`PatternNode` と `Pattern` の `to_string_internal` は `with_type` が常に偽になるので、その引数と 1 段の間接を落として `to_string` に畳んだ。

**振る舞いを変えない根拠**: 消した 3 項目に呼び出し元が無い。`to_string` が返す文字列は、`with_type` が偽のときの `to_string_internal` と同じである。

規約: *Remove dead and half-finished code*。

## variant 名が属する union を 1 か所で答えるようにした

「union パターンの variant 名の namespace は、その名前が属する union の型構築子である。型検査が受理する前の名前は、ソースに書かれたままの namespace を持ち、何も書かれていなければ空である」— この規則を 3 か所が別々に綴っていた。

- `Pattern::resolve_union_variant` は `namespace.is_local()` で判定する。
- `PatternNode::find_node_at_pos` は `!variant.namespace.names.is_empty()` で判定する。
- `src/commands/lsp/references.rs` の `collect_pattern_bare_field_occs` も同じ式で判定し、そのうえ「念のため」と断るコメントを 4 行付けていた。

いずれも空の namespace で `assert!` する `NameSpace::to_fullname` を避けるための手書きのガードである。`Pattern` に置いた `variant_union_tycon` が規則を 1 度だけ述べ、3 か所はそれを通して union を読む。

```rust
/// The union a variant name belongs to, which is the type constructor its namespace names.
pub fn variant_union_tycon(variant_name: &FullName) -> Option<TyCon>
```

`references.rs` の判定は、`Pattern::variant_union_tycon(variant).as_ref() == Some(tc)` の 1 行になった。解決できない名前は `None` になり、どの `tc` とも等しくない。

**振る舞いを変えない根拠**: 3 か所とも、空の namespace を除いてから同じ `TyCon::new(namespace.to_fullname())` を組み立てていた。新しい関数はその 2 段をそのまま持つ。`find_node_at_pos` は、ガードが偽のとき部分パターンの探索へ落ちる形も元のままである。

規約: *Avoid shotgun-surgery coupling; annotate it when unavoidable*（1 つの真実の源へ畳む側）。

## 網羅性検査に、union の variant を覆うパターンを名指しさせた

`Pattern::validate_match_cases_exhaustiveness` は、`match &pat.pattern` で `Pattern::Union` 以外を `_ =>` で受け、「残りの variant を全部覆うアーム」と見なしていた。いまの 2 つの形ではこれは正しい — 変数は値が何であれ束縛し、struct パターンはその型のどの値も分解する。しかし、マッチに失敗しうるパターンの形が増えたとき、網羅性検査は黙ってそれも「全部を覆う」と見なす。`Pattern::Var(_, _) | Pattern::Struct(_, _) =>` と書けば、3 つ目が来たときにコンパイラが答えを要求する。

**振る舞いを変えない根拠**: `Pattern` の形は 3 つで、`Union` は上のアームが受ける。残る 2 つを名指ししたので、いま到達する枝は同じである。

規約: *Avoid shotgun-surgery coupling*（網羅的でない `match` は、バリアントを足しても黙って通る）。

## このパスが報告だけにとどめたもの

無し。前の版で挙げていた 4 件のうち、3 件は上のとおり直した。残る 1 件（`get_typed_matching` が `TypeNode::field_index` と同じ仕事をしている）は、その関数を削除したので消えた。

## 検査

`cargo test --release` で 142 + 1442、失敗 0。