### PR TITLE
レビュー清掃 (#401): #373 の修正が触った 2 ファイルの周辺

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -43,7 +43,7 @@ use crate::parse::sourcefile::Span;
 use crate::rc_ir::ast::{FieldPath, RcState, RcTarget, UniqueCheckOperand};
 use crate::rc_ir::leaf_map::boxed_leaf_paths;
 use crate::rc_ir::locality::{ExtCond, ExtShape, LeafCond};
-use crate::rc_ir::provenance::{LeafOrigin, Provenance};
+use crate::rc_ir::provenance::{sole_origin, LeafOrigin, Provenance};
 use inkwell::module::Linkage;
 use inkwell::values::{BasicValue, IntValue, PointerValue};
 use inkwell::{AddressSpace, FloatPredicate, IntPredicate};
@@ -4301,7 +4301,7 @@ impl LLVMGen for InlineLLVMStructGetBody {
             Provenance::build_shape(result_ty, type_env, &|sigma: &FieldPath| {
                 let mut p = vec![field];
                 p.extend_from_slice(sigma);
-                Provenance::leaf(LeafOrigin::Arg(0, p))
+                sole_origin(LeafOrigin::Arg(0, p))
             })
         }
     }
@@ -4419,8 +4419,8 @@ impl LLVMGen for InlineLLVMMakeStructBody {
         // unboxed struct lays out its fields, so field `i`'s boxed leaves carry constructor operand
         // `i` (the path's head is the field index, its tail the position within that field).
         Provenance::build_shape(result_ty, type_env, &|path| match path.split_first() {
-            None => Provenance::leaf(LeafOrigin::Fresh),
-            Some((i, rest)) => Provenance::leaf(LeafOrigin::Arg(*i, rest.to_vec())),
+            None => sole_origin(LeafOrigin::Fresh),
+            Some((i, rest)) => sole_origin(LeafOrigin::Arg(*i, rest.to_vec())),
         })
     }
 
@@ -4798,7 +4798,7 @@ impl LLVMGen for InlineLLVMStructPunchBody {
             return Provenance::fresh_under(result_ty, type_env, &[PUNCHED_STRUCT_FIELD]);
         }
         Provenance::build_shape(result_ty, type_env, &|path| {
-            Provenance::leaf(LeafOrigin::Arg(0, self.arg_leaf_path(path)))
+            sole_origin(LeafOrigin::Arg(0, self.arg_leaf_path(path)))
         })
     }
 
@@ -5029,9 +5029,9 @@ fn replaced_field_prov(
             .split_first()
             .expect("a boxed leaf of an unboxed struct has a non-empty path");
         if *field == field_idx {
-            Provenance::leaf(LeafOrigin::Arg(value_arg, rest.to_vec()))
+            sole_origin(LeafOrigin::Arg(value_arg, rest.to_vec()))
         } else {
-            Provenance::leaf(LeafOrigin::Arg(struct_arg, path.clone()))
+            sole_origin(LeafOrigin::Arg(struct_arg, path.clone()))
         }
     })
 }
@@ -6111,8 +6111,8 @@ impl LLVMGen for InlineLLVMMakeUnionBody {
         // its tail the position within that variant's payload.
         let active = self.variant_index();
         Provenance::build_shape(result_ty, type_env, &|path| match path.split_first() {
-            None => Provenance::leaf(LeafOrigin::Fresh),
-            Some((k, rest)) if *k == active => Provenance::leaf(LeafOrigin::Arg(0, rest.to_vec())),
+            None => sole_origin(LeafOrigin::Fresh),
+            Some((k, rest)) if *k == active => sole_origin(LeafOrigin::Arg(0, rest.to_vec())),
             Some(_) => Set::default(),
         })
     }
@@ -6304,7 +6304,7 @@ impl LLVMGen for InlineLLVMUnionAsBody {
             Provenance::build_shape(result_ty, type_env, &|sigma: &FieldPath| {
                 let mut p = vec![variant];
                 p.extend_from_slice(sigma);
-                Provenance::leaf(LeafOrigin::Arg(0, p))
+                sole_origin(LeafOrigin::Arg(0, p))
             })
         }
     }

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -45,9 +45,10 @@ use crate::rc_ir::ast::{
     FieldPath, FuncRef, MatchArm, Ownership, OwnershipShape, RcExpr, RcExprNode, RcFunc,
     RcGlobalInit, RcProgram, RcRhs, RcState, RcVar, VarPath,
 };
+use crate::rc_ir::leaf_map::boxed_leaf_paths;
 use crate::rc_ir::ownership::{
-    acted_unit_keys, all_owned_units, boxed_leaves, collect_consumes, destructure_consumes, origin,
-    rc_units, rhs_consumes, truncate_to_unit, unit_key, units_under, VarTable,
+    acted_unit_keys, all_owned_units, collect_consumes, destructure_consumes, origin, rc_units,
+    rhs_consumes, truncate_to_unit, unit_key, units_under, VarTable,
 };
 use crate::rc_ir::rename::fresh_rename_function;
 use std::sync::Arc;
