### PR TITLE
レビュー清掃 (#346): テストの参照・局所名・変更の周りの doc

### DIFF
--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -455,7 +455,10 @@ impl SymbolExpr {
     pub fn source(&self) -> Option<Span> {
         match self {
             SymbolExpr::Simple(e) => e.expr.source.clone(),
-            SymbolExpr::Method(ms) => ms.first().map(|m| m.expr.expr.source.clone()).flatten(),
+            SymbolExpr::Method(impls) => impls
+                .first()
+                .map(|impl_| impl_.expr.expr.source.clone())
+                .flatten(),
         }
     }
 
@@ -465,7 +468,10 @@ impl SymbolExpr {
     pub fn find_node_at(&self, name: &FullName, pos: &SourcePos) -> Option<EndNode> {
         match self {
             SymbolExpr::Simple(e) => e.find_node_at(pos),
-            SymbolExpr::Method(ms) => ms.iter().filter_map(|m| m.find_node_at(name, pos)).next(),
+            SymbolExpr::Method(impls) => impls
+                .iter()
+                .filter_map(|impl_| impl_.find_node_at(name, pos))
+                .next(),
         }
     }
 
@@ -1598,8 +1604,11 @@ impl Program {
             // forward, but still install the typed expression below so
             // the LSP can hover on its sub-expressions.
             errors.append(output.errors);
-            for (k, mut v) in output.te.opaque_types.drain() {
-                self.opaque_types.entry(k).or_default().append(&mut v);
+            for (tycon_name, mut resolutions) in output.te.opaque_types.drain() {
+                self.opaque_types
+                    .entry(tycon_name)
+                    .or_default()
+                    .append(&mut resolutions);
             }
             self.merge_import_required(output.import_required);
             let gv = self.global_values.get_mut(&result.val_name).unwrap();
@@ -1946,8 +1955,8 @@ impl Program {
                 let syntactic_member_scm = trait_.member_scheme(&member.name, true);
                 let mut member_impls: Vec<TraitMemberImpl> = vec![];
                 let instances = self.trait_env.impls.get(trait_id);
-                if let Some(insntances) = instances {
-                    for trait_impl in insntances {
+                if let Some(instances) = instances {
+                    for trait_impl in instances {
                         let scm = trait_impl.member_scheme(&member.name, trait_);
                         let scm_via_defn = trait_impl.member_scheme_by_defn(&member.name, trait_);
                         let expr = trait_impl.member_expr(&member.name);

--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -337,17 +337,21 @@ pub struct GlobalValue {
 }
 
 impl GlobalValue {
+    /// Replaces every name written in this value's declared type by the full name it stands for.
+    ///
+    /// Asked of a simple value: the declaration of a trait method is name-resolved on `TraitEnv`,
+    /// and the global value of the method is built from the resolved one.
     pub fn resolve_namespace_in_declaration(
         &mut self,
         ctx: &mut NameResolutionContext,
     ) -> Result<(), Errors> {
-        // Currently, global values generated from member implementations do not come here.
-        // This is because name resolution is performed on TraitEnv, and then global values are generated from trait member implementations.
         assert!(matches!(self.expr, SymbolExpr::Simple(_)));
         self.scm = self.scm.resolve_namespace(ctx)?;
         Ok(())
     }
 
+    /// Replaces every type alias written in this value's type, and in the types of its trait member
+    /// implementations, by the type it stands for. The type as written is kept in `syn_scm`.
     pub fn resolve_type_aliases(&mut self, type_env: &TypeEnv) -> Result<(), Errors> {
         self.syn_scm = Some(self.scm.clone());
         self.scm = self.scm.resolve_type_aliases(type_env)?;
@@ -355,6 +359,8 @@ impl GlobalValue {
         Ok(())
     }
 
+    /// Sets the kinds of the type variables of this value's scheme, and of the schemes of its trait
+    /// member implementations, and reports a scheme whose kinds do not fit together.
     pub fn set_kinds(&mut self, kind_env: &KindEnv) -> Result<(), Errors> {
         self.scm = self.scm.set_kinds(kind_env)?;
         self.scm.check_kinds(kind_env)?;
@@ -369,12 +375,15 @@ impl GlobalValue {
         Ok(())
     }
 
-    // Check if this value is a simple value, not a trait method.
+    /// Whether this value is defined by one expression. A trait method is defined by one
+    /// implementation per type the trait is implemented for.
     pub fn is_simple_value(&self) -> bool {
         matches!(self.expr, SymbolExpr::Simple(_))
     }
 
-    // Get the document of this value.
+    /// The documentation comment written above this value's declaration, and the `document` field
+    /// where the source code of the declaration is unavailable. Documentation that is empty is
+    /// answered as `None`.
     pub fn get_document(&self) -> Option<String> {
         // Try to get document from the source code.
         let docs = self
@@ -401,16 +410,20 @@ impl GlobalValue {
         }
     }
 
-    // Find the minimum node which includes the specified source code position.
-    // - `name`: the name of this global value (i.e., the key in `Program::global_values`).
+    /// The innermost node of this value that includes the source code position `pos`: a node of its
+    /// expression, a node of its type signature, or the value itself where `pos` is on the name it
+    /// is declared or defined under.
+    ///
+    /// # Arguments
+    /// * `name` — the name this value is known by, the key it is held under in
+    ///   `Program::global_values`, which the answer carries where `pos` is on the name.
     pub fn find_node_at(&self, name: &FullName, pos: &SourcePos) -> Option<EndNode> {
         let node = self.expr.find_node_at(name, pos);
         if node.is_some() {
             return node;
         }
-        // Walk the syntactic scheme if available so that type aliases written
-        // in source resolve back to the alias name (rather than the expanded
-        // type, which is what `scm` carries).
+        // Walk the syntactic scheme where there is one, so that a type alias written in the source
+        // resolves to the alias name; `scm` carries the type the alias expands to.
         let scm_for_lookup = self.syn_scm.as_ref().unwrap_or(&self.scm);
         let node = scm_for_lookup.find_node_at(pos);
         if node.is_some() {
@@ -430,14 +443,18 @@ impl GlobalValue {
     }
 }
 
-// Expression of global symbol.
+/// What a global value is defined by.
 #[derive(Clone)]
 pub enum SymbolExpr {
-    Simple(TypedExpr),            // Definition such as "id : a -> a; id = \x -> x".
-    Method(Vec<TraitMemberImpl>), // Trait member implementations.
+    /// The one expression a value is defined by, as `id = |x| x` defines `id : a -> a`.
+    Simple(TypedExpr),
+    /// The implementations of a trait member, one per type the trait is implemented for.
+    Method(Vec<TraitMemberImpl>),
 }
 
 impl SymbolExpr {
+    /// Replaces every type alias written in the type of each trait member implementation by the
+    /// type it stands for. A simple value's type is held by the `GlobalValue` itself.
     pub fn resolve_type_aliases(&mut self, type_env: &TypeEnv) -> Result<(), Errors> {
         match self {
             SymbolExpr::Simple(_) => Ok(()),
@@ -451,6 +468,8 @@ impl SymbolExpr {
         }
     }
 
+    /// The source code of the expression this value is defined by, and of the first implementation
+    /// for a trait member.
     #[allow(dead_code)]
     pub fn source(&self) -> Option<Span> {
         match self {
@@ -462,9 +481,13 @@ impl SymbolExpr {
         }
     }
 
-    // Find the minimum expression node which includes the specified source code position.
-    // - `name`: the name of the global value (e.g., `Std::ToString::to_string`), used to return `EndNode::ValueDecl` when
-    //   the cursor is on the LHS of a trait member implementation.
+    /// The innermost expression node that includes the source code position `pos`, searching the
+    /// implementations of a trait member in turn.
+    ///
+    /// # Arguments
+    /// * `name` — the name of the global value this expression defines (e.g.
+    ///   `Std::ToString::to_string`), which the answer carries where `pos` is on the left hand side
+    ///   of a trait member implementation.
     pub fn find_node_at(&self, name: &FullName, pos: &SourcePos) -> Option<EndNode> {
         match self {
             SymbolExpr::Simple(e) => e.find_node_at(pos),
@@ -502,33 +525,38 @@ impl SymbolExpr {
     }
 }
 
-// The expression with all sub-expressions typed.
+/// The expression with all sub-expressions typed.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TypedExpr {
-    // The expression.
-    //
-    // It and its all subexpressions has their types resolved, and these types contains only ones that appear in the context (type signature) of this expression.
+    /// The expression.
+    ///
+    /// It and all its subexpressions have their types resolved, and these types contain only the
+    /// type variables that appear in the context (type signature) of this expression.
     pub expr: Arc<ExprNode>,
-    // Equalities to be assumed in the context of this expression.
-    //
-    // For example, consider the following expression:
-    // ```
-    // extend : [c1 : Collects, c2 : Collects, Elem c1 = e, Elem c2 = e] c1 -> c2 -> c2;
-    // extend = |xs, ys| xs.to_iter.fold(ys, |ys, x| ys.insert(x));
-    // ```
-    // In this case, the `equalities` field consists of two equalities: `Elem c1 = e` and `Elem c2 = e`.
-    //
-    // In fact, this information is neccesary to instantiate the typed expression to a concrete type:
-    // In the above case, the sub-expression `x` has type `e` (not `Elem c1` or `Elem c2`).
-    // When instantiating this typed expression to a concrete type, e.g., `extend : Array I64 -> Array I64 -> Array I64`,
-    // we need to use the equality `Elem c1 = e` to prove that `x` has type `I64`.
+    /// Equalities to be assumed in the context of this expression.
+    ///
+    /// For example, consider the following expression:
+    /// ```text
+    /// extend : [c1 : Collects, c2 : Collects, Elem c1 = e, Elem c2 = e] c1 -> c2 -> c2;
+    /// extend = |xs, ys| xs.to_iter.fold(ys, |ys, x| ys.insert(x));
+    /// ```
+    /// In this case, the `equalities` field consists of two equalities: `Elem c1 = e` and
+    /// `Elem c2 = e`.
+    ///
+    /// This information is necessary to instantiate the typed expression to a concrete type:
+    /// in the above case, the sub-expression `x` has type `e`. When instantiating this typed
+    /// expression to a concrete type, e.g., `extend : Array I64 -> Array I64 -> Array I64`, the
+    /// equality `Elem c1 = e` is what proves that `x` has type `I64`.
     pub equalities: Vec<Equality>,
-    // Concrete types for opaque type constructors in this expression.
+    /// The concrete type behind each opaque type constructor this expression determines, by the
+    /// constructor's name. Type-checking this expression fills in the concrete types.
     #[serde(default)]
     pub opaque_types: Map<FullName, Vec<OpaqueTyConResolution>>,
 }
 
 impl TypedExpr {
+    /// The expression carrying no context of its own: neither an equality to assume nor a concrete
+    /// type for an opaque type constructor, which type-checking fills in.
     pub fn from_expr(expr: Arc<ExprNode>) -> Self {
         TypedExpr {
             expr,
@@ -537,7 +565,7 @@ impl TypedExpr {
         }
     }
 
-    // Find the minimum expression node which includes the specified source code position.
+    /// The innermost node of this expression that includes the source code position `pos`.
     pub fn find_node_at(&self, pos: &SourcePos) -> Option<EndNode> {
         let node = self.expr.find_node_at(pos);
         if node.is_none() {
@@ -548,30 +576,33 @@ impl TypedExpr {
     }
 }
 
-// Trait member implementation
+/// One implementation of a trait member: the body a trait method takes for one of the types the
+/// trait is implemented for.
 #[derive(Clone)]
 pub struct TraitMemberImpl {
-    // Type of this member.
-    //
-    // For example, in case "impl [a: ToString, b: ToString] (a, b): ToString {...}",
-    // the type of member "to_string" is "[a: ToString, b: ToString] (a, b) -> String",
-    //
-    // Users can give type signatures in each trait member implementation.
-    // In this case, the `scm` field contains the type signature given by users.
+    /// Type of this member.
+    ///
+    /// For example, in case `impl [a : ToString, b : ToString] (a, b) : ToString {...}`, the type
+    /// of member `to_string` is `[a : ToString, b : ToString] (a, b) -> String`.
+    ///
+    /// A type signature written in the trait member implementation is what this field holds.
     pub scm: Arc<Scheme>,
-    // This field holds the type scheme obtained from the trait member definition.
+    /// The type of this member as the trait member declaration gives it, with the trait's type
+    /// variable sent to the type this implementation is for. A type signature written in the
+    /// implementation is left out, so this field and `scm` can name the type variables differently.
     pub scm_via_defn: Arc<Scheme>,
-    // Expression of this implementation
+    /// Expression of this implementation.
     pub expr: TypedExpr,
-    // Module where this implmentation is given.
-    // NOTE:
-    // For trait member, `define_module` may differ to the first component of namespace of the function.
-    // For example, if `Main` module implements `SomeType : Eq`, then implementation of `eq` for `SomeType` is defined in `Main` module,
-    // but its name as a function is still `Std::Eq::eq`.
+    /// Module where this implementation is given.
+    ///
+    /// For a trait member, `define_module` may differ from the first component of the namespace of
+    /// the function. For example, if the `Main` module implements `SomeType : Eq`, then the
+    /// implementation of `eq` for `SomeType` is defined in the `Main` module, while its name as a
+    /// function is still `Std::Eq::eq`.
     pub define_module: Name,
-    // The source spans of the left-hand side names in the trait member implementation.
-    // For example, in `impl MyType : ToString { to_string : MyType -> String; to_string = ...; }`,
-    // this contains spans of both `to_string` occurrences (type signature and definition).
+    /// The source spans of the left-hand side names in the trait member implementation.
+    /// For example, in `impl MyType : ToString { to_string : MyType -> String; to_string = ...; }`,
+    /// this contains spans of both `to_string` occurrences (type signature and definition).
     pub lhs_srcs: Vec<Span>,
     /// The trait's type variable, sent to the type this implementation is for: `c` to `Array a` for
     /// `impl [a : ToString] Array a : ToIter` of `trait c : ToIter`.
@@ -584,6 +615,8 @@ pub struct TraitMemberImpl {
 }
 
 impl TraitMemberImpl {
+    /// Replaces every type alias written in the two schemes of this implementation by the type it
+    /// stands for.
     pub fn resolve_type_aliases(&mut self, type_env: &TypeEnv) -> Result<(), Errors> {
         self.scm = self.scm.resolve_type_aliases(type_env)?;
         self.scm_via_defn = self.scm_via_defn.resolve_type_aliases(type_env)?;
@@ -627,9 +660,13 @@ impl TraitMemberImpl {
         Ok(())
     }
 
-    // Find the minimum expression node which includes the specified source code position.
-    // - `name`: the name of the global value (e.g., `Std::ToString::to_string`), used to return
-    //   `EndNode::ValueDecl` when the cursor is on the LHS of this trait member implementation.
+    /// The innermost node of this implementation that includes the source code position `pos`: a
+    /// node of its expression, or the member itself where `pos` is on one of the left hand side
+    /// names the implementation writes.
+    ///
+    /// # Arguments
+    /// * `name` — the name of the global value this implements (e.g. `Std::ToString::to_string`),
+    ///   which the answer carries where `pos` is on a left hand side name.
     pub fn find_node_at(&self, name: &FullName, pos: &SourcePos) -> Option<EndNode> {
         let node = self.expr.find_node_at(pos);
         if node.is_some() {
@@ -684,7 +721,9 @@ pub struct Program {
     pub mod_to_import_stmts: Map<Name, Vec<ImportStatement>>,
 
     /* Instantiated symbols */
-    // Opaque types instantiated in this program, keyed by opaque TyCon name.
+    /// The concrete type behind each opaque type constructor of this program, by the constructor's
+    /// name. The opaque type constructor of a trait member has one resolution per implementation,
+    /// told apart by the type each is for.
     pub opaque_types: Map<FullName, Vec<OpaqueTyConResolution>>,
     // Instantiated symbols.
     pub symbols: Map<FullName, Symbol>,
@@ -1947,7 +1986,8 @@ impl Program {
         Ok(name)
     }
 
-    // Create symbols of trait members from TraitEnv.
+    /// Adds a global value for every member of every trait, holding the implementations of that
+    /// member — one per type the trait is implemented for — as its expression.
     pub fn create_trait_member_symbols(&mut self) {
         for (trait_id, trait_) in &self.trait_env.traits {
             for member in &trait_.members {

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -453,31 +453,36 @@ impl TraitDefn {
     }
 }
 
-// Trait implementation
+/// An implementation of a trait for one type: the head it is written for, and the body it gives
+/// each member of the trait.
 #[derive(Clone)]
 pub struct TraitImpl {
-    // Statement such as "[a: Show, b: Show] (a, b): Show".
+    /// The head of this implementation, with the constraints it assumes, such as
+    /// `[a : Show, b : Show] (a, b) : Show`.
     pub qual_pred: QualPred,
-    // Member implementation.
+    /// The expression implementing each member, by the member's name.
     pub members: Map<Name, Arc<ExprNode>>,
-    // Source spans of the left-hand side names in member implementations.
-    // For example, in `impl MyType : ToString { to_string : MyType -> String; to_string = ...; }`,
-    // this stores the spans of both occurrences of `to_string`.
+    /// Source spans of the left-hand side names in member implementations.
+    /// For example, in `impl MyType : ToString { to_string : MyType -> String; to_string = ...; }`,
+    /// this stores the spans of both occurrences of `to_string`.
     pub member_lhs_srcs: Map<Name, Vec<Span>>,
-    // Type signatures of members, if provided by user.
+    /// The type signature written for a member in this implementation, by the member's name. A
+    /// member whose implementation carries no signature is absent.
     pub member_sigs: Map<Name, QualType>,
-    // Associated type synonym implementation.
+    /// The type given to each associated type of the trait, by the associated type's name.
     pub assoc_types: Map<Name, AssocTypeImpl>,
-    // Module where this instance is defined.
+    /// Module where this instance is defined.
     pub define_module: Name,
-    // Source location where this instance is defined.
+    /// Source location where this instance is defined.
     pub source: Option<Span>,
-    // Is this instance implememted by user? (not by compiler)
+    /// Whether this instance is written in a Fix program. The compiler generates instances of its
+    /// own, such as the ones for tuples.
     pub is_user_defined: bool,
 }
 
 impl TraitImpl {
-    // Find the minimum node which includes the specified source code position.
+    /// The innermost node of this implementation that includes the source code position `pos`:
+    /// a node of its head, of an associated type it gives, or of a member's type signature.
     pub fn find_node_at(&self, pos: &SourcePos) -> Option<EndNode> {
         let trait_id = self.trait_id();
         let node = self.qual_pred.find_node_at(pos);
@@ -499,6 +504,9 @@ impl TraitImpl {
         None
     }
 
+    /// Sets the kinds of the type variables of this implementation's head and of the type
+    /// signatures written for its members, taking each kind from the constraints in force where the
+    /// variable stands, and reports a set of constraints whose kinds do not fit together.
     pub fn set_kinds_in_qual_pred_and_member_sigs(
         &mut self,
         kind_env: &KindEnv,
@@ -546,6 +554,10 @@ impl TraitImpl {
         Ok(())
     }
 
+    /// Replaces every name written in the declarations of this implementation — its head, the types
+    /// it gives the associated types, and the type signatures of its members — by the full name it
+    /// stands for. The expressions implementing the members are name-resolved with the rest of the
+    /// program's expressions.
     pub fn resolve_namespace(&mut self, ctx: &mut NameResolutionContext) -> Result<(), Errors> {
         self.qual_pred.resolve_namespace(ctx)?;
 
@@ -558,10 +570,10 @@ impl TraitImpl {
         }
 
         errors.to_result()
-
-        // This function is called only by resolve_namespace_in_declaration, so we don't need to see into expression.
     }
 
+    /// Replaces every type alias written in this implementation's head, in the types it gives the
+    /// associated types, and in the type signatures of its members, by the type it stands for.
     pub fn resolve_type_aliases(&mut self, type_env: &TypeEnv) -> Result<(), Errors> {
         let mut errors = Errors::empty();
         errors.eat_err(self.qual_pred.resolve_type_aliases(type_env));
@@ -574,22 +586,24 @@ impl TraitImpl {
         errors.to_result()
     }
 
-    // Get trait id.
+    /// The trait this implements.
     fn trait_id(&self) -> TraitId {
         self.qual_pred.predicate.trait_id.clone()
     }
 
-    // Get mutable trait id.
+    /// The trait this implements, as the head of this implementation holds it, so that its name can
+    /// be replaced.
     fn trait_id_mut(&mut self) -> &mut TraitId {
         &mut self.qual_pred.predicate.trait_id
     }
 
-    // Get type-scheme of a member implementation.
-    // Here, for example, in case "impl [a: ToString, b: ToString] (a, b): ToString",
-    // this function returns "[a: ToString, b: ToString] (a, b) -> String" as the type of "to_string".
-    //
-    // Users can also write type annotations in trait implementations.
-    // This function trusts and returns the type annotation if the user has written one.
+    /// The type-scheme of a member implementation.
+    /// Here, for example, in case `impl [a : ToString, b : ToString] (a, b) : ToString`,
+    /// this function returns `[a : ToString, b : ToString] (a, b) -> String` as the type of
+    /// `to_string`.
+    ///
+    /// A type signature written for the member in this implementation is trusted and returned as
+    /// the member's type, qualified by the constraints of this implementation's head.
     pub fn member_scheme(&self, member: &Name, trait_defn: &TraitDefn) -> Arc<Scheme> {
         if let Some(qual_ty) = self.member_sigs.get(member) {
             // If type annotation is provided by user, use it.

--- a/src/elaboration/desugar_opaque.rs
+++ b/src/elaboration/desugar_opaque.rs
@@ -92,17 +92,17 @@ impl Program {
         let gv_names: Vec<FullName> = self.global_values.keys().cloned().collect();
 
         // Collect opaque infos for global values that have opaque type variables.
-        let mut targets: Vec<(FullName, Vec<OpaqueInfo>)> = vec![];
+        let mut opaque_global_values: Vec<(FullName, Vec<OpaqueInfo>)> = vec![];
         for gv_name in &gv_names {
             let gv = self.global_values.get(gv_name).unwrap();
             let opaque_infos = collect_opaque_infos(&gv.scm, gv_name);
             if !opaque_infos.is_empty() {
-                targets.push((gv_name.clone(), opaque_infos));
+                opaque_global_values.push((gv_name.clone(), opaque_infos));
             }
         }
 
         // Step 1 & 2: Register opaque TyCons and add constraints to TraitEnv.
-        for (gv_name, opaque_infos) in &targets {
+        for (gv_name, opaque_infos) in &opaque_global_values {
             let scm = self.global_values.get(gv_name).unwrap().scm.clone();
 
             for info in opaque_infos {
@@ -112,7 +112,7 @@ impl Program {
         }
 
         // Step 3: Rewrite type signatures and generate #wrap_opaque GlobalValues.
-        for (gv_name, opaque_infos) in &targets {
+        for (gv_name, opaque_infos) in &opaque_global_values {
             let scm = self.global_values.get(gv_name).unwrap().scm.clone();
             let decl_src = self.global_values.get(gv_name).unwrap().decl_src.clone();
             let new_scm = rewrite_scheme(&scm, opaque_infos);
@@ -463,19 +463,19 @@ fn collect_opaque_infos(scm: &Arc<Scheme>, gv_name: &FullName) -> Vec<OpaqueInfo
 
     opaque_vars
         .into_iter()
-        .map(|opq_var| {
+        .map(|opaque_var| {
             // TyCon kind: gen_var kinds → opaque tyvar kind.
             // E.g., for gen_vars [a : *] and opaque tyvar ?it : *, the TyCon kind is * -> *.
-            let mut tc_kind: Arc<Kind> = opq_var.kind.clone();
-            for gv in gen_vars.iter().rev() {
-                tc_kind = kind_arrow(gv.kind.clone(), tc_kind);
+            let mut tycon_kind: Arc<Kind> = opaque_var.kind.clone();
+            for gen_var in gen_vars.iter().rev() {
+                tycon_kind = kind_arrow(gen_var.kind.clone(), tycon_kind);
             }
-            let tycon_name = FullName::new(&gv_name.to_namespace(), &opq_var.name);
+            let tycon_name = FullName::new(&gv_name.to_namespace(), &opaque_var.name);
             OpaqueInfo {
-                tyvar: opq_var.clone(),
+                tyvar: opaque_var.clone(),
                 tycon: tycon(tycon_name),
                 tycon_vars: gen_vars.clone(),
-                tycon_kind: tc_kind,
+                tycon_kind,
             }
         })
         .collect()
@@ -516,10 +516,10 @@ fn build_opaque_resolutions(
     defn_to_impl: &Substitution,
     src: Option<Span>,
 ) -> Map<FullName, Vec<OpaqueTyConResolution>> {
-    let mut result: Map<FullName, Vec<OpaqueTyConResolution>> = Map::default();
+    let mut resolutions: Map<FullName, Vec<OpaqueTyConResolution>> = Map::default();
     for info in opaque_infos {
         let lhs = defn_to_impl.substitute_type(&info.opaque_tycon_applied());
-        result
+        resolutions
             .entry(info.tycon.name.clone())
             .or_default()
             .push(OpaqueTyConResolution {
@@ -528,7 +528,7 @@ fn build_opaque_resolutions(
                 src: src.clone(),
             });
     }
-    result
+    resolutions
 }
 
 /// Apply a substitution to a scheme's type and remove predicates/equalities on opaque TyVars.
@@ -619,9 +619,10 @@ fn rewrite_impl_scheme(
 
         // Build TyCon application using the impl's type expressions for each type argument.
         let mut ty = type_tycon(&info.tycon);
-        for defn_gv in &info.tycon_vars {
-            let impl_gv_ty = defn_to_impl.substitute_type(&type_from_tyvar(defn_gv.clone()));
-            ty = type_tyapp(ty, impl_gv_ty);
+        for defn_tycon_var in &info.tycon_vars {
+            let impl_tycon_arg_ty =
+                defn_to_impl.substitute_type(&type_from_tyvar(defn_tycon_var.clone()));
+            ty = type_tyapp(ty, impl_tycon_arg_ty);
         }
 
         assert!(sub.merge(&Substitution::single(impl_opaque_name, ty)));

--- a/src/elaboration/desugar_opaque.rs
+++ b/src/elaboration/desugar_opaque.rs
@@ -24,7 +24,8 @@
 //   `to_iter : [?it : Iterator, Item ?it = Elem c] c -> ?it`
 //
 // Step 1: Generate TyCon `ToIter::to_iter::?it` with kind `* -> *`, type args `[c]`.
-//   (The TyCon's type args are the trait's type variables, not the method's own gen_vars.)
+//   (The TyCon's type args are the variables the member's scheme generalizes, the trait's type
+//   variable `c` among them.)
 //
 // Step 2: Add global constraints:
 //   QualPredScheme { gen_vars: [c], pred_constraints: [], pred: ?it c : Iterator }
@@ -76,13 +77,15 @@ use std::sync::Arc;
 ///   tycon_vars = [a]
 ///   tycon_kind = * -> *
 struct OpaqueInfo {
-    // The opaque type variable.
+    /// The opaque type variable, as the scheme writes it.
     tyvar: Arc<TyVar>,
-    // The generated TyCon (e.g., `Std::repeat::?it`).
+    /// The generated TyCon (e.g., `Std::repeat::?it`) that stands in the opaque type variable's
+    /// place.
     tycon: Arc<TyCon>,
-    // Non-opaque gen_vars from the scheme; become the TyCon's type arguments.
+    /// The variables the scheme generalizes, which become the TyCon's type arguments in the order
+    /// they stand here.
     tycon_vars: Vec<Arc<TyVar>>,
-    // Kind of the TyCon (e.g., `* -> *` when there is one type argument of kind `*`).
+    /// Kind of the TyCon (e.g., `* -> *` when there is one type argument of kind `*`).
     tycon_kind: Arc<Kind>,
 }
 
@@ -181,6 +184,10 @@ impl Program {
         }
     }
 
+    /// Declares the generated TyCon of an opaque type variable in the type environment, as a type
+    /// constructor of the opaque variant, taking the type arguments `info` records and holding no
+    /// field. What the TyCon stands for is settled by type-checking, and until then a type written
+    /// in terms of it is a type like any other.
     fn register_opaque_tycon(&mut self, info: &OpaqueInfo) {
         let ti = TyConInfo {
             punched_from: None,
@@ -197,6 +204,13 @@ impl Program {
         self.type_env.add_tycons(new_tycons);
     }
 
+    /// Grants to the generated TyCon of each opaque type variable the constraints `scm` writes on
+    /// that variable, so that a caller who receives the opaque type has what the signature promises
+    /// about it: `[?it : Iterator, Item ?it = a] a -> I64 -> ?it` grants `?it a : Iterator` and
+    /// `Item (?it a) = a`, each generalized over the TyCon's type arguments.
+    ///
+    /// A trait alias in a constraint is resolved first, so that each trait it stands for is granted
+    /// on its own.
     fn add_opaque_constraints(&mut self, scm: &Arc<Scheme>, opaque_infos: &[OpaqueInfo]) {
         // Build a combined substitution mapping ALL opaque tyvars to their TyCons.
         // This is needed for equalities that reference multiple opaque types,
@@ -458,7 +472,7 @@ fn collect_opaque_infos(scm: &Arc<Scheme>, gv_name: &FullName) -> Vec<OpaqueInfo
         }
     }
 
-    // Non-opaque gen_vars become the TyCon's type arguments.
+    // The variables the scheme generalizes become the TyCon's type arguments.
     let gen_vars = scm.gen_vars.clone();
 
     opaque_vars

--- a/src/elaboration/typecheck.rs
+++ b/src/elaboration/typecheck.rs
@@ -959,11 +959,13 @@ impl TypeCheckContext {
         opaque_types: &mut Map<FullName, Vec<OpaqueTyConResolution>>,
     ) {
         let instantiations = self.opaque_instantiations.clone();
-        for (k, v) in instantiations {
-            let fullname_str = k.strip_prefix(WRAP_OPAQUE_TYVAR_PREFIX).unwrap();
+        for (wrap_tyvar_name, instantiated_tyvar) in instantiations {
+            let fullname_str = wrap_tyvar_name
+                .strip_prefix(WRAP_OPAQUE_TYVAR_PREFIX)
+                .unwrap();
             let opaque_tycon_name = FullName::parse(fullname_str).unwrap();
             let rhs = self
-                .substitute_and_reduce_type(&type_from_tyvar(v))
+                .substitute_and_reduce_type(&type_from_tyvar(instantiated_tyvar))
                 .unwrap_or_else(|_| panic!("failed to reduce opaque type rhs"));
             if let Some(resolutions) = opaque_types.get_mut(&opaque_tycon_name) {
                 for resolution in resolutions {

--- a/src/tests/test_opaque_type.rs
+++ b/src/tests/test_opaque_type.rs
@@ -2,12 +2,14 @@ use crate::configuration::Configuration;
 use crate::tests::test_util::{run_source_assert_failed, test_source, test_source_fail};
 
 // ============================================================
-// 1-1. Basic use case tests
+// A declared return type that is opaque, hiding the concrete type the definition gives it
 // ============================================================
 
+/// A chain of iterator combinators is returned under an opaque type, so the caller writes none of
+/// the combinator types. The value is called at two element types, and each call gets the elements
+/// it put in.
 #[test]
 pub fn test_opaque_repeat() {
-    // Use case 1: Iterator combinator return type simplification
     let source = r#"
         module Main;
 
@@ -26,9 +28,11 @@ pub fn test_opaque_repeat() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Several combinators applied in turn build a type that names every one of them; the opaque
+/// return type stands for all of it, and the elements the caller receives are the ones the chain
+/// produces.
 #[test]
 pub fn test_opaque_doubled_evens() {
-    // Use case 2: Multiple combinator chaining (type explosion avoidance)
     let source = r#"
         module Main;
 
@@ -45,9 +49,10 @@ pub fn test_opaque_doubled_evens() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// A trait member declares an opaque return type, constrained by an equality that ties its element
+/// type to the trait's associated type. The one implementation hides its iterator behind it.
 #[test]
 pub fn test_opaque_to_iter() {
-    // Use case 3: Trait method with opaque return type
     let source = r##"
         module Main;
 
@@ -73,9 +78,10 @@ pub fn test_opaque_to_iter() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Two types implement one member whose return type is opaque, each hiding an iterator of its own,
+/// and a call on a value of either type reaches that type's implementation.
 #[test]
 pub fn test_opaque_to_iter_multiple_impls() {
-    // Use case 3 extended: Multiple types implementing the same trait with opaque return
     let source = r##"
         module Main;
 
@@ -110,9 +116,10 @@ pub fn test_opaque_to_iter_multiple_impls() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An opaque type of kind `* -> *` stands for the monad the definition returns, and the caller
+/// reaches it through the `Monad` interface the signature promises, binding one call into the next.
 #[test]
 pub fn test_opaque_higher_kinded() {
-    // Use case 4: Higher-kinded opaque type (Monad)
     let source = r#"
         module Main;
 
@@ -151,9 +158,11 @@ pub fn test_opaque_higher_kinded_without_a_kind_signature() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// One signature carries an ordinary type variable for the iterator it takes and an opaque one for
+/// the iterator it returns, and the element type of the result is written in terms of the element
+/// type of the argument.
 #[test]
 pub fn test_opaque_zip_with_index() {
-    // Use case 5: Opaque type with normal type variable mixed in signature
     let source = r#"
         module Main;
 
@@ -170,9 +179,10 @@ pub fn test_opaque_zip_with_index() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Two opaque types under the same constraints appear in one signature, and each stands for the
+/// concrete type of the component of the returned pair it is written for.
 #[test]
 pub fn test_opaque_partition() {
-    // Use case 6: Multiple opaque types with the same constraints
     let source = r#"
         module Main;
 
@@ -191,9 +201,10 @@ pub fn test_opaque_partition() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An opaque type carrying a trait constraint alone is enough to use the value through that
+/// trait's interface, which is all the caller learns about it.
 #[test]
 pub fn test_opaque_predicate_only() {
-    // Use case 7: Opaque type with predicate only (no equality constraint)
     let source = r#"
         module Main;
 
@@ -212,9 +223,10 @@ pub fn test_opaque_predicate_only() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// The constraints on an opaque type may name an associated type of more than one argument, and
+/// the concrete type the definition gives it has to answer them all.
 #[test]
 pub fn test_opaque_higher_arity_associated_type() {
-    // Use case 8: Higher-arity associated type (Rebuildable pattern)
     let source = r##"
         module Main;
 
@@ -405,14 +417,14 @@ pub fn test_opaque_trait_variable_fixed_by_a_constraint_alone_reached_through_a_
 }
 
 // ============================================================
-// 1-2. Opaque type in impl annotation without type signature should be rejected
+// An opaque type variable named in a type annotation inside a trait member implementation
 // ============================================================
 
+/// The opaque type variable of a member's declared type belongs to the trait definition, and an
+/// implementation that names it in a type annotation of its body is reported as writing a type
+/// variable no scope of its own gives a meaning to.
 #[test]
 pub fn test_opaque_in_impl_annotation() {
-    // Using an opaque type variable in a type annotation inside an impl method
-    // without a type signature should be rejected, because the opaque type variable
-    // is a trait-definition-derived variable not visible in the impl context.
     let source = r##"
         module Main;
 
@@ -439,19 +451,18 @@ pub fn test_opaque_in_impl_annotation() {
 }
 
 // ============================================================
-// 1-2b. Opaque type annotation in impl expression WITH type signature (currently unsupported)
+// An opaque type variable named in a type annotation of an implementation that writes its own
+// type signature
 // ============================================================
 
+/// An implementation that declares its own opaque type variable, such as `?iter`, may name it in
+/// its type signature, and naming it in a type annotation inside the body is reported.
+///
+/// Accepting the annotation asks for the implementation's name for the variable to be carried to
+/// the trait definition's name for it, `?it`, under which the `#wrap_opaque` instantiation that
+/// settles the concrete type is held.
 #[test]
 pub fn test_opaque_in_impl_annotation_with_sig() {
-    // Using an opaque type variable in a type annotation inside an impl method body
-    // is not yet supported, even when the user provides an explicit type signature.
-    //
-    // Supporting this would require mapping the impl's opaque tyvar name (e.g., `?iter`)
-    // to the trait definition's name (e.g., `?it`) so that the type-checker can look up
-    // the corresponding #wrap_opaque instantiation. A prototype was implemented using
-    // expression-level renaming in desugar_opaque.rs, but was reverted as too ad-hoc.
-    // This may be revisited in the future with a cleaner approach.
     let source = r##"
         module Main;
 
@@ -479,14 +490,15 @@ pub fn test_opaque_in_impl_annotation_with_sig() {
 }
 
 // ============================================================
-// 1-2c. Opaque type with user type signature on impl method
+// A type signature written on the implementation of a member whose return type is opaque
 // ============================================================
 
+/// The implementation writes its own type signature, naming the opaque type variable `?iter` where
+/// the trait definition names it `?it`. The resolution recorded for the opaque type constructor is
+/// written in the names of the signature the body is checked against, so the concrete type the
+/// body determines is the one the resolution carries.
 #[test]
 pub fn test_opaque_impl_method_type_sig() {
-    // User provides a type signature on the impl method with different variable names
-    // than the trait definition. This tests that defn_to_impl substitution correctly
-    // uses the impl scheme's variable names (not scm_via_defn's).
     let source = r##"
         module Main;
 
@@ -513,12 +525,12 @@ pub fn test_opaque_impl_method_type_sig() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// The member `my_map` carries a type variable `b` of its own beyond the trait's type variable
+/// `c`, and the implementation's signature names that variable `d`. The left hand side of the
+/// opaque type constructor's resolution is written in `d`, as is the concrete type the body
+/// determines, so the two meet.
 #[test]
 pub fn test_opaque_impl_method_type_sig_renamed_vars() {
-    // The trait method `my_map` has an extra free type variable `b` beyond the trait's
-    // type variable `c`. The user impl renames `b` to `d` in the type signature.
-    // This detects whether defn_to_impl maps via impl_.scm.ty (correct: lhs uses `d`)
-    // vs impl_.scm_via_defn.ty (wrong: lhs uses `b`, mismatching rhs which uses `d`).
     let source = r##"
         module Main;
 
@@ -542,12 +554,13 @@ pub fn test_opaque_impl_method_type_sig_renamed_vars() {
 }
 
 // ============================================================
-// 1-3. Higher-kinded opaque type additional cases
+// An opaque type of a higher kind
 // ============================================================
 
+/// An opaque type of kind `* -> *` constrained by `Functor` is applied to a type argument in the
+/// return type, and the caller maps over what it receives, twice in a row.
 #[test]
 pub fn test_opaque_higher_kinded_functor() {
-    // Higher-kinded opaque with Functor constraint
     let source = r#"
         module Main;
 
@@ -568,7 +581,7 @@ pub fn test_opaque_higher_kinded_functor() {
 }
 
 // ============================================================
-// 1-4. Associated type tests
+// An opaque type constrained by an equality on an associated type
 // ============================================================
 
 #[test]
@@ -709,7 +722,7 @@ pub fn test_opaque_multi_opaque_with_shared_assoc_type() {
 }
 
 // ============================================================
-// 1-5. Multiple calls of the same opaque function
+// Several calls of one value whose return type is opaque
 // ============================================================
 
 #[test]
@@ -757,7 +770,7 @@ pub fn test_opaque_multiple_calls_same_type_args() {
 }
 
 // ============================================================
-// 2-1. V-1: Opaque type variable usage restriction
+// Where an opaque type variable may be written
 // ============================================================
 
 #[test]
@@ -820,7 +833,7 @@ pub fn test_opaque_in_impl_type_param() {
 }
 
 // ============================================================
-// 2-2. V-3: Equality constraint formal parameter checks
+// The formal parameters of an equality constraint on an opaque type
 // ============================================================
 
 #[test]
@@ -880,7 +893,7 @@ pub fn test_opaque_equality_formal_param_in_ty_body() {
 }
 
 // ============================================================
-// 2-3. Opaque type concrete type determination failures
+// An opaque type whose concrete type is left undetermined
 // ============================================================
 
 #[test]
@@ -1270,7 +1283,7 @@ pub fn test_opaque_member_implementation_owes_the_constraint_at_its_own_type() {
 }
 
 // ============================================================
-// 2-4. Opaque type trait constraint not satisfied at use site
+// A use of an opaque type that asks for more than the constraints it carries
 // ============================================================
 
 #[test]
@@ -1294,7 +1307,7 @@ pub fn test_opaque_trait_not_satisfied_at_use_site() {
 }
 
 // ============================================================
-// 2-5. Opaque type on equality RHS
+// An opaque type standing on the right hand side of an equality constraint
 // ============================================================
 
 #[test]
@@ -1497,7 +1510,7 @@ pub fn test_opaque_trait_method_returning_opaque() {
 }
 
 // ============================================================
-// 3. Implementation does not satisfy declared opaque constraints
+// A definition whose body breaks a constraint declared on the opaque return type
 // ============================================================
 
 #[test]

--- a/src/tests/test_opaque_type.rs
+++ b/src/tests/test_opaque_type.rs
@@ -1597,7 +1597,10 @@ pub fn test_opaque_regression_unknown_name_undefined_internal() {
         f = |n| Iterator::range(0, n);
 
         main : IO ();
-        main = pure();
+        main = (
+            eval f(3);
+            pure()
+        );
     "#;
     test_source(&source, Configuration::develop_mode());
 }

--- a/src/tests/test_typecheck_cache.rs
+++ b/src/tests/test_typecheck_cache.rs
@@ -158,18 +158,18 @@ main = (
         let dir = temp.path();
         fs::write(dir.join("main.fix"), BROKEN_IMPLEMENTATION).expect("Failed to write main.fix");
 
-        let (cold_succeeded, cold) = try_build(dir);
+        let (cold_succeeded, cold_stderr) = try_build(dir);
         assert!(
-            !cold_succeeded && cold.contains("`Std::I64 : Std::Iterator` cannot be deduced"),
+            !cold_succeeded && cold_stderr.contains("`Std::I64 : Std::Iterator` cannot be deduced"),
             "the first build must reject the implementation whose body is not an iterator.\nstderr: {}",
-            cold
+            cold_stderr
         );
 
-        let (warm_succeeded, warm) = try_build(dir);
+        let (warm_succeeded, warm_stderr) = try_build(dir);
         assert!(
-            !warm_succeeded && warm.contains("`Std::I64 : Std::Iterator` cannot be deduced"),
+            !warm_succeeded && warm_stderr.contains("`Std::I64 : Std::Iterator` cannot be deduced"),
             "the second build read the cache and accepted the program the first build rejected.\nstderr: {}",
-            warm
+            warm_stderr
         );
     }
 
@@ -182,29 +182,29 @@ main = (
         let dir = temp.path();
         fs::write(dir.join("main.fix"), DEPRECATED_USE).expect("Failed to write main.fix");
 
-        let cold = build(dir);
+        let cold_stderr = build(dir);
         assert!(
-            cold.contains("`Main::old_val` is deprecated"),
+            cold_stderr.contains("`Main::old_val` is deprecated"),
             "the first build must report the deprecated use.\nstderr: {}",
-            cold
+            cold_stderr
         );
         assert!(
-            cold.contains("in \"main.fix\""),
+            cold_stderr.contains("in \"main.fix\""),
             "the first build must attribute the use to the file it is written in.\nstderr: {}",
-            cold
+            cold_stderr
         );
 
-        let warm = build(dir);
+        let warm_stderr = build(dir);
         assert!(
-            warm.contains("`Main::old_val` is deprecated"),
+            warm_stderr.contains("`Main::old_val` is deprecated"),
             "the second build serves `Main::main` from the type-check cache and lost the \
              deprecation warning with it.\nstderr: {}",
-            warm
+            warm_stderr
         );
         assert!(
-            warm.contains("in \"main.fix\""),
+            warm_stderr.contains("in \"main.fix\""),
             "the second build attributed the deprecated use to another file.\nstderr: {}",
-            warm
+            warm_stderr
         );
     }
 }


### PR DESCRIPTION
Refs #335

PR #346 のコードレビューが、変更したファイルの**変更箇所の外**に見つけた清掃をまとめたもの。base はその #346 のブランチなので、#346 の差分は読むときにこの清掃を含まない。

3 つのコミットは、レビューのアスペクトごとに分かれている。いずれも振る舞いを変えない編集だけを含む（コメント、局所束縛の名前、テストの `main` からの参照）。フルスイートはこのブランチで `exit=0`（142 + 1445 件、失敗 0）。

## テストの対象を `main` から参照する

`src/tests/test_opaque_type.rs` の `test_opaque_regression_unknown_name_undefined_internal` は、不透明型を返すグローバル値 `f` を宣言・定義したうえで `main = pure();` としていた。Fix のコンパイラは `main` から到達しない値の elaboration を飛ばせるので、この回帰（`#wrap_opaque` のプレースホルダが `Std::_undefined_internal` の unknown name を起こす）が復活してもテストは緑のままになる。`main` を `eval f(3);` を通る形にした。

由来する規約: CLAUDE.md の「Always reference the thing under test from `main`」。

## 局所束縛を、それが保持するものの名前にする

いずれも 1 つの関数本体に閉じた改名である。

- `src/elaboration/desugar_opaque.rs`: `targets` -> `opaque_global_values`（中身は不透明型変数を持つグローバル値とその情報）、`gv` -> `gen_var` と `defn_gv` / `impl_gv_ty` -> `defn_tycon_var` / `impl_tycon_arg_ty`（このファイルの `gv` は global value を指すので、汎化型変数と語が衝突していた）、`tc_kind` -> `tycon_kind`（`tc` は `TypeCheckContext`）、`opq_var` -> `opaque_var`、`result` -> `resolutions`。
- `src/ast/program.rs`: `ms` / `m` -> `impls` / `impl_`（ファイルの支配的な綴りに合わせた）、`(k, mut v)` -> `(tycon_name, mut resolutions)`、綴り誤り `insntances` -> `instances`。
- `src/elaboration/typecheck.rs`: `(k, v)` -> `(wrap_tyvar_name, instantiated_tyvar)`。
- `src/tests/test_typecheck_cache.rs`: `cold` / `warm` -> `cold_stderr` / `warm_stderr`。

## 変更の周りの項目に doc を付ける

`src/ast/program.rs` の `GlobalValue` のメソッド、`SymbolExpr`、`TypedExpr`、`TraitMemberImpl` の各フィールド、`Program::opaque_types` と `create_trait_member_symbols`；`src/ast/traits.rs` の `TraitImpl` とその 8 つのフィールド・メソッド；`src/elaboration/desugar_opaque.rs` の `register_opaque_tycon` / `add_opaque_constraints` / `OpaqueInfo` のフィールド；`src/tests/test_opaque_type.rs` の 14 本のテスト。`//` を `///` に替え、否定形で書かれていた説明を肯定形に直した。

テストファイルの見出しからは計画の段階番号（`1-2.`, `1-2b.`, `1-3.` など）を外し、対象の機能を名指す見出しにした。CLAUDE.md の「計画の段階名・節番号をコードのコメントやテストの見出しに書かない」に従う。

このコミットは 1 つ、コメントの主張の誤りも直している。`desugar_opaque.rs` の冒頭は、生成される型構築子の型引数を「トレイトの型変数であって、メソッド自身の gen_vars ではない」と述べていた。実際にはメンバのスキームが一般化する変数すべてであり、メンバ自身の変数もそこに入る（`Item ?it = b` の `b` は等式の右辺なので `Scheme::generalize` は落とさない）。

## マージの仕方

このプルリクエストの base は #346 のブランチなので、次のどちらでもよい。

- このプルリクエストを #346 のブランチへマージしてから、#346 を `main` へマージする（`main` へのマージは 1 回）。
- #346 を `main` へマージし、そのブランチを削除する。GitHub は base ブランチが消えたプルリクエストをその base の base（`main`）へ張り替えるので、このプルリクエストは `main` 向けの独立したものになる。
