### PR TITLE
バグハントが残したテスト (#401): union のまわりの参照カウント 2 本

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -73,6 +73,7 @@ mod test_union_as_borrow;
 mod test_union_catchall_match;
 mod test_union_layout;
 mod test_union_match;
+mod test_union_rc_shapes;
 mod test_unrelated_module_cache;
 mod test_util;
 mod test_valgrind_suppression;

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -1,0 +1,130 @@
+// Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
+// then nobody reads, and an unboxed union nested inside unboxed aggregates.
+
+#[cfg(test)]
+mod union_rc_shapes_tests {
+    use crate::{configuration::Configuration, tests::test_util::test_source};
+
+    #[test]
+    pub fn test_discarded_operand_released_once() {
+        // Matching a union built on the spot lets the simplifier replace the match with the arm it
+        // knows is taken, substituting the payload the construction was given. Where the arm then
+        // ignores that payload — an arm binding nothing, a pattern binding a field the body never
+        // reads — the substituted operand is left with no reader, and its reference has to be
+        // released exactly once all the same. Run under memcheck.
+        let source = r#"
+            module Main;
+
+            type Payload = box union { arr : Array I64, txt : String };
+            type Fields = struct { a : Array I64, b : String, c : I64 };
+
+            main : IO ();
+            main = (
+                // The arm ignores the payload the construction was given.
+                let discarded = match Payload::arr([1, 2, 3]) {
+                    arr(_) => 10,
+                    txt(_) => -1
+                };
+                assert_eq(|_|"payload discarded", discarded, 10);;
+
+                // The arm reads the payload twice.
+                let read_twice = match Payload::arr([1, 2, 3, 4]) {
+                    arr(x) => x.@size + x.@(0),
+                    txt(_) => -1
+                };
+                assert_eq(|_|"payload read twice", read_twice, 5);;
+
+                // A catch-all binds the union built on the spot, and matches it a second time.
+                let rematched = match Payload::txt("abcd") {
+                    arr(x) => x.@size,
+                    other => (
+                        match other {
+                            arr(_) => -1,
+                            txt(t) => t.@size
+                        }
+                    )
+                };
+                assert_eq(|_|"catch-all over a known constructor", rematched, 4);;
+
+                // A struct literal destructured with a boxed field the body never reads.
+                let Fields { a : _unread, b : text, c : count } = Fields {
+                    a : [7, 8, 9], b : "xy", c : 5
+                };
+                assert_eq(|_|"field discarded", text.@size + count, 7);;
+
+                // A tuple built and destructured in one step.
+                let (numbers, letters) = ([1, 2], "zzz");
+                assert_eq(|_|"tuple destructured", numbers.@size + letters.@size, 5);;
+
+                pure()
+            );
+        "#;
+        test_source(&source, Configuration::develop_mode());
+    }
+
+    #[test]
+    pub fn test_nested_unboxed_union_shared_mod() {
+        // An unboxed union is one reference-counting unit whose root is where its count is kept,
+        // while the references it holds live inside its variants and differ in shape from one
+        // variant to the next. Nesting such a union inside a struct and a tuple, and then modifying
+        // an array of them while a second binding keeps the array shared, makes the copy the
+        // modification takes reach those units through two levels of unboxed aggregate. Run under
+        // memcheck.
+        let source = r#"
+            module Main;
+
+            type Payload = union { arr : Array I64, txt : String, num : I64 };
+            type Slot = struct { p : Payload, n : I64 };
+            type Pair = struct { left : Slot, right : (Payload, Payload) };
+
+            size_of : Payload -> I64;
+            size_of = |p| match p {
+                arr(a) => a.@size,
+                txt(t) => t.@size,
+                num(i) => i
+            };
+
+            // Cycles through the three variants, so that the units beneath one union's root differ
+            // from element to element.
+            mk : I64 -> Payload;
+            mk = |k| (
+                if k % 3 == 0 { Payload::arr(Array::fill(k + 1, k)) };
+                if k % 3 == 1 { Payload::txt(k.to_string) };
+                Payload::num(k)
+            );
+
+            total : Pair -> I64;
+            total = |t| (
+                let Pair { right : r, left : l } = t;
+                let Slot { p : lp, n : ln } = l;
+                let (r0, r1) = r;
+                size_of(lp) + ln + size_of(r0) + size_of(r1)
+            );
+
+            main : IO ();
+            main = (
+                let pairs = Array::from_map(9, |k| Pair {
+                    left : Slot { p : mk(k), n : k },
+                    right : (mk(k + 1), mk(k + 2))
+                });
+                assert_eq(
+                    |_|"nested unions summed",
+                    pairs.to_iter.fold(0, |t, acc| acc + total(t)), 145
+                );;
+
+                // A second binding keeps the array shared, so the modification copies rather than
+                // writing in place.
+                let kept = pairs;
+                let modified = pairs.mod(0, |t| t.set_left(Slot { p : Payload::num(100), n : 1 }));
+                assert_eq(|_|"mutated copy", total(modified.@(0)), 104);;
+                assert_eq(|_|"original element untouched", total(kept.@(0)), 4);;
+                assert_eq(
+                    |_|"original array untouched",
+                    kept.to_iter.fold(0, |t, acc| acc + total(t)), 145
+                );;
+                pure()
+            );
+        "#;
+        test_source(&source, Configuration::develop_mode());
+    }
+}


### PR DESCRIPTION
#373 の修正のあとに `src/rc_ir/` を対象として走らせたバグハントが、疑って書いたが**通った**テスト 2 本。欠陥は報告していないので、どちらも「疑って、確認できた」性質を固定するだけのもの。取り込むかどうかを判断してほしい。

同じハントが見つけた欠陥は #399 と #400 に出してある。この pull request はそれとは別で、どちらのテストも今日のコンパイラで通る。

## 置き場所

新しいファイル [`src/tests/test_union_rc_shapes.rs`](https://github.com/tttmmmyyyy/fixlang/blob/399fbcb4bb4bf246d7b3ef49a1281ce73adcc777/src/tests/test_union_rc_shapes.rs) にまとめた。どちらも「RC IR が書き換える union のまわりの参照カウント」という同じ問いに属する。

## `test_discarded_operand_released_once`

その場で組み立てた union を `match` すると、簡約器は「どの腕が選ばれるかは分かっている」として `match` を腕の中身に置き換え、組み立てに渡されたペイロードをそこへ代入する。**腕がそのペイロードを一度も読まない**場合、代入されたオペランドは読み手を持たないまま残る。それでもその参照はちょうど 1 度解放されなければならない。

固定する形は 5 つ。何も束縛しない腕、ペイロードを 2 度読む腕、その場で組み立てた union を catch-all で束縛して**もう一度** `match` する形、本体が読まないフィールドを束縛する構造体パターン、その場で組み立てて分解するタプル。MemCheck の下で走らせる。

## `test_nested_unboxed_union_shared_mod`

非 box union は 1 つの参照カウント単位で、カウントは根に置かれる。一方その union が持つ参照は variant の中にあり、**variant ごとに形が違う**。

このテストは、3 つの variant（配列を持つもの、文字列を持つもの、数値だけのもの）を巡回する union を struct とタプルの両方に入れ子にし、その配列を、別の束縛が配列を共有したまま `mod` する。共有されているので `mod` は書き換えではなく複製を取り、その複製が 2 段の非 box 集約を通って union の単位に届く。複製されたほうと元のほうの両方を読み直して、どちらも壊れていないことを見る。MemCheck の下で走らせる。

## 既存のテストとの重なり

`test_union_match.rs` は box union と箱入りペイロードについて、ペイロードを捨てる腕と、`match` のあとも使われる被検査値を MemCheck の下で見ている。1 本目はその隣にあたるが、catch-all で束縛し直して再度 `match` する形と、構造体・タプルの分解は含まれていない。

2 本目に最も近いのは #373 の修正が足した `test_borrowed_union_field.rs` で、あちらは配列の要素の struct に入った union を**借用で読む**形。共有されたままの `mod` が複製を取る経路は通っていない。

判断が「重なりのほうが大きい」なら、この pull request は閉じてもらってかまわない。
