### PR TITLE
英語を平易に書く／コードが名前を持つものはその名前で呼ぶ

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -916,9 +916,9 @@ The Rust source comments, `std.fix`'s doc comments, and the documents the projec
 
 This convention covers the text the project ships. Writing addressed to the people working on the change — a dev doc under `dev-docs/`, a pull request body, an issue — is in the language of the people who read it, and this convention does not reach it. The `devdoc` skill governs a dev doc's writing.
 
-A document that exists as a translation is **written** in its language rather than transposed into it. A paragraph that keeps the other language's sentence structure — the em-dash aside, the stacked relative clause, the clause-per-sentence chop — reads as a translation, and the reader pays to undo it. Read each rewritten paragraph on its own and ask whether someone writing from scratch in that language would have put it that way.
+Write that English plainly. A reader of this project need not be a native speaker, and a long sentence, a rare word where a common one fits, or a clause folded inside another costs them more than it costs a native reader. Short sentences and ordinary words carry the same meaning for less, and they are also what a translator of the document has to work from.
 
-**Rewrite**: translate the comment into clear English while preserving its meaning; say a translated paragraph the way its own language says it.
+**Rewrite**: translate the comment into clear English while preserving its meaning; say a long or ornate sentence plainly.
 
 #### Every Rust item must have a doc comment — [Rust]
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -916,7 +916,9 @@ The Rust source comments, `std.fix`'s doc comments, and the documents the projec
 
 This convention covers the text the project ships. Writing addressed to the people working on the change — a dev doc under `dev-docs/`, a pull request body, an issue — is in the language of the people who read it, and this convention does not reach it. The `devdoc` skill governs a dev doc's writing.
 
-**Rewrite**: translate the comment into clear English while preserving its meaning.
+A document that exists as a translation is **written** in its language rather than transposed into it. A paragraph that keeps the other language's sentence structure — the em-dash aside, the stacked relative clause, the clause-per-sentence chop — reads as a translation, and the reader pays to undo it. Read each rewritten paragraph on its own and ask whether someone writing from scratch in that language would have put it that way.
+
+**Rewrite**: translate the comment into clear English while preserving its meaning; say a translated paragraph the way its own language says it.
 
 #### Every Rust item must have a doc comment — [Rust]
 
@@ -985,6 +987,16 @@ State what *is*, not what *isn't*. Two anti-patterns to catch, both applying to 
 **Keep** genuine prohibitions and deprecations — "must not be called after `close()`", "callers should not rely on the ordering here". These regulate future behavior rather than negating a phantom alternative, so they belong.
 
 **Rewrite** (a) and (b) into the affirmative equivalent. When the negation carries no residual information once affirmed, drop the sentence.
+
+#### Don't coin a term for one document — [Rust + Markdown]
+
+A word invented to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has no definition to go to. In a document that is translated, it survives as a word that means nothing in the other language either.
+
+The test: can the sentence be written without the coined word? It usually can, and is shorter for it.
+
+**Keep** a term the code itself names — a type, a field, a variant — since the reader can go and read what it is.
+
+**Rewrite**: replace the coined word with what it stands for.
 
 #### Reference by name, not by line or section number — [Rust + Markdown]
 

--- a/.claude/skills/devdoc/SKILL.md
+++ b/.claude/skills/devdoc/SKILL.md
@@ -41,6 +41,10 @@ Write a measurement into the body instead when the argument at that point does n
 
 Write the doc in the implementers' language. It does not have to be English.
 
+Write it *in* that language rather than translating into it. A paragraph carrying another language's sentence structure — the em-dash aside, the stacked clause — reads as a translation, and the reader pays to undo it.
+
+Do not coin a word to carry a concept through a few paragraphs: a reader who meets it once has nothing to attach it to. Say what the thing is; the sentence is usually shorter for it. A term the code itself names is different, since the reader can go and read what it is.
+
 ## Audience and self-containedness
 
 Write for a reader who knows the project thinly and broadly, but knows nothing about this change or about the code it touches. The doc must be self-contained for that reader:

--- a/.claude/skills/devdoc/SKILL.md
+++ b/.claude/skills/devdoc/SKILL.md
@@ -41,7 +41,7 @@ Write a measurement into the body instead when the argument at that point does n
 
 Write the doc in the implementers' language. It does not have to be English.
 
-Write it *in* that language rather than translating into it. A paragraph carrying another language's sentence structure — the em-dash aside, the stacked clause — reads as a translation, and the reader pays to undo it.
+Where that language is English, write it plainly: a reader need not be a native speaker, and a long sentence or a rare word costs them more than it costs a native reader.
 
 Do not coin a word to carry a concept through a few paragraphs: a reader who meets it once has nothing to attach it to. Say what the thing is; the sentence is usually shorter for it. A term the code itself names is different, since the reader can go and read what it is.
 


