### PR TITLE
レビュー清掃 (#369): 局所名の綴りと、存在しない関数を指すコメント

### DIFF
--- a/src/ast/program.rs
+++ b/src/ast/program.rs
@@ -1918,9 +1918,8 @@ impl Program {
                 let member_scm = trait_.member_scheme(&member.name, false);
                 let syntactic_member_scm = trait_.member_scheme(&member.name, true);
                 let mut member_impls: Vec<TraitMemberImpl> = vec![];
-                let instances = self.trait_env.impls.get(trait_id);
-                if let Some(insntances) = instances {
-                    for trait_impl in insntances {
+                if let Some(instances) = self.trait_env.impls.get(trait_id) {
+                    for trait_impl in instances {
                         let scm = trait_impl.member_scheme(&member.name, trait_);
                         let scm_via_defn = trait_impl.member_scheme_by_defn(&member.name, trait_);
                         let expr = trait_impl.member_expr(&member.name);

--- a/src/elaboration/mod.rs
+++ b/src/elaboration/mod.rs
@@ -69,7 +69,7 @@ fn elaborate(mut program: Program, config: &Configuration) -> Result<Program, Er
     program.validate_global_value_type_constraints()?;
 
     // Check if all items referred in import statements are defined.
-    // This check should be done after `add_methods` and `create_trait_method_symbols`.
+    // This check should be done after `add_methods` and `create_trait_member_symbols`.
     program.validate_import_statements()?;
 
     // Set and check kinds that appear in type signatures.


### PR DESCRIPTION
Refs #351

PR #369 のコードレビューが、変更したファイルの**変更箇所の外**に見つけた清掃。base はその #369 のブランチなので、#369 の差分は読むときにこの清掃を含まない。

いずれも振る舞いを変えない編集である。フルスイートはこのブランチで `exit=0`（142 + 1438 件、失敗 0）。

## 局所束縛の名前と、その周りの形

`src/ast/program.rs` の `trait_member_symbols`（トレイト環境から各メンバのグローバル値を作る関数）の中で、トレイトの実装の一覧を取り出す部分:

```rust
let instances = self.trait_env.impls.get(trait_id);
if let Some(insntances) = instances {
    for trait_impl in insntances {
```

`insntances` は `instances` の綴り誤りである。加えて、一時変数 `instances` は 1 度しか使われないので、`if let Some(instances) = self.trait_env.impls.get(trait_id)` と 1 行で書ける。綴り誤りは検索に掛からないという実害があり、それを直すついでに変数の寿命も縮めた。

由来する規約: 局所束縛の名前と、可変・一時状態の範囲を狭めること。

## 存在しない関数を指すコメント

`src/elaboration/mod.rs` の `elaborate`（elaboration の各段を順に呼ぶ関数）の中のコメント:

```
// This check should be done after `add_methods` and `create_trait_method_symbols`.
```

`create_trait_method_symbols` という関数は無い。正しくは `create_trait_member_symbols` である。読み手が検索しても見つからない参照になっていた。

由来する規約: 参照は名前で行い、その名前が実在すること。

## マージの仕方

このプルリクエストの base は #369 のブランチなので、次のどちらでもよい。

- このプルリクエストを #369 のブランチへマージしてから、#369 を `main` へマージする（`main` へのマージは 1 回）。
- #369 を `main` へマージし、そのブランチを削除する。GitHub は base ブランチが消えたプルリクエストをその base の base（`main`）へ張り替えるので、このプルリクエストは `main` 向けの独立したものになる。