@@ -132,7 +133,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
         if let Some(bref) = borrow_versions.get(&func.name) {
             let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
             for p in &func.params {
-                for leaf in boxed_leaves(&p.ty, type_env) {
+                for leaf in boxed_leaf_paths(&p.ty, type_env) {
                     if ownerships.own.contains(&(p.name.clone(), leaf.clone())) {
                         let unit = truncate_to_unit(&p.ty, &leaf, type_env);
                         owned_units.insert((rename[&p.name].clone(), unit));
@@ -256,7 +257,7 @@ fn borrow_funcref(name: &FuncRef) -> FuncRef {
 /// Whether any of a function's parameter leaves is borrowable (not in the inferred owned set).
 fn func_has_borrowable_param(func: &RcFunc, ownerships: &Ownerships, type_env: &TypeEnv) -> bool {
     func.params.iter().any(|p| {
-        boxed_leaves(&p.ty, type_env)
+        boxed_leaf_paths(&p.ty, type_env)
             .iter()
             .any(|leaf| !ownerships.own.contains(&(p.name.clone(), leaf.clone())))
     })

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -388,9 +388,13 @@ fn as_arg_projection(sources: &Set<LeafOrigin>) -> Option<(usize, FieldPath)> {
     if sources.len() != 1 {
         return None;
     }
-    match sources.iter().next() {
-        Some(LeafOrigin::Arg(j, p)) => Some((*j, p.clone())),
-        _ => None,
+    match sources
+        .iter()
+        .next()
+        .expect("a one-element set has an element")
+    {
+        LeafOrigin::Arg(j, p) => Some((*j, p.clone())),
+        LeafOrigin::Fresh | LeafOrigin::Unknown => None,
     }
 }
 

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -99,7 +99,7 @@ fn collect_bindings(node: &RcExprNode, vars: &mut VarTable) {
     match node.expr.as_ref() {
         RcExpr::Ret(_) => {}
         RcExpr::Let(x, rhs, k) => {
-            let def = match rhs {
+            let binding = match rhs {
                 RcRhs::Var(y) => Binding::Move(y.clone()),
                 RcRhs::Llvm(llvm_gen, args) => {
                     Binding::Llvm(llvm_gen.clone(), args.clone(), x.ty.clone())
@@ -124,7 +124,7 @@ fn collect_bindings(node: &RcExprNode, vars: &mut VarTable) {
                     Binding::Join(arm_results)
                 }
             };
-            vars.bindings.insert(x.name.clone(), def);
+            vars.bindings.insert(x.name.clone(), binding);
             vars.var_tys.insert(x.name.clone(), x.ty.clone());
             collect_bindings(k, vars);
         }
@@ -252,23 +252,12 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             // The arms bind their values to one variable, so a path into it is a path into each of
             // them. Arms that all reach the same object leave the value exact.
             let mut candidates = Set::default();
-            for r in arm_results {
-                for p in origin(vars, type_env, &r.name, path).candidates() {
+            for arm_result in arm_results {
+                for p in origin(vars, type_env, &arm_result.name, path).candidates() {
                     candidates.insert(p.clone());
                 }
             }
-            match candidates.len() {
-                1 => Origin::Exactly(
-                    candidates
-                        .into_iter()
-                        .next()
-                        .expect("a one-element set has an element"),
-                ),
-                _ => Origin::Join {
-                    identity: (var.clone(), path.to_vec()),
-                    candidates,
-                },
-            }
+            Origin::of_candidates(candidates, &(var.clone(), path.to_vec()))
         }
         Some(Binding::Llvm(llvm_gen, args, result_ty)) => {
             // Constructing an unboxed union lays its payload in place, so the whole union's root is
@@ -457,7 +446,7 @@ pub(crate) fn destructure_consumes(
     if container.ty.is_box(type_env) {
         return leaves;
     }
-    let named: Set<usize> = fields.iter().map(|(i, _)| *i).collect();
+    let named_fields: Set<usize> = fields.iter().map(|(i, _)| *i).collect();
     leaves
         .into_iter()
         .filter(|leaf| {
@@ -465,7 +454,7 @@ pub(crate) fn destructure_consumes(
             let field = leaf
                 .first()
                 .expect("a boxed leaf of an unboxed container has a non-empty path");
-            !named.contains(field)
+            !named_fields.contains(field)
         })
         .collect()
 }
@@ -500,11 +489,11 @@ pub(crate) fn rhs_consumes<F: Fn(&RcVar, &FieldPath) -> bool>(
                 for leaf in boxed_leaves(&a.ty, type_env) {
                     // `i` ranges over the arguments and `args.len() <= params.len()` (no over-
                     // application), so `params[i]` is in range.
-                    let owns_pos = match &callee_params {
+                    let is_owning_position = match &callee_params {
                         Some(params) => owns(&params[i], &leaf),
                         None => true,
                     };
-                    if owns_pos {
+                    if is_owning_position {
                         out.push((a.name.clone(), leaf));
                     }
                 }
@@ -795,8 +784,8 @@ mod tests {
     /// the argument's index and path.
     #[test]
     fn a_lone_arg_is_a_projection() {
-        let ls = Provenance::leaf(LeafOrigin::Arg(1, vec![0]));
-        assert_eq!(as_arg_projection(&ls), Some((1, vec![0])));
+        let leaf_srcs = Provenance::leaf(LeafOrigin::Arg(1, vec![0]));
+        assert_eq!(as_arg_projection(&leaf_srcs), Some((1, vec![0])));
     }
 
     /// A result leaf that is the argument on one path and a new value on another aliases neither:
@@ -804,16 +793,16 @@ mod tests {
     /// projection would drop the consume without the alias, releasing one object twice.
     #[test]
     fn an_arg_joined_with_another_source_is_not_a_projection() {
-        let ls = sources(vec![LeafOrigin::Fresh, LeafOrigin::Arg(0, vec![])]);
-        assert_eq!(as_arg_projection(&ls), None);
+        let leaf_srcs = sources(vec![LeafOrigin::Fresh, LeafOrigin::Arg(0, vec![])]);
+        assert_eq!(as_arg_projection(&leaf_srcs), None);
     }
 
     /// A result leaf that may come from either of two arguments aliases neither: a projection names
     /// one argument, and here the choice would fall to whichever of the two the set yields first.
     #[test]
     fn one_of_two_args_is_not_a_projection() {
-        let ls = sources(vec![LeafOrigin::Arg(0, vec![]), LeafOrigin::Arg(1, vec![])]);
-        assert_eq!(as_arg_projection(&ls), None);
+        let leaf_srcs = sources(vec![LeafOrigin::Arg(0, vec![]), LeafOrigin::Arg(1, vec![])]);
+        assert_eq!(as_arg_projection(&leaf_srcs), None);
     }
 
     /// A leaf the op itself produced — a fresh object, or one of unknown origin — aliases no
@@ -851,9 +840,9 @@ mod tests {
     /// A table of the given bindings, with every named variable also a known local.
     fn table(bindings: Vec<(&str, Binding)>) -> VarTable {
         let mut vars = VarTable::empty();
-        for (name, b) in bindings {
+        for (name, binding) in bindings {
             let v = var(name);
-            vars.bindings.insert(v.name.clone(), b);
+            vars.bindings.insert(v.name.clone(), binding);
             vars.var_tys.insert(v.name, v.ty);
         }
         vars

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -784,7 +784,7 @@ mod tests {
     use crate::fixstd::builtin::make_i64_ty;
     use crate::misc::Set;
     use crate::rc_ir::ast::{RcVar, VarPath};
-    use crate::rc_ir::provenance::{sole_origin, LeafOrigin, Provenance};
+    use crate::rc_ir::provenance::{sole_origin, LeafOrigin};
 
     /// The sources of one result leaf, as `result_prov` declares them.
     fn sources(srcs: Vec<LeafOrigin>) -> Set<LeafOrigin> {

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -455,7 +455,7 @@ pub(crate) fn destructure_consumes(
     fields: &[(usize, RcVar)],
     type_env: &TypeEnv,
 ) -> Vec<FieldPath> {
-    let leaves = boxed_leaves(&container.ty, type_env);
+    let leaves = boxed_leaf_paths(&container.ty, type_env);
     if container.ty.is_box(type_env) {
         return leaves;
     }
@@ -499,7 +499,7 @@ pub(crate) fn rhs_consumes<F: Fn(&RcVar, &FieldPath) -> bool>(
             // callee owns every position.
             let callee_params = resolve_callee_params(callee, vars, prog);
             for (i, a) in args.iter().enumerate() {
-                for leaf in boxed_leaves(&a.ty, type_env) {
+                for leaf in boxed_leaf_paths(&a.ty, type_env) {
                     // `i` ranges over the arguments and `args.len() <= params.len()` (no over-
                     // application), so `params[i]` is in range.
                     let is_owning_position = match &callee_params {
@@ -519,7 +519,7 @@ pub(crate) fn rhs_consumes<F: Fn(&RcVar, &FieldPath) -> bool>(
                 if llvm_gen.borrows_operand(i, &arg_tys, type_env) {
                     continue;
                 }
-                for leaf in boxed_leaves(&a.ty, type_env) {
+                for leaf in boxed_leaf_paths(&a.ty, type_env) {
                     // An argument leaf that the op passes through to its result is not consumed;
                     // anything else at an owning position is moved into the op.
                     if !passthrough.contains(&(i, leaf.clone())) {
@@ -584,22 +584,16 @@ fn push_boxed_leaves(
     type_env: &TypeEnv,
     out: &mut Vec<VarPath>,
 ) {
-    for p in boxed_leaves(ty, type_env) {
+    for p in boxed_leaf_paths(ty, type_env) {
         out.push((var.clone(), p));
     }
-}
-
-/// The paths of every boxed leaf of a type: the whole value if boxed, the capture of a closure, or
-/// each boxed leaf of an unboxed aggregate.
-pub(crate) fn boxed_leaves(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath> {
-    boxed_leaf_paths(ty, type_env)
 }
 
 // --- reference-counting units ---
 
 /// The reference-counting units of a value's type: the capture of a closure, or each unit root
 /// (`is_rc_unit_root`) — a boxed value, an unboxed union, or a punched array — reached by descending
-/// its unboxed structs/tuples. Unlike `boxed_leaves`, it stops at a unit root rather than expanding it
+/// its unboxed structs/tuples. Unlike `boxed_leaf_paths`, it stops at a unit root rather than expanding it
 /// into the inner boxed leaves (e.g. an unboxed union is one unit, since only its active variant is
 /// live and a refcount operation must dispatch on the tag rather than name a variant's leaf).
 pub(crate) fn rc_units(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath> {

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -780,7 +780,7 @@ mod tests {
     use crate::fixstd::builtin::make_i64_ty;
     use crate::misc::Set;
     use crate::rc_ir::ast::{RcVar, VarPath};
-    use crate::rc_ir::provenance::{LeafOrigin, Provenance};
+    use crate::rc_ir::provenance::{sole_origin, LeafOrigin, Provenance};
 
     /// The sources of one result leaf, as `result_prov` declares them.
     fn sources(srcs: Vec<LeafOrigin>) -> Set<LeafOrigin> {
@@ -791,7 +791,7 @@ mod tests {
     /// the argument's index and path.
     #[test]
     fn a_lone_arg_is_a_projection() {
-        let leaf_srcs = Provenance::leaf(LeafOrigin::Arg(1, vec![0]));
+        let leaf_srcs = sole_origin(LeafOrigin::Arg(1, vec![0]));
         assert_eq!(as_arg_projection(&leaf_srcs), Some((1, vec![0])));
     }
 
@@ -816,14 +816,8 @@ mod tests {
     /// argument.
     #[test]
     fn a_produced_leaf_is_not_a_projection() {
-        assert_eq!(
-            as_arg_projection(&Provenance::leaf(LeafOrigin::Fresh)),
-            None
-        );
-        assert_eq!(
-            as_arg_projection(&Provenance::leaf(LeafOrigin::Unknown)),
-            None
-        );
+        assert_eq!(as_arg_projection(&sole_origin(LeafOrigin::Fresh)), None);
+        assert_eq!(as_arg_projection(&sole_origin(LeafOrigin::Unknown)), None);
     }
 
     /// A leaf with no source at all — the result of `_undefined_internal`, which aborts — aliases no

--- a/src/rc_ir/print.rs
+++ b/src/rc_ir/print.rs
@@ -81,7 +81,7 @@ fn var_to_string(var: &RcVar, ann: Annotations) -> String {
             let prov = provs.get(&var.name).unwrap_or_else(|| {
                 unreachable!("no provenance recorded for `{}`", var.name.to_string())
             });
-            format!(" [{}]", prov.to_string())
+            format!(" [{}]", prov)
         }
         None => String::new(),
     };

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -59,6 +59,13 @@ pub enum LeafOrigin {
 /// branch join, empty for an absent union variant (the bottom of the lattice).
 pub type LeafOrigins = Set<LeafOrigin>;
 
+/// The origins of a leaf that has just the one.
+pub fn sole_origin(src: LeafOrigin) -> LeafOrigins {
+    let mut origins = Set::default();
+    origins.insert(src);
+    origins
+}
+
 /// The provenance of a whole value: the source of each of its boxed leaves.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct Provenance(LeafMap<LeafOrigins>);
@@ -67,13 +74,6 @@ impl Provenance {
     /// A value with no boxed leaf (a scalar or a fieldless aggregate).
     pub fn empty() -> Provenance {
         Provenance(LeafMap::empty())
-    }
-
-    /// The singleton leaf-source `{src}`.
-    pub fn leaf(src: LeafOrigin) -> LeafOrigins {
-        let mut s = Set::default();
-        s.insert(src);
-        s
     }
 
     /// The source of each boxed leaf of a value of type `ty`, keyed by its path. `leaf` is called once
@@ -88,7 +88,7 @@ impl Provenance {
 
     /// The provenance whose every boxed leaf is `src`.
     pub fn uniform(ty: &Arc<TypeNode>, type_env: &TypeEnv, src: LeafOrigin) -> Provenance {
-        Provenance(LeafMap::uniform(ty, type_env, Provenance::leaf(src)))
+        Provenance(LeafMap::uniform(ty, type_env, sole_origin(src)))
     }
 
     /// The provenance whose every boxed leaf is bottom (the empty set) — an absent union variant.
@@ -107,7 +107,7 @@ impl Provenance {
     /// input `arg_index` carried through unchanged.
     pub fn arg_passthrough(ty: &Arc<TypeNode>, type_env: &TypeEnv, arg_index: usize) -> Provenance {
         Provenance::build_shape(ty, type_env, &|path: &FieldPath| {
-            Provenance::leaf(LeafOrigin::Arg(arg_index, path.clone()))
+            sole_origin(LeafOrigin::Arg(arg_index, path.clone()))
         })
     }
 
@@ -193,10 +193,7 @@ impl Provenance {
 
     /// Give every boxed leaf under `path` the source `src`. An empty path covers the whole value.
     fn set_leaves_under(&self, path: &[usize], src: LeafOrigin) -> Provenance {
-        Provenance(
-            self.0
-                .map_leaves_under(path, |_| Provenance::leaf(src.clone())),
-        )
+        Provenance(self.0.map_leaves_under(path, |_| sole_origin(src.clone())))
     }
 
     /// Demote every boxed leaf under `path` to `Unknown` (the effect of duplicating the reference with a
@@ -886,7 +883,7 @@ mod tests {
 
     /// A single boxed value's provenance: one leaf at the root path.
     fn boxed(src: LeafOrigin) -> Provenance {
-        Provenance([(vec![], Provenance::leaf(src))].into_iter().collect())
+        Provenance([(vec![], sole_origin(src))].into_iter().collect())
     }
     /// A boxed value produced where it is bound, so nothing else holds a reference to it.
     fn fresh() -> Provenance {

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -200,17 +200,20 @@ impl Provenance {
         self.set_leaves_under(path, LeafOrigin::Unknown)
     }
 
+}
+
+impl std::fmt::Display for Provenance {
     /// A readable one-line rendering, for the RC IR dump: a value with no boxed leaf as `unboxed`, a
     /// boxed value (one leaf at the root) as its source, and anything else as its leaves rendered
     /// `π=source`, sorted by path, inside braces.
-    pub fn to_string(&self) -> String {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0.is_empty() {
-            return "unboxed".to_string();
+            return write!(f, "unboxed");
         }
         if self.0.len() == 1 {
             let (path, origins) = self.0.iter().next().unwrap();
             if path.is_empty() {
-                return leaf_source_to_string(origins);
+                return write!(f, "{}", leaf_source_to_string(origins));
             }
         }
         let mut entries: Vec<(&FieldPath, &LeafOrigins)> = self.0.iter().collect();
@@ -223,7 +226,7 @@ impl Provenance {
             })
             .collect::<Vec<_>>()
             .join(", ");
-        format!("{{{}}}", inner)
+        write!(f, "{{{}}}", inner)
     }
 }
 

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -877,7 +877,9 @@ pub fn analyze_program(prog: &RcProgram, type_env: &TypeEnv) -> ProvenanceAnalys
 
 #[cfg(test)]
 mod tests {
-    use super::{join_envs, resolve, LeafOrigin, Provenance, SharingVerdict, Uniqueness};
+    use super::{
+        join_envs, resolve, sole_origin, LeafOrigin, Provenance, SharingVerdict, Uniqueness,
+    };
     use crate::ast::name::FullName;
     use crate::misc::{Map, Set};
 

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -204,7 +204,6 @@ impl Provenance {
     fn demote(&self, path: &[usize]) -> Provenance {
         self.set_leaves_under(path, LeafOrigin::Unknown)
     }
-
 }
 
 impl std::fmt::Display for Provenance {

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -23,10 +23,10 @@
 //! `result_prov` and composed with the operands, and branches join by set union. Each function's
 //! effect — its result provenance, symbolic in its parameters — is computed to a fixed point (so
 //! recursion converges) and substituted at a direct call site; an indirect call is conservatively
-//! `Unknown`. A `Retain` demotes the retained variable's own leaves. Demoting the *other* variables that
-//! alias the same object — one reached by projecting the same unboxed-aggregate leaf — needs the
-//! shared object-identity (`root`) analysis, which the borrow-inference pass introduces; the demotion
-//! becomes root-based then.
+//! `Unknown`. A `Retain` demotes the retained variable's own leaves. The *other* variables that alias
+//! the same object — one reached by projecting the same unboxed-aggregate leaf — keep their
+//! provenance, since telling those aliases apart takes the object identity `rc_ir::ownership::origin`
+//! computes, which this pass does not read.
 
 use crate::ast::inline_llvm::LLVMGen;
 use crate::ast::name::FullName;
@@ -116,8 +116,8 @@ impl Provenance {
     }
 
     /// The origins recorded for the boxed leaf at path `π`. `None` where `π` is not a boxed leaf of
-    /// this value — a scalar, or an aggregate queried at a non-leaf path such as its root `[]` (which
-    /// `root` does to test whether the whole value is a single boxed leaf). A recorded `⊥` is the
+    /// this value — a scalar, or an aggregate queried at a non-leaf path such as its root `[]`, so a
+    /// query at the root answers whether the whole value is a single boxed leaf. A recorded `⊥` is the
     /// empty set, which is a different answer: it is the bottom of the lattice and resolves to
     /// `Unique`.
     pub fn leaf_origins_at(&self, path: &[usize]) -> Option<&LeafOrigins> {
@@ -164,14 +164,14 @@ impl Provenance {
                             )
                         });
                         // A declared `Arg(j, σ)` names a boxed leaf of operand `j`.
-                        let leaf = operand.leaf_origins_at(arg_path).unwrap_or_else(|| {
+                        let operand_origins = operand.leaf_origins_at(arg_path).unwrap_or_else(|| {
                             unreachable!(
                                 "a declaration names input {} at {:?}, which is not a boxed leaf of it",
                                 j, arg_path
                             )
                         });
-                        for s in leaf {
-                            out.insert(s.clone());
+                        for operand_src in operand_origins {
+                            out.insert(operand_src.clone());
                         }
                     }
                 }
@@ -262,7 +262,9 @@ impl Provenance {
 /// leaf sourced from several places is `Unique` only when every source is.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum SharingVerdict {
+    /// The leaf's reference is the only one there is, established at compile time.
     Unique,
+    /// How widely the leaf is shared is settled at run time, by reading its reference count.
     Dynamic,
 }
 
@@ -272,9 +274,9 @@ pub enum SharingVerdict {
 pub struct Uniqueness(LeafKey<SharingVerdict>);
 
 impl Uniqueness {
-    /// The `SharingVerdict` of the boxed leaf at path `π`. `π` is always a boxed leaf of this shape: the only
-    /// caller (`resolve_leaf`) resolves an `Arg`'s path, which addresses a boxed leaf of the input's
-    /// type — so a miss is a malformed provenance, not a case to default away.
+    /// The `SharingVerdict` of the boxed leaf at path `π`. `π` is always a boxed leaf of this shape:
+    /// it comes from an `Arg`, which addresses a boxed leaf of the input's type, so a miss is a
+    /// malformed provenance and aborts.
     fn verdict_at(&self, path: &[usize]) -> SharingVerdict {
         self.0.at(path)
     }
@@ -316,7 +318,7 @@ fn resolve_leaf(origins: &LeafOrigins, inputs: &[Uniqueness]) -> SharingVerdict 
 }
 
 /// Resolve a provenance against the uniqueness of its function's inputs, mapping each boxed leaf to
-/// its `SharingVerdict` verdict. `inputs` must give the uniqueness of every input the provenance's `Arg`
+/// its `SharingVerdict`. `inputs` must give the uniqueness of every input the provenance's `Arg`
 /// leaves name — a parameter per index, plus the capture past them (an unspecialized function's are
 /// all `Dynamic`). A provenance with no `Arg` leaf (e.g. an all-`Unknown` one) references none, so it
 /// needs no inputs.
@@ -372,6 +374,8 @@ struct Interpreter<'a> {
 }
 
 impl<'a> Interpreter<'a> {
+    /// An interpreter for one function or global initializer, with every table it records into
+    /// empty. `func_result_provs` is the whole program's effects, which a direct call composes with.
     fn new(type_env: &'a TypeEnv, func_result_provs: &'a Map<FuncRef, Provenance>) -> Self {
         Interpreter {
             type_env,
@@ -429,6 +433,9 @@ impl<'a> Interpreter<'a> {
         grow_stack(|| self.interpret_inner(node, env))
     }
 
+    /// The body of `interpret`: each construct records what it binds and hands the environment on to
+    /// its continuation, and a `Ret` ends the walk with the provenance of the value it names.
+    /// `interpret` wraps this so that a deeply nested body does not exhaust the stack.
     fn interpret_inner(
         &mut self,
         node: &RcExprNode,
@@ -871,22 +878,27 @@ pub fn analyze_program(prog: &RcProgram, type_env: &TypeEnv) -> ProvenanceAnalys
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{join_envs, resolve, LeafOrigin, Provenance, SharingVerdict, Uniqueness};
+    use crate::ast::name::FullName;
+    use crate::misc::{Map, Set};
 
-    // A single boxed value's provenance: one leaf at the root path.
+    /// A single boxed value's provenance: one leaf at the root path.
     fn boxed(src: LeafOrigin) -> Provenance {
         Provenance([(vec![], Provenance::leaf(src))].into_iter().collect())
     }
+    /// A boxed value produced where it is bound, so nothing else holds a reference to it.
     fn fresh() -> Provenance {
         boxed(LeafOrigin::Fresh)
     }
+    /// A boxed value of unknown sharing.
     fn unknown() -> Provenance {
         boxed(LeafOrigin::Unknown)
     }
+    /// A boxed value carried through unchanged from input `i`'s leaf at `path`.
     fn arg(i: usize, path: Vec<usize>) -> Provenance {
         boxed(LeafOrigin::Arg(i, path))
     }
-    // An unboxed aggregate: each child's leaves keyed under the child's field index.
+    /// An unboxed aggregate: each child's leaves keyed under the child's field index.
     fn agg(children: Vec<Provenance>) -> Provenance {
         let mut leaves = vec![];
         for (i, child) in children.iter().enumerate() {
@@ -898,11 +910,13 @@ mod tests {
         }
         Provenance(leaves.into_iter().collect())
     }
-    // A resolved uniqueness from its `(path, verdict)` leaves.
+    /// A resolved uniqueness from its `(path, verdict)` leaves.
     fn uniq(leaves: Vec<(Vec<usize>, SharingVerdict)>) -> Uniqueness {
         Uniqueness(leaves.into_iter().collect())
     }
 
+    /// A leaf reached by two branches carries both branches' sources, so an answer read off it holds
+    /// on either path — picking one of them would claim a value is unique where one branch shares it.
     #[test]
     fn join_unions_leaf_sources() {
         let joined = fresh().join(&unknown());
@@ -912,6 +926,8 @@ mod tests {
         assert_eq!(origins.len(), 2);
     }
 
+    /// A retain names one leaf of an aggregate, so only that leaf becomes shared: a sibling boxed
+    /// value the retain never touched stays uniquely owned.
     #[test]
     fn demote_only_the_named_leaf() {
         // `(fresh, fresh)`, demoting child 0, leaves child 1 fresh.
@@ -919,18 +935,23 @@ mod tests {
         assert_eq!(a.demote(&[0]), agg(vec![unknown(), fresh()]));
     }
 
+    /// A retain of a whole value reaches every leaf beneath it, whatever each leaf's source was.
     #[test]
     fn demote_empty_path_demotes_whole_value() {
         let a = agg(vec![fresh(), arg(0, vec![])]);
         assert_eq!(a.demote(&[]), agg(vec![unknown(), unknown()]));
     }
 
+    /// An operation declared to pass an input through reports the sharing of whatever was actually
+    /// supplied there, so a freshly produced operand comes out fresh.
     #[test]
     fn compose_substitutes_arg_with_operand_leaf() {
         // A declaration `arg0` composed with operand 0 = `fresh` yields `fresh`.
         assert_eq!(arg(0, vec![]).compose(&[fresh()]), fresh());
     }
 
+    /// A declaration may name a leaf inside an operand rather than the whole of it, and composition
+    /// descends to that leaf — the case of an op that returns a field of an unboxed argument.
     #[test]
     fn compose_substitutes_arg_through_a_subpath() {
         // A declaration `arg0.1` composed with operand 0 = `(unboxed, fresh)` yields `fresh`.
@@ -938,6 +959,8 @@ mod tests {
         assert_eq!(arg(0, vec![1]).compose(&[operand]), fresh());
     }
 
+    /// Composition substitutes the `Arg` symbols of a declaration and leaves its other sources
+    /// standing, so a leaf declared to come from either an allocation or an input reports both.
     #[test]
     fn compose_keeps_fresh_and_unknown_and_unions_with_arg() {
         // `{fresh | arg1}` (a union-mod-style phi) composed with operand 1 = `dyn` yields
@@ -953,6 +976,8 @@ mod tests {
         assert_eq!(out.len(), 2);
     }
 
+    /// A leaf of an aggregate is addressed by its own path, so a reader that knows where a boxed
+    /// value sits inside an unboxed value reaches its sources directly.
     #[test]
     fn leaf_at_navigates_to_the_boxed_leaf() {
         let a = agg(vec![Provenance::empty(), arg(1, vec![0])]);
@@ -962,6 +987,8 @@ mod tests {
             .contains(&LeafOrigin::Arg(1, vec![0])));
     }
 
+    /// Reading a child out of an aggregate — a destructured field, or an unboxed union's payload —
+    /// yields that child's own provenance, keyed from the child's root.
     #[test]
     fn project_reads_an_aggregate_child() {
         let a = agg(vec![fresh(), unknown()]);
@@ -969,10 +996,11 @@ mod tests {
         assert_eq!(a.project(1), unknown());
     }
 
+    /// A scalar, an empty aggregate, and an all-unboxed aggregate share one representation — the
+    /// empty map — so no recorded aggregate structure can disagree with the type, and a join of two
+    /// such values stays that one representation.
     #[test]
     fn a_fieldless_value_is_the_empty_map() {
-        // A scalar, an empty aggregate, and an all-unboxed aggregate share one representation — the
-        // empty map — so there is no aggregate structure that could disagree with the type.
         assert_eq!(agg(vec![]), Provenance::empty());
         assert_eq!(
             agg(vec![Provenance::empty(), Provenance::empty()]),
@@ -984,10 +1012,10 @@ mod tests {
         );
     }
 
+    /// The rendering a dump reader sees tells the four shapes apart: a fieldless value as `unboxed`,
+    /// a bottom leaf as `_`, a boxed value as its source, and an aggregate as its leaves by path.
     #[test]
     fn to_string_renders_leaves() {
-        // A fieldless value is `unboxed`; a boxed value shows its source (a bottom leaf as `_`);
-        // an aggregate's leaves are keyed by path inside braces.
         assert_eq!(Provenance::empty().to_string(), "unboxed");
         let bottom = Provenance([(vec![], Set::default())].into_iter().collect());
         assert_eq!(bottom.to_string(), "_");
@@ -998,6 +1026,9 @@ mod tests {
         );
     }
 
+    /// Where a match's arms merge, a variable live on both sides takes both arms' sources, and an
+    /// arm-local binding is carried through untouched — the environment is joined variable by
+    /// variable rather than one arm's winning.
     #[test]
     fn join_envs_is_pointwise_and_keeps_one_sided_bindings() {
         let x = FullName::local("x");
@@ -1019,10 +1050,11 @@ mod tests {
         assert_eq!(joined[&z], unknown());
     }
 
+    /// A resolved uniqueness reflects the boxed leaves alone, so a specialization keyed on it treats
+    /// two values alike however their unboxed structure nests.
     #[test]
     fn resolve_keys_only_the_boxed_leaves() {
-        // A boxed-leaf-free value resolves to the empty map, so a uniqueness key reflects only the
-        // boxed leaves and same-typed values key alike whatever their unboxed structure.
+        // A boxed-leaf-free value resolves to the empty map.
         assert_eq!(resolve(&agg(vec![]), &[]), uniq(vec![]));
         assert_eq!(
             resolve(&agg(vec![Provenance::empty(), Provenance::empty()]), &[]),

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -91,6 +91,11 @@ impl Provenance {
         Provenance(LeafMap::uniform(ty, type_env, Provenance::leaf(src)))
     }
 
+    /// The provenance whose every boxed leaf is bottom (the empty set) — an absent union variant.
+    pub fn uniform_bottom(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Provenance {
+        Provenance::build_shape(ty, type_env, &|_| Set::default())
+    }
+
     /// The provenance of the result of an operation that produces one uniquely owned value among
     /// values of unknown sharing: every boxed leaf under `path` is `Fresh`, every other leaf `Unknown`.
     pub fn fresh_under(ty: &Arc<TypeNode>, type_env: &TypeEnv, path: &[usize]) -> Provenance {
@@ -250,13 +255,6 @@ fn leaf_source_to_string(origins: &LeafOrigins) -> String {
         .collect();
     parts.sort();
     parts.join(" | ")
-}
-
-impl Provenance {
-    /// The provenance whose every boxed leaf is bottom (the empty set) — an absent union variant.
-    pub fn uniform_bottom(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Provenance {
-        Provenance::build_shape(ty, type_env, &|_| Set::default())
-    }
 }
 
 /// The compile-time reference-count verdict for one boxed leaf, obtained by resolving its provenance

--- a/src/rc_ir/provenance.rs
+++ b/src/rc_ir/provenance.rs
@@ -516,6 +516,12 @@ impl<'a> Interpreter<'a> {
                 let arg_provs: Vec<Provenance> =
                     args.iter().map(|a| self.prov_of(a, env)).collect();
                 let arg_tys: Vec<Arc<TypeNode>> = args.iter().map(|a| a.ty.clone()).collect();
+                // `is_unique` is the one operation that answers a uniqueness question rather than
+                // acting on it, so its result is what makes a branch's condition readable as a fact
+                // about a value (`interpret_match` refines the `true` arm with it), and it is also
+                // the one whose own result is that fact rather than a value the operands compose
+                // into. The array-storage variant answers the same question for `Array`.
+                let answers_uniqueness = is_is_unique_op(llvm_gen.as_ref());
                 // Snapshot the checked container operand of a uniqueness-branching operation at this
                 // program point, for unique-check elimination to resolve later.
                 if let Some(check) = llvm_gen.unique_check_operand(&arg_tys, self.type_env) {
@@ -523,16 +529,12 @@ impl<'a> Interpreter<'a> {
                         result.name.clone(),
                         arg_provs[check.container_index].clone(),
                     );
-                    // `is_unique` is the one operation that answers a uniqueness question rather than
-                    // acting on it, so its result is what makes a branch's condition readable as a
-                    // fact about a value (`interpret_match` refines the `true` arm with it). The
-                    // array-storage variant answers the same question for `Array`.
-                    if is_is_unique_op(llvm_gen.as_ref()) {
+                    if answers_uniqueness {
                         self.is_unique_tested_paths
                             .insert(result.name.clone(), check.path.clone());
                     }
                 }
-                if is_is_unique_op(llvm_gen.as_ref()) {
+                if answers_uniqueness {
                     return is_unique_result(
                         &result.ty,
                         self.type_env,


### PR DESCRIPTION
#373 の修正が触った 2 ファイルについて、変更の周りを片付けたもの。`as_arg_projection` の 1 件を除いて振る舞いは変えていない（その 1 件は起こり得ない入力で panic するようになる）。

対象ブランチは `uaf-union-in-array`。修正そのものの差分を読みやすく保つため、周辺の掃除はこちらに分けてある。

## `src/rc_ir/ownership.rs`

**畳み込みが 2 か所に書かれていた。** 「候補となるオブジェクトの集合を `Origin` にする」処理 — 1 つに揃えば `Exactly`、割れていれば `Join` — が、`match` 束縛の腕と、#373 の修正が新しく書いた解決の両方にあった。前者を、後者の側で切り出した `Origin::of_candidates` の呼び出しに置き換えた。

**局所名 5 つ。** `def` -> `binding`（型は `Binding`、ファイルの語も binding）、`r` -> `arm_result`、`named` -> `named_fields`（形容詞だけでは集合の中身を言わない）、`owns_pos` -> `is_owning_position`（真偽値は述語の形で読める）、テスト内の `ls` -> `leaf_srcs`。

## `src/rc_ir/provenance.rs`

**テストモジュールが `use super::*;` で全部を引いていた。** 実際に使う名前を並べる形にした。

**doc コメントの無い項目。** `Interpreter::new`、`Interpreter::interpret_inner`、`SharingVerdict` の 2 つの variant、テストの補助 `fresh` / `unknown` / `arg`、そして 12 本の `#[test]` すべて。テストのコメントは「何を試すか」ではなく**どの観点を押さえているか**を述べている。`boxed` / `agg` / `uniq` は `//` だったので `///` にした。

**古くなった記述。** モジュールの doc と `leaf_origins_at` が、このファイルにもう無い `root` 解析を指していた。`Uniqueness::verdict_at` は呼び出し元を列挙していた。`resolve` は「`SharingVerdict` verdict」と型名を重ねていた。

**局所名 2 つ。** `compose` の `leaf` -> `operand_origins`、`s` -> `operand_src`。前者は `&LeafOrigins` を持つのに、ファイルの語彙では leaf は path を指すので衝突していた。

## 判断を仰いでいた 6 件（採用して適用した）

以下は当初、ring 2 の「振る舞いを変えない編集」の枠に収まらないか、項目そのものの改名・削除・移動にあたるため、付録に挙げて判断を待っていたもの。全件を適用した。

**1. `as_arg_projection` の catch-all を畳んだ。** `_ => None` が、`Fresh` と `Unknown` という実在する 2 つの答えに加えて、直前の `sources.len() != 1` が既に弾いている「集合が空」も吸収していた。2 つの実在する答えを名前で並べ、要素の取り出しを `expect` にした。

```rust
match sources
    .iter()
    .next()
    .expect("a one-element set has an element")
{
    LeafOrigin::Arg(j, p) => Some((*j, p.clone())),
    LeafOrigin::Fresh | LeafOrigin::Unknown => None,
}
```

**この 1 件だけは厳密には振る舞いを変える**。起こり得ない入力に対して `None` を返す代わりに panic する。既存の単体テストが渡している空集合は早期 return が受けるので、そちらは変わらない。

**2. `Provenance::leaf` を `sole_origin` にした。** `leaf(src) -> LeafOrigins` は「provenance の leaf」を予告して「1 つの leaf の origin 全体」を返していた。`LeafOrigins` は `Set` の型別名なので固有 impl を置けず、返す型の隣に立つ自由関数にしてある。呼び出しは 16 か所。

```rust
/// The origins of a leaf that has just the one.
pub fn sole_origin(src: LeafOrigin) -> LeafOrigins {
```

**3. `boxed_leaves` を削った。** `boxed_leaf_paths` へ同じ署名で転送するだけの関数で、1 つの概念に 2 つの名前を与えていた。呼び出し側（`ownership.rs` と `borrow.rs`）は `boxed_leaf_paths` を直接呼ぶ。`rc_units` の doc がこの名前で対比していた箇所も直した。

**4. `uniform_bottom` を構築子の並びへ移した。** 6 つの構築子のうち 5 つが 1 つの `impl` ブロックに並び、これだけが描画用の自由関数を挟んだ別ブロックに居た。`uniform` の隣に置き、空になったブロックを削除。

**5. `Provenance::to_string` を `Display` にした。** 固有の `to_string` は呼び出し側で `ToString::to_string` を隠すので、どちらが走るかが呼び出しから見えず、`format!("{}", prov)` はどちらにも届かなかった。`impl std::fmt::Display for Provenance` にすると、呼び出しも書式文字列も同じ 1 つの描画に届く。`print.rs` の唯一の呼び出しは `format!(" [{}]", prov)` になった。

**6. `interpret_rhs` の二重評価をやめた。** `is_is_unique_op(llvm_gen.as_ref())` を同じ腕で 2 度評価していた。上で `answers_uniqueness` に束縛し、その事実を説明していたコメントも問いを立てる位置へ移した。2 つの分岐が 1 つの事実で切り替わることが読める。

## 検査

`FIX_MAX_OPT_LEVEL=max cargo test --release` で 1456 passed / 0 failed。

途中 1 度、`cargo build` は通るのに `cargo test` が落ちた。`#[cfg(test)]` のモジュールは `cargo build` でコンパイルされないため、改名の追随漏れがそこだけ残っていた（`247741af` で修正）。

## 落とし方

`uaf-union-in-array` にこれを取り込んでから `main` へ入れても、`uaf-union-in-array` を `main` へ入れて削除しても構わない。後者の場合、GitHub が head ブランチの削除時にこの PR の base を `main` に付け替える。