### PR DESCRIPTION
`code-review` の `comment-style` と `devdoc` は、**どの言語で書くか**は言っていたが、**その言語をどう書くか**を言っていなかった。PR #379 で 2 つの形の欠陥が出たので、両方に書き足す。

# 1. 英語を平易に書く

`Document.md` に足した節に、こういう文があった。

> Two types a C declaration writes identically describe the same position, so one C function's `unsigned long` result may be read as `U64` in one place and as `I64` in another.

1 文に 2 つの節を畳み、`describe the same position` という抽象名詞句で主張を運んでいる。書き直した後:

> Whether two signatures are the same is decided by whether C writes them the same way. `U64` and `I64` are one declaration in C, so one C function's result may be read as `U64` in one place and as `I64` in another.

**この規約を英語の側に置いたのが要点である。** 最初の版は「翻訳がその言語で書かれたように読めること」を求めていたが、それは仕事を逆の側に置いていた。**英語が原文なので、そこで長い文・凝った文は、運ばれた先の言語でも長く凝ったままになる。** Fix を書く読み手は英語圏に限らず、`Document-ja.md` は英語版から訳される。原文を平易にすれば、両方が同時に楽になる。

書き足した文:

> Write that English plainly. A reader of this project need not be a native speaker, and a long sentence, a rare word where a common one fits, or a clause folded inside another costs them more than it costs a native reader. Short sentences and ordinary words carry the same meaning for less, and they are also what a translator of the document has to work from.

# 2. コードが名前を持つものは、その名前で呼ぶ

`Document.md` の同じ節に「位置」という語があった。英語で書いた *position*（シグネチャの中の引数や戻り値の場所）をそのまま訳したもので、**定義はどこにも無い**。一度しか出会わない読み手には何も指しておらず、英語の *position* も同じ問題を抱えていた。この語を使わずに書くと、文はむしろ短くなった。

同じ失敗のもう 1 つの顔が、**コードが持っている名前を言い換えてしまう**ことである。

> それが指す完全名を 1 つ返す

`完全名` はコードの `FullName` を訳した結果で、**1 つのものに 2 つ目の名前を作り、コードへの帰り道を切っている**。読み手は `完全名` を grep できない。正しくは:

> それが指す `FullName` を 1 つ返す

規約はこの順で書いた。**識別子を使うことが第一**で、造語を避けることはその裏側である。

> #### Name a thing the way the code names it — [Rust + Markdown]
>
> An identifier the code carries — a type, a field, a function, a variant — is vocabulary the reader already shares with the text, and it is a word they can search for. Write `FullName`, not "the full name"; `CTypeShape`, not "the shape a C declaration carries". A paraphrase makes a second name for one thing and cuts the reader's way back to the code, and a paraphrase translated into another language cuts it twice.
>
> Where the code names nothing, say what the thing is rather than inventing a word for it. A word coined to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has nowhere to look it up. The test: can the sentence be written without the coined word? It usually can, and is shorter for it.

# 置き場所

| ファイル | 対象 | 足したもの |
|---|---|---|
| `code-review` の `comment-style` | Rust のコメント、`std.fix` の doc、`Document.md` / `Document-ja.md` | 平易な英語（既存の言語規約を広げた）+ 識別子の規約（新設） |
| `devdoc` の `Language` | PR 本文・issue・`dev-docs/` | 同じ 2 つを短く |

**同じ「位置」が PR #379 の本文にもあった**ので、`devdoc` にも要る。2 つのスキルは互いを参照せずに単体で読まれる（`code-review` は subagent に「これを唯一の指示とせよ」と渡す）ので、同じ趣旨が両方に要る。

# 規約を 1 本増やすことについて

`code-review` は「すべての規約が毎回全文読まれるので、集合は共有された予算である」と述べている。識別子の規約を新設したのは、次の 2 点による。

- **クラスであって出来事ではない**。「コードの名前を言い換える／その文書のためだけの語を作る」は、別の書き手が別のサブシステムで繰り返しうる。挙げている `FullName` と "position" は例であって内容ではない。
- **既存のどの規約も覆っていない**。「肯定形で書く」「番号で参照しない」「歴史を語らない」はいずれも別の失敗を見ている。近いのは「参照は名前で行う」だが、あれは*どこを*指すかの規約で、こちらは*何と呼ぶ*かの規約である。

平易な英語の方は、主題が同じ（その文がどの言語で、どう書かれるか）なので新設せず既存を広げた。