### PR TITLE
union 自身の origin を、その下の leaf から解く (#399)

### DIFF
--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -9,12 +9,12 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 - **RC unit** = `(変数名, Path)`（`VarPath`）。`rc_units` が列挙し、`is_rc_unit_root`（boxed / union / punched array）で降下を止める。
   punched フィールドはスキップする。
 - **boxed leaf** = `boxed_leaf_paths` が列挙する末端。unbox union は**各 variant の中まで降り**、punched
-  フィールドは `rc_units` と同じくスキップする（穴の開いたフィールドは参照を持たない）。
+  フィールドは `rc_units` と同じくスキップする（参照を持たないため）。
 - 消費と provenance は **leaf 空間**、`Retain`/`Release` ノードは **unit 空間**に住む。橋渡しは
   `truncate_to_unit`（leaf path を unit path に切り詰める）と `units_under`。
-- 参照数を数える鍵 `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、
-  根の型の `rc_units` の要素である。切り詰めは下向きにしか効かないので、identity の path が unit root より
-  上で止まるとどの unit も指さない鍵ができる。`unit_of` の assertion がこれを検査する。
+- `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、根の型の
+  `rc_units` の要素である。切り詰めは下向きにしか効かないので、identity の path が unit root より上で
+  止まると、どの unit も指さない `unit_key` ができる。`unit_of` の assertion がこれを検査する。
 - `origin` は leaf でない path も受ける。unit path は leaf とは限らない（unbox union の unit は根、その leaf は
   各 variant の中。punched array の unit は `[i]`、その leaf は `[i, 0]`）。`result_prov` に該当する leaf が
   無いときは、**その下の leaf 群がどのオペランドの unit から射影されたか**で答える（`origin_from_leaves_under`）。
@@ -96,8 +96,8 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
   現れない。
 - **unbox union が参照を数えるキー**: union の参照は生きている variant の参照で、どのオブジェクトに属するかは
   タグで決まる。`origin` は union の根に対して payload の unit 群を候補に持つ `Join` を答え、variant の中の
-  leaf に対してはその payload の unit を答える。union の根の鍵と、その下の leaf が解決する鍵の両方を検査
-  対象外にする。
+  leaf に対してはその payload の unit を答える。union の根の `unit_key` と、その下の leaf が解決する
+  `unit_key` の両方を検査対象外にする。
 - **fully-unboxed 値**（`needs_rc` が偽）には RC ノードが無い。funptr 型もここに入る。
 - **1 変数が複数 unit を持ち、unit ごとに所有権が違う**（`split_rc_units` 以降）。
 - **他コンパイル単位のシンボル**: `prog.funcs` に無い callee は全 `Own` とみなす（borrow 最適化が走るのは

--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -95,8 +95,9 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 - **punched フィールドの下の leaf**: `rc_units` はスキップするが `boxed_leaf_paths` はしない。leaf 側でも
   ミラーして除外する。
 - **unbox union が参照を数えるキー**: union の参照は生きている variant の参照で、どのオブジェクトに属するかは
-  タグで決まるのに、`origin` は構築時に置かれたオブジェクトを答える。union の unit path と各 variant leaf が
-  解決するキーをまとめて検査対象外にする（別名の先も同じキーなので一緒に外れる）。
+  タグで決まる。`origin` は union の根に対して payload の unit 群を候補に持つ `Join` を答え、variant の中の
+  leaf に対してはその payload の unit を答える。union の根の鍵と、その下の leaf が解決する鍵の両方を検査
+  対象外にする。
 - **fully-unboxed 値**（`needs_rc` が偽）には RC ノードが無い。funptr 型もここに入る。
 - **1 変数が複数 unit を持ち、unit ごとに所有権が違う**（`split_rc_units` 以降）。
 - **他コンパイル単位のシンボル**: `prog.funcs` に無い callee は全 `Own` とみなす（borrow 最適化が走るのは

--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -12,6 +12,9 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
   スキップしない。
 - 消費と provenance は **leaf 空間**、`Retain`/`Release` ノードは **unit 空間**に住む。橋渡しは
   `truncate_to_unit`（leaf path を unit path に切り詰める）と `units_under`。
+- 参照数を数える鍵 `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、
+  根の型の `rc_units` の要素である。切り詰めは下向きにしか効かないので、identity の path が unit root より
+  上で止まるとどの unit も指さない鍵ができる。`unit_of` の assertion がこれを検査する。
 - `origin` は leaf でない path も受ける。unit path は leaf とは限らない（unbox union の unit は根、その leaf は
   各 variant の中。punched array の unit は `[i]`、その leaf は `[i, 0]`）。`result_prov` に該当する leaf が
   無いときは、**その下の leaf 群がどのオペランドの unit から射影されたか**で答える（`origin_from_leaves_under`）。
@@ -60,8 +63,8 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
   **boxed union の variant** は producer。
 - `Binding::Llvm`: `result_prov` の leaf が単一の `Arg(j, p)` なら引数 `j` の別名。leaf でない path は
   その下の leaf 群から決める（`origin_from_leaves_under`）。unbox union の構築
-  （`InlineLLVMMakeUnionBody`）は whole-union path で payload の別名で、payload が複数の unit にまたがる
-  ときはこちらだけが payload 自身の path を答えられる。
+  （`InlineLLVMMakeUnionBody`）もこの規則で解ける。whole-union path の下の leaf は、構築された variant
+  では payload の leaf、他の variant では ⊥ なので、答えは payload の unit 群になる。
 - `Binding::Param` / `Binding::Producer` はそこで止まる。
 
 ## 4. ステージごとの不変条件

--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -12,11 +12,12 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
   フィールドは `rc_units` と同じくスキップする（参照を持たないため）。
 - 消費と provenance は **leaf 空間**、`Retain`/`Release` ノードは **unit 空間**に住む。橋渡しは
   `truncate_to_unit`（leaf path を unit path に切り詰める）と `units_under`。
-- `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、根の型の
-  `rc_units` の要素である。切り詰めは下向きにしか効かないので、identity の path が unit root より上で
-  止まると、どの unit も指さない `unit_key` ができる。`unit_of` の assertion がこれを検査する。
-- `origin` は leaf でない path も受ける。unit path は leaf とは限らない（unbox union の unit は根、その leaf は
-  各 variant の中。punched array の unit は `[i]`、その leaf は `[i, 0]`）。`result_prov` に該当する leaf が
+- `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、root
+  （`VarPath` の先頭にある変数）の型の `rc_units` の要素である。切り詰めは下向きにしか効かないので、
+  identity の path が unit root より上で止まると、どの unit も指さない `unit_key` ができる。`unit_of` の
+  assertion がこれを検査する。
+- `origin` は leaf でない path も受ける。unit path は leaf とは限らない（unbox union の unit は union 自身の
+  path、その leaf は各 variant の中。punched array の unit は `[i]`、その leaf は `[i, 0]`）。`result_prov` に該当する leaf が
   無いときは、**その下の leaf 群がどのオペランドの unit から射影されたか**で答える（`origin_from_leaves_under`）。
   下の leaf が 1 つのオペランド unit に揃えば `Exactly`、複数に分かれるか射影でない leaf を含むなら、その値が
   取りうるオブジェクトを全部並べた `Join`。⊥（不在 variant）の leaf は参照を持たないので読み飛ばす。
@@ -95,9 +96,9 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 - **punched フィールドの下の leaf**: `rc_units` も `boxed_leaf_paths` も降りないので、どちらの空間にも
   現れない。
 - **unbox union が参照を数えるキー**: union の参照は生きている variant の参照で、どのオブジェクトに属するかは
-  タグで決まる。`origin` は union の根に対して payload の unit 群を候補に持つ `Join` を答え、variant の中の
-  leaf に対してはその payload の unit を答える。union の根の `unit_key` と、その下の leaf が解決する
-  `unit_key` の両方を検査対象外にする。
+  タグで決まる。`origin` は union 自身の path に対して payload の unit 群を候補に持つ `Join` を答え、
+  variant の中の leaf に対してはその payload の unit を答える。union 自身の `unit_key` と、その下の leaf が
+  解決する `unit_key` の両方を検査対象外にする。
 - **fully-unboxed 値**（`needs_rc` が偽）には RC ノードが無い。funptr 型もここに入る。
 - **1 変数が複数 unit を持ち、unit ごとに所有権が違う**（`split_rc_units` 以降）。
 - **他コンパイル単位のシンボル**: `prog.funcs` に無い callee は全 `Own` とみなす（borrow 最適化が走るのは

--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -8,8 +8,8 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 
 - **RC unit** = `(変数名, Path)`（`VarPath`）。`rc_units` が列挙し、`is_rc_unit_root`（boxed / union / punched array）で降下を止める。
   punched フィールドはスキップする。
-- **boxed leaf** = `boxed_leaf_paths` が列挙する末端。unbox union は**各 variant の中まで降り**、punched フィールドも
-  スキップしない。
+- **boxed leaf** = `boxed_leaf_paths` が列挙する末端。unbox union は**各 variant の中まで降り**、punched
+  フィールドは `rc_units` と同じくスキップする（穴の開いたフィールドは参照を持たない）。
 - 消費と provenance は **leaf 空間**、`Retain`/`Release` ノードは **unit 空間**に住む。橋渡しは
   `truncate_to_unit`（leaf path を unit path に切り詰める）と `units_under`。
 - 参照数を数える鍵 `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）が答える path は、
@@ -92,8 +92,8 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 
 - **root がグローバル名の unit**: グローバルは線形規律の外（読むたびに新しい参照が生まれ、refcount 操作は
   no-op）。丸ごとスキップする。
-- **punched フィールドの下の leaf**: `rc_units` はスキップするが `boxed_leaf_paths` はしない。leaf 側でも
-  ミラーして除外する。
+- **punched フィールドの下の leaf**: `rc_units` も `boxed_leaf_paths` も降りないので、どちらの空間にも
+  現れない。
 - **unbox union が参照を数えるキー**: union の参照は生きている variant の参照で、どのオブジェクトに属するかは
   タグで決まる。`origin` は union の根に対して payload の unit 群を候補に持つ `Join` を答え、variant の中の
   leaf に対してはその payload の unit を答える。union の根の鍵と、その下の leaf が解決する鍵の両方を検査

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -125,7 +125,8 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     for func in prog.funcs.values() {
         // `f_own`: every parameter and capture unit is owned.
         owned_units.extend(param_capture_units(func, type_env));
-        // `f_borrow`: a fresh clone whose owned units are the inferred ones, clamped to units.
+        // `f_borrow`: a fresh clone whose owned units are the inferred owned leaves, each truncated
+        // to its unit.
         if let Some(bref) = borrow_versions.get(&func.name) {
             let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
             for p in &func.params {

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -63,7 +63,7 @@ struct Ownerships {
 /// leaf `Borrow`, then repeatedly demote to `Own` any leaf that a consume site traces back to, until
 /// nothing changes. Demotion is monotone (`Borrow` to `Own` only), so it terminates.
 fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
-    let vars: Map<FuncRef, VarTable> = prog
+    let var_tables: Map<FuncRef, VarTable> = prog
         .funcs
         .values()
         .map(|f| (f.name.clone(), VarTable::of(f)))
@@ -73,7 +73,7 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
     loop {
         let mut changed = false;
         for func in prog.funcs.values() {
-            let vars = &vars[&func.name];
+            let vars = &var_tables[&func.name];
             let mut consumed = vec![];
             collect_consumes(&func.body, vars, prog, &own, type_env, &mut consumed);
             for (var, path) in consumed {
@@ -1051,20 +1051,20 @@ impl<'a> CancelAnalysis<'a> {
         pending_in: &PendingRetains,
         arm_exits: &[PendingRetains],
     ) -> PendingRetains {
-        let n = arm_exits.len();
-        let mut arms_pending: Map<NodeId, usize> = Map::default();
+        let arm_count = arm_exits.len();
+        let mut pending_arm_count: Map<NodeId, usize> = Map::default();
         for exit in arm_exits {
             let mut seen: Set<NodeId> = Set::default();
             for stack in exit.values() {
                 for &retain in stack {
                     if seen.insert(retain) {
-                        *arms_pending.entry(retain).or_default() += 1;
+                        *pending_arm_count.entry(retain).or_default() += 1;
                     }
                 }
             }
         }
-        for (&retain, &count) in &arms_pending {
-            if count != n {
+        for (&retain, &count) in &pending_arm_count {
+            if count != arm_count {
                 self.needed_retains.insert(retain);
             }
         }
@@ -1075,7 +1075,7 @@ impl<'a> CancelAnalysis<'a> {
             let kept: Vec<NodeId> = stack
                 .iter()
                 .copied()
-                .filter(|retain| arms_pending.get(retain) == Some(&n))
+                .filter(|retain| pending_arm_count.get(retain) == Some(&arm_count))
                 .collect();
             if !kept.is_empty() {
                 merged.insert(key.clone(), kept);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -24,8 +24,8 @@
 //! Borrow-ification and cancellation both work one reference-counting unit at a time, so
 //! `split_rc_units` first normalizes the lowered reference counting to that granularity: it
 //! decomposes a whole-value or subtree `Retain`/`Release` into one node per unit — a boxed leaf, a
-//! closure capture, or an unboxed-union root (a union is one unit, since a physical refcount
-//! operation on it must dispatch on the tag rather than name a variant).
+//! closure capture, or an unboxed union (a union is one unit, since a physical refcount operation on
+//! it must dispatch on the tag rather than name a variant).
 //!
 //! Borrow-ification leaves the caller with a retain before a borrow call and a release after it,
 //! bracketing the call with no consume between. `cancel` removes those net-zero brackets: a retain is

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -579,11 +579,9 @@ impl<'a> RewriteCtx<'a> {
     /// Whether this version owns the object a leaf comes from.
     fn owns_object(&self, root: &FullName, path: &FieldPath) -> bool {
         match self.vars.param_tys.get(root) {
-            // The path may name a subtree that spans several reference-counting units rather than
-            // one — a union built from an unboxed tuple roots to the tuple at the empty path, whose
-            // units are its fields. The value is owned only when every unit it covers is owned. Each
-            // covered path is clamped to its unit key, so a path that descends into a union variant
-            // keys to the union root the owned set records.
+            // The value is owned only when every reference-counting unit the path covers is owned.
+            // Each covered path is clamped to its unit key, so a path that descends into a union
+            // variant keys to the union root the owned set records.
             Some(root_ty) => units_under(root_ty, path, self.type_env)
                 .iter()
                 .all(|unit| {

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -124,11 +124,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     let mut clones: Vec<(FuncRef, RcFunc, Map<FullName, FullName>)> = vec![];
     for func in prog.funcs.values() {
         // `f_own`: every parameter and capture unit is owned.
-        for p in func.params.iter().chain(func.capture.iter()) {
-            for unit in rc_units(&p.ty, type_env) {
-                owned_units.insert((p.name.clone(), unit));
-            }
-        }
+        owned_units.extend(param_capture_units(func, type_env));
         // `f_borrow`: a fresh clone whose owned units are the inferred ones, clamped to units.
         if let Some(bref) = borrow_versions.get(&func.name) {
             let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
@@ -207,16 +203,10 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
 
     // Annotate every version with the parameter/capture units it borrows (those not in `owned_units`).
     for func in funcs.values_mut() {
-        let mut borrowed = Set::default();
-        for p in func.params.iter().chain(func.capture.iter()) {
-            for unit in rc_units(&p.ty, type_env) {
-                let unit_path = (p.name.clone(), unit);
-                if !owned_units.contains(&unit_path) {
-                    borrowed.insert(unit_path);
-                }
-            }
-        }
-        func.borrowed_units = borrowed;
+        func.borrowed_units = param_capture_units(func, type_env)
+            .into_iter()
+            .filter(|unit_path| !owned_units.contains(unit_path))
+            .collect();
     }
 
     RcProgram {
@@ -269,6 +259,20 @@ fn param_names_and_types(func: &RcFunc) -> Vec<(FullName, Arc<TypeNode>)> {
         .iter()
         .chain(func.capture.iter())
         .map(|p| (p.name.clone(), p.ty.clone()))
+        .collect()
+}
+
+/// Every reference-counting unit of a function's parameters and capture, each as the
+/// `(variable, unit path)` pair the owned and borrowed unit sets are keyed by.
+fn param_capture_units(func: &RcFunc, type_env: &TypeEnv) -> Vec<VarPath> {
+    func.params
+        .iter()
+        .chain(func.capture.iter())
+        .flat_map(|p| {
+            rc_units(&p.ty, type_env)
+                .into_iter()
+                .map(|unit| (p.name.clone(), unit))
+        })
         .collect()
 }
 

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -581,7 +581,7 @@ impl<'a> RewriteCtx<'a> {
         match self.vars.param_tys.get(root) {
             // The value is owned only when every reference-counting unit the path covers is owned.
             // Each covered path is truncated to its unit, so a path that descends into a union
-            // variant keys to the union root that `owned_units` records.
+            // variant keys to the union itself, which is what `owned_units` records.
             Some(root_ty) => units_under(root_ty, path, self.type_env)
                 .iter()
                 .all(|unit| {

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -53,9 +53,10 @@ use crate::rc_ir::ownership::{
 use crate::rc_ir::rename::fresh_rename_function;
 use std::sync::Arc;
 
-/// The result of borrow inference: which parameter leaves are `Own` (all others are `Borrow`), keyed
-/// by the parameter variable's name and the leaf path.
+/// The result of borrow inference: which parameter leaves each function of the program owns.
 struct Ownerships {
+    /// The parameter leaves inferred `Own`, keyed by the parameter variable's name and the leaf
+    /// path. A leaf absent from it is `Borrow`.
     own: Set<VarPath>,
 }
 
@@ -101,9 +102,8 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
 
 /// Borrow-ify a program: materialize a borrowing version of every function with a borrowable
 /// parameter, route each direct call to a version, rewrite the reference counting accordingly, and
-/// annotate every output version with the parameter/capture units it borrows (`RcFunc::borrowed_units`,
-/// whose owned complement `cancel` reads to find each call's consume sites and the RC IR dump reads
-/// for its shapes).
+/// annotate every output version with the parameter/capture units it borrows
+/// (`RcFunc::borrowed_units`).
 pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     let ownerships = infer_ownership(prog, type_env);
 
@@ -883,9 +883,15 @@ pub fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
 
 /// The forward must-analysis for one function: it decides which retain and release nodes to delete.
 struct CancelAnalysis<'a> {
+    /// This function's variables: what binds each one and its type, which decide the unit key a
+    /// retain and a release pair on.
     vars: &'a VarTable,
+    /// The whole program, so a call resolves to its callee's parameters.
     prog: &'a RcProgram,
+    /// The parameter/capture units the program's functions own, which decide which argument
+    /// positions of a call consume.
     owned_units: &'a Set<VarPath>,
+    /// The type definitions, for resolving a value's type to its reference-counting units.
     type_env: &'a TypeEnv,
     /// Retains that are load-bearing on some path, so they cannot be cancelled.
     needed_retains: Set<NodeId>,

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -580,8 +580,8 @@ impl<'a> RewriteCtx<'a> {
     fn owns_object(&self, root: &FullName, path: &FieldPath) -> bool {
         match self.vars.param_tys.get(root) {
             // The value is owned only when every reference-counting unit the path covers is owned.
-            // Each covered path is clamped to its unit key, so a path that descends into a union
-            // variant keys to the union root the owned set records.
+            // Each covered path is truncated to its unit, so a path that descends into a union
+            // variant keys to the union root that `owned_units` records.
             Some(root_ty) => units_under(root_ty, path, self.type_env)
                 .iter()
                 .all(|unit| {

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -18,7 +18,6 @@ use crate::ast::name::FullName;
 use crate::ast::program::TypeEnv;
 use crate::ast::types::TypeNode;
 use crate::constants::CLOSURE_CAPTURE_IDX;
-use crate::fixstd::builtin::InlineLLVMMakeUnionBody;
 use crate::misc::{grow_stack, Map, Set};
 use crate::rc_ir::ast::{
     FieldPath, FuncRef, RcExpr, RcExprNode, RcFunc, RcProgram, RcRhs, RcVar, VarPath,
@@ -260,17 +259,6 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             Origin::of_candidates(candidates, &(var.clone(), path.to_vec()))
         }
         Some(Binding::Llvm(llvm_gen, args, result_ty)) => {
-            // Constructing an unboxed union lays its payload in place, so the whole union's root is
-            // the payload's root — the construction alias edge, dual to reading a payload out with
-            // `match`. The whole-union path is where this matters: a leaf path descends into the
-            // active variant, which the projection rule below already aliases through `result_prov`.
-            if path.is_empty()
-                && !args.is_empty()
-                && llvm_gen.as_any().is::<InlineLLVMMakeUnionBody>()
-                && !result_ty.is_box(type_env)
-            {
-                return origin(vars, type_env, &args[0].name, &[]);
-            }
             let arg_tys: Vec<Arc<TypeNode>> = args.iter().map(|a| a.ty.clone()).collect();
             let decl = llvm_gen.result_prov(result_ty, &arg_tys, type_env);
             // A result leaf that is a single `Arg(j, p)` is a pure projection of argument `j`'s leaf
@@ -695,7 +683,7 @@ pub(crate) fn acted_unit_keys(
 }
 
 /// The unit key of an object identity: the root it names, with its path truncated to the
-/// reference-counting unit that holds it.
+/// reference-counting unit that holds it. The path it answers with is one of that root's units.
 fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPath {
     let Some(ty) = vars.var_tys.get(root) else {
         // A root with no type here is a global: the table holds the function's own variables.
@@ -708,7 +696,22 @@ fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPa
         );
         return (root.clone(), path.clone());
     };
-    (root.clone(), truncate_to_unit(ty, path, type_env))
+    let truncated = truncate_to_unit(ty, path, type_env);
+    // Truncation only descends, so an identity whose path stops above every unit root of its type
+    // comes out naming no unit at all. A key like that puts a retain in a bucket no release of the
+    // object can reach, which leaves the retain to be cancelled and the object freed while it is
+    // still held, so it is caught here, where the key is made, rather than where a program built
+    // with it goes wrong.
+    let units = rc_units(ty, type_env);
+    assert!(
+        units.contains(&truncated),
+        "the key `{}{:?}` names no reference-counting unit of `{}`, whose units are {:?}",
+        root.to_string(),
+        truncated,
+        ty.to_string(),
+        units,
+    );
+    (root.clone(), truncated)
 }
 
 /// The owned parameter/capture units of every function: each version's units minus the ones it

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -650,9 +650,9 @@ pub(crate) fn truncate_to_unit(
 }
 
 /// The reference-counting unit a leaf belongs to, as an object identity: its `origin`'s identity,
-/// clamped to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
-/// retain and a payload consume land in the same bucket (without which a payload consume could not
-/// keep the union retain needed, and a later union release would wrongly cancel it).
+/// truncated to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
+/// retain and a consume of the payload get the same key: the consume marks that retain as needed,
+/// and cancellation keeps it together with the union release that un-bumps it.
 ///
 /// This is the key a retain and a release are paired on, and the key a reference count is kept
 /// under, so it must name one object: a leaf whose object is path-dependent keys to the match

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -764,14 +764,19 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
 }
 
 /// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
-/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `what` names the
-/// walk in the message an out-of-range index aborts with.
-fn field_type_at(ty: &Arc<TypeNode>, idx: usize, type_env: &TypeEnv, what: &str) -> Arc<TypeNode> {
+/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `walk_name` names
+/// the walk in the message an out-of-range index aborts with.
+fn field_type_at(
+    ty: &Arc<TypeNode>,
+    idx: usize,
+    type_env: &TypeEnv,
+    walk_name: &str,
+) -> Arc<TypeNode> {
     let fields = ty.field_types(type_env);
     assert!(
         idx < fields.len(),
         "{}: path index {} out of range ({} fields)",
-        what,
+        walk_name,
         idx,
         fields.len()
     );

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -683,7 +683,7 @@ pub(crate) fn acted_unit_keys(
 }
 
 /// The unit key of an object identity: the root it names, with its path truncated to the
-/// reference-counting unit that holds it. The path it answers with is one of that root's units.
+/// reference-counting unit that holds it. The returned path is always one of that root's units.
 fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPath {
     let Some(ty) = vars.var_tys.get(root) else {
         // A root with no type here is a global: the table holds the function's own variables.
@@ -698,9 +698,9 @@ fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPa
     };
     let truncated = truncate_to_unit(ty, path, type_env);
     // Truncation only descends, so an identity whose path stops above every unit root of its type
-    // comes out naming no unit at all. A key like that puts a retain in a bucket no release of the
-    // object can reach, which leaves the retain to be cancelled and the object freed while it is
-    // still held, so the key is checked here, where it is made.
+    // comes out naming no unit at all. A retain under such a key pairs with no release of the
+    // object, so cancellation drops it and the object is freed while it is still held. The check
+    // sits here, where every key is made.
     let units = rc_units(ty, type_env);
     assert!(
         units.contains(&truncated),

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -266,8 +266,8 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             // several sources) is a producer, stopping here. An `Llvm` op is never partially applied,
             // so a well-formed `result_prov` names only real argument indices (`args[j]` else panics).
             // A path whose own record does not name an object is handled by
-            // `origin_from_leaves_under`: a reference-counting unit path may name the root of an
-            // unboxed union, which is a subtree whose provenance is declared on the leaves beneath.
+            // `origin_from_leaves_under`: a reference-counting unit path may name an unboxed union
+            // itself, whose provenance is declared on the leaves of its variants.
             match decl.leaf_origins_at(path).and_then(as_arg_projection) {
                 Some((j, p)) => origin(vars, type_env, &args[j].name, &p),
                 None => {
@@ -310,16 +310,16 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
 /// The object a value denotes at a path whose own record does not name one: the objects the leaves
 /// beneath that path reach.
 ///
-/// A reference-counting unit path may name the root of an unboxed union, whose provenance is
-/// declared one level down, on the leaves of its variants, so a reader that stops at the root finds
-/// nothing recorded and takes the value for one produced on the spot — its own to release, when it
-/// may be an operand's. The leaves beneath decide instead. A leaf recorded as `⊥` belongs to a
+/// A reference-counting unit path may name an unboxed union itself, whose provenance is declared one
+/// level down, on the leaves of its variants, so a reader that stops at the union finds nothing
+/// recorded and takes the value for one produced on the spot — its own to release, when it may be an
+/// operand's. The leaves beneath decide instead. A leaf recorded as `⊥` belongs to a
 /// variant the value does not have and holds no reference, so it names no object and is passed
 /// over; a leaf produced here rather than projected names this value itself. A leaf that records
 /// several sources holds one per path it can be reached by, and each of them names an object.
 ///
 /// The answer is exact where the leaves agree on one unit. Where they reach several, or where one
-/// of them is a value produced here rather than a projection, every object the root may denote is
+/// of them is a value produced here rather than a projection, every object the value may denote is
 /// reported together, so that a reader whose answer has to hold on all paths — whether this
 /// version owns the value — sees them all. `None` where no leaf names an object.
 ///
@@ -327,7 +327,7 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
 /// * `here` - the value's own identity, which is what it denotes on any path the leaves leave open.
 ///
 /// # Examples
-/// At the root of `unbox union { wait : Guard, pair : (Guard, Guard), mark : I64 }` read out of one
+/// Asked for `unbox union { wait : Guard, pair : (Guard, Guard), mark : I64 }` itself, read out of one
 /// borrowed node, the `wait` leaf is `⊥` and both `pair` leaves project out of that node, so the
 /// answer is `Exactly` the node's object. Give one of those two leaves a second operand and the
 /// answer becomes a `Join` naming both.
@@ -595,7 +595,7 @@ pub(crate) fn rc_units(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath>
 }
 
 /// Descend a type, pushing onto `out` the path of each unit root reached. `path` is the field path
-/// from the value's root down to `ty`, which each pushed unit is named relative to.
+/// from the whole value down to `ty`, which each pushed unit is named relative to.
 fn rc_units_go(
     ty: &Arc<TypeNode>,
     type_env: &TypeEnv,
@@ -640,7 +640,7 @@ pub(crate) fn truncate_to_unit(
         }
         if cur.is_rc_unit_root(type_env) {
             // A boxed value, an unboxed union, or a punched array is one unit; a leaf below it (a
-            // boxed leaf under a union variant, or the punched array's inner array) keys to its root.
+            // boxed leaf under a union variant, or the punched array's inner array) keys to that unit.
             break;
         }
         out.push(idx);
@@ -650,7 +650,7 @@ pub(crate) fn truncate_to_unit(
 }
 
 /// The reference-counting unit a leaf belongs to, as an object identity: its `origin`'s identity,
-/// truncated to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
+/// truncated to the unit. A leaf below an unboxed union keys to the union itself, so a whole-union
 /// retain and a consume of the payload get the same key: the consume marks that retain as needed,
 /// and cancellation keeps it together with the union release that un-bumps it.
 ///
@@ -764,8 +764,8 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
 }
 
 /// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
-/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `walk_name` names
-/// the walk in the message an out-of-range index aborts with.
+/// unboxed struct/tuple, so that a well-formed unit or leaf path index is in range. `walk_name`
+/// names the walk in the message an out-of-range index aborts with.
 fn field_type_at(
     ty: &Arc<TypeNode>,
     idx: usize,

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -700,8 +700,7 @@ fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPa
     // Truncation only descends, so an identity whose path stops above every unit root of its type
     // comes out naming no unit at all. A key like that puts a retain in a bucket no release of the
     // object can reach, which leaves the retain to be cancelled and the object freed while it is
-    // still held, so it is caught here, where the key is made, rather than where a program built
-    // with it goes wrong.
+    // still held, so the key is checked here, where it is made.
     let units = rc_units(ty, type_env);
     assert!(
         units.contains(&truncated),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod test_predicate_deduction;
 mod test_preliminary_commands;
 mod test_provenance;
 mod test_punched_array;
+mod test_rc_ir_aliasing;
 mod test_sanitize_setting;
 mod test_shared_boxed_swap;
 mod test_signal;

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -170,4 +170,71 @@ main = (
         let config = Configuration::develop_mode();
         test_source(BORROWED_UNION_FIELD_SOURCE, config);
     }
+
+    const DROPPED_UNION_FIELD_SOURCE: &str = r#"
+module Main;
+
+// A boxed value a variant of the union carries, so that the union holds a reference count.
+type Guard = box struct { allowed : Array U8 };
+
+// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+type Pair = unbox struct { first : Guard, second : Guard };
+
+// One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
+// root is resolved where a single leaf lies beneath it, where several do, and where none does.
+type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
+
+type Node = unbox struct { action : Action, n : I64 };
+
+// Reads the union out of a node it is handed and lets it die without consuming it. The node is only
+// read here, so the reading version borrows it and takes no reference of its own; the union has to
+// be recognized as the caller's rather than as a value produced here.
+glance : I64 -> Node -> I64;
+glance = |k, node| (
+    let action = node.@action;
+    eval action;
+    if k <= 0 { node.@n };
+    node.@n + glance(k - 1, node)
+);
+
+// The same, with the union asked about by a borrowing getter before it is dropped.
+sniff : I64 -> Node -> I64;
+sniff = |k, node| (
+    let action = node.@action;
+    if action.is_mark { node.@n };
+    if k <= 0 { 100 };
+    1 + sniff(k - 1, node)
+);
+
+main : IO ();
+main = (
+    let single = Node { action : Action::wait(Guard { allowed : ['a'] }), n : 5 };
+    let several = Node { action : Action::pair(Pair {
+        first : Guard { allowed : ['b'] }, second : Guard { allowed : ['c'] }
+    }), n : 2 };
+    let scalar = Node { action : Action::mark(9), n : 1 };
+    assert_eq(|_|"one leaf beneath the union's root", glance(3, single), 20);;
+    assert_eq(|_|"several leaves beneath the union's root", glance(3, several), 8);;
+    assert_eq(|_|"no leaf beneath the union's root", glance(3, scalar), 4);;
+    assert_eq(|_|"dropped after a borrowing getter", sniff(3, several), 103);;
+    assert_eq(|_|"dropped by the getter's own arm", sniff(3, scalar), 1);;
+    pure()
+);
+"#;
+
+    /// The boxed values a borrowed node carries survive a reader that reads the union out of it and
+    /// drops it without consuming it, and none of them leaks. Checked under Valgrind MemCheck: the
+    /// release that falls twice frees a value nothing reads afterwards, so the answers stay right.
+    #[test]
+    pub fn test_dropped_union_field_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        let config = Configuration::develop_mode();
+        test_source(DROPPED_UNION_FIELD_SOURCE, config);
+    }
 }

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -181,14 +181,14 @@ type Guard = box struct { allowed : Array U8 };
 type Pair = unbox struct { first : Guard, second : Guard };
 
 // One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
-// root is resolved where a single leaf lies beneath it, where several do, and where none does.
+// root is resolved with one leaf beneath it, with several, and with none.
 type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
 
 type Node = unbox struct { action : Action, n : I64 };
 
-// Reads the union out of a node it is handed and lets it die without consuming it. The node is only
-// read here, so the reading version borrows it and takes no reference of its own; the union has to
-// be recognized as the caller's rather than as a value produced here.
+// Reads the union out of a node it is handed and drops it without consuming it. This function only
+// reads the node, so it is given the node borrowed, and the union read out of it has to be
+// recognized as the caller's.
 glance : I64 -> Node -> I64;
 glance = |k, node| (
     let action = node.@action;
@@ -197,7 +197,7 @@ glance = |k, node| (
     node.@n + glance(k - 1, node)
 );
 
-// The same, with the union asked about by a borrowing getter before it is dropped.
+// The same, with the borrowing getter `is_mark` reading the union before it is dropped.
 sniff : I64 -> Node -> I64;
 sniff = |k, node| (
     let action = node.@action;
@@ -223,8 +223,9 @@ main = (
 "#;
 
     /// The boxed values a borrowed node carries survive a reader that reads the union out of it and
-    /// drops it without consuming it, and none of them leaks. Checked under Valgrind MemCheck: the
-    /// release that falls twice frees a value nothing reads afterwards, so the answers stay right.
+    /// drops it without consuming it, and none of them leaks. This runs under Valgrind MemCheck
+    /// because a double release here frees a value nothing reads afterwards, so the assertions on
+    /// their own still pass.
     #[test]
     pub fn test_dropped_union_field_memory_safety() {
         if !platform_valgrind_supported() {

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -1,18 +1,17 @@
 // Memory-safety tests for a union read out of an aggregate the reading function only borrows.
 //
 // An unboxed union is one reference-counting unit: an operation on it dispatches on the tag rather
-// than naming a variant, so its reference count is kept at the union's root. Its provenance,
-// though, is recorded one level down, on the leaves of its variants. A reader that asks where the
-// union at that root came from therefore finds nothing recorded and would take it for a value
-// produced on the spot — its own to release — when it is really the caller's, read out of a
-// borrowed parameter. The release then falls twice: once in the callee that never took a
-// reference, once in the caller that did.
+// than naming a variant, so its reference count is kept on the union itself. Its provenance, though,
+// is recorded one level down, on the leaves of its variants. A reader that asks where the union came
+// from therefore finds nothing recorded and would take it for a value produced on the spot — its own
+// to release — when it is really the caller's, read out of a borrowed parameter. The release then
+// falls twice: once in the callee that never took a reference, once in the caller that did.
 //
 // The program below has that shape: a node of an array carries an unboxed union with boxed
 // variants, a function reads the union out of a node it is handed and only looks at it, and the
 // walk that hands the nodes over is a loop whose state carries an array. Two of the union's
 // variants carry a boxed value: one carries a single one, and one carries a pair of them, so that
-// the root is resolved both where a single leaf lies beneath it and where several have to agree on
+// the union is resolved both with a single leaf beneath it and with several that have to agree on
 // the object they come from.
 
 #[cfg(test)]
@@ -29,7 +28,7 @@ module Main;
 // A boxed value a variant of the union carries, so that the union holds a reference count.
 type Guard = box struct { allowed : Array U8 };
 
-// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+// Two boxed values in one variant, so that the union has several leaves beneath it.
 type Pair = unbox struct { first : Guard, second : Guard };
 
 // The union the node carries: one variant holds a boxed value, one a pair of them, and one only a
@@ -177,11 +176,11 @@ module Main;
 // A boxed value a variant of the union carries, so that the union holds a reference count.
 type Guard = box struct { allowed : Array U8 };
 
-// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+// Two boxed values in one variant, so that the union has several leaves beneath it.
 type Pair = unbox struct { first : Guard, second : Guard };
 
-// One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
-// root is resolved with one leaf beneath it, with several, and with none.
+// One variant holds a boxed value, one a pair of them, and one only a number, so that the union is
+// resolved with one leaf beneath it, with several, and with none.
 type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
 
 type Node = unbox struct { action : Action, n : I64 };
@@ -213,9 +212,9 @@ main = (
         first : Guard { allowed : ['b'] }, second : Guard { allowed : ['c'] }
     }), n : 2 };
     let scalar = Node { action : Action::mark(9), n : 1 };
-    assert_eq(|_|"one leaf beneath the union's root", glance(3, single), 20);;
-    assert_eq(|_|"several leaves beneath the union's root", glance(3, several), 8);;
-    assert_eq(|_|"no leaf beneath the union's root", glance(3, scalar), 4);;
+    assert_eq(|_|"one leaf beneath the union", glance(3, single), 20);;
+    assert_eq(|_|"several leaves beneath the union", glance(3, several), 8);;
+    assert_eq(|_|"no leaf beneath the union", glance(3, scalar), 4);;
     assert_eq(|_|"dropped after a borrowing getter", sniff(3, several), 103);;
     assert_eq(|_|"dropped by the getter's own arm", sniff(3, scalar), 1);;
     pure()

--- a/src/tests/test_rc_ir_aliasing.rs
+++ b/src/tests/test_rc_ir_aliasing.rs
@@ -1,14 +1,16 @@
-// A value reached through a union, a struct, a closure or a tuple keeps the reference its container
-// holds, so mutating what is read out of it copies rather than writes in place. Each case keeps a
-// witness alive across the mutation and asserts the witness is unchanged.
+// A value read out of a union, a struct, a closure or a tuple keeps the reference its container
+// holds, so mutating that value copies it and leaves the container's own copy as it was. Each case
+// keeps the container alive across the mutation and asserts that what it holds still reads as it
+// did.
 
 #[cfg(test)]
 mod rc_ir_aliasing_tests {
     use crate::{configuration::Configuration, tests::test_util::test_source};
 
-    /// Reading a value out of each kind of container and mutating it leaves the container's own copy
-    /// as it was, for a union built on the spot, a boxed and an unboxed union, a boxed and an
-    /// unboxed struct, a closure capture, and one array stored in both fields of a tuple.
+    /// Reading a value out of a container and mutating it leaves the container's own copy as it was.
+    /// The containers covered are an `Option::some` built on the spot, a boxed and an unboxed union,
+    /// a boxed and an unboxed struct, a closure capture, and one array stored in both fields of a
+    /// tuple.
     #[test]
     pub fn test_container_keeps_its_reference_across_a_read_out() {
         let source = r#"
@@ -25,7 +27,7 @@ mod rc_ir_aliasing_tests {
                 let base = Array::fill(4, 0);
                 let taken = match Option::some(base) { some(x) => x.set(0, 111), none() => base };
                 assert_eq(|_|"payload mutated", taken.@(0), 111);;
-                assert_eq(|_|"payload witness", base.@(0), 0);;
+                assert_eq(|_|"payload unchanged", base.@(0), 0);;
 
                 // A boxed union still alive after its payload is read out.
                 let boxed = BU::a(Array::fill(4, 0));
@@ -33,7 +35,7 @@ mod rc_ir_aliasing_tests {
                 let mutated_boxed = out_of_boxed.set(1, 222);
                 assert_eq(|_|"boxed union payload mutated", mutated_boxed.@(1), 222);;
                 assert_eq(
-                    |_|"boxed union witness",
+                    |_|"boxed union payload unchanged",
                     match boxed { a(x) => x.@(1), b(_) => -1 }, 0
                 );;
 
@@ -43,7 +45,7 @@ mod rc_ir_aliasing_tests {
                 let mutated_unboxed = out_of_unboxed.set(2, 333);
                 assert_eq(|_|"unboxed union payload mutated", mutated_unboxed.@(2), 333);;
                 assert_eq(
-                    |_|"unboxed union witness",
+                    |_|"unboxed union payload unchanged",
                     match unboxed { p(x) => x.@(2), q(_) => -1 }, 0
                 );;
 
@@ -51,25 +53,25 @@ mod rc_ir_aliasing_tests {
                 let plain = S { xs : Array::fill(4, 0), n : 1 };
                 let S { xs : plain_field, n : _ } = plain;
                 assert_eq(|_|"unboxed struct field mutated", plain_field.set(3, 444).@(3), 444);;
-                assert_eq(|_|"unboxed struct witness", plain.@xs.@(3), 0);;
+                assert_eq(|_|"unboxed struct field unchanged", plain.@xs.@(3), 0);;
 
                 // A boxed struct destructured while the struct is still alive.
                 let boxed_struct = BS { xs : Array::fill(4, 0), n : 1 };
                 let BS { xs : boxed_field, n : _ } = boxed_struct;
                 assert_eq(|_|"boxed struct field mutated", boxed_field.set(3, 555).@(3), 555);;
-                assert_eq(|_|"boxed struct witness", boxed_struct.@xs.@(3), 0);;
+                assert_eq(|_|"boxed struct field unchanged", boxed_struct.@xs.@(3), 0);;
 
                 // A closure capturing an array the enclosing scope also holds.
                 let captured = Array::fill(4, 0);
                 let writer = |k| captured.set(0, k);
                 assert_eq(|_|"capture mutated", writer(666).@(0), 666);;
-                assert_eq(|_|"capture witness", captured.@(0), 0);;
+                assert_eq(|_|"capture unchanged", captured.@(0), 0);;
 
                 // One array stored in both fields of a tuple.
                 let twice = Array::fill(4, 0);
                 let pair = (twice, twice);
                 assert_eq(|_|"tuple field mutated", pair.@0.set(0, 777).@(0), 777);;
-                assert_eq(|_|"tuple field witness", pair.@1.@(0), 0);;
+                assert_eq(|_|"tuple field unchanged", pair.@1.@(0), 0);;
 
                 pure()
             );

--- a/src/tests/test_rc_ir_aliasing.rs
+++ b/src/tests/test_rc_ir_aliasing.rs
@@ -1,0 +1,79 @@
+// A value reached through a union, a struct, a closure or a tuple keeps the reference its container
+// holds, so mutating what is read out of it copies rather than writes in place. Each case keeps a
+// witness alive across the mutation and asserts the witness is unchanged.
+
+#[cfg(test)]
+mod rc_ir_aliasing_tests {
+    use crate::{configuration::Configuration, tests::test_util::test_source};
+
+    /// Reading a value out of each kind of container and mutating it leaves the container's own copy
+    /// as it was, for a union built on the spot, a boxed and an unboxed union, a boxed and an
+    /// unboxed struct, a closure capture, and one array stored in both fields of a tuple.
+    #[test]
+    pub fn test_container_keeps_its_reference_across_a_read_out() {
+        let source = r#"
+            module Main;
+
+            type BU = box union { a : Array I64, b : I64 };
+            type UU = unbox union { p : Array I64, q : I64 };
+            type S = struct { xs : Array I64, n : I64 };
+            type BS = box struct { xs : Array I64, n : I64 };
+
+            main : IO ();
+            main = (
+                // A union built on the spot, whose payload the enclosing scope also holds.
+                let base = Array::fill(4, 0);
+                let taken = match Option::some(base) { some(x) => x.set(0, 111), none() => base };
+                assert_eq(|_|"payload mutated", taken.@(0), 111);;
+                assert_eq(|_|"payload witness", base.@(0), 0);;
+
+                // A boxed union still alive after its payload is read out.
+                let boxed = BU::a(Array::fill(4, 0));
+                let out_of_boxed = match boxed { a(x) => x, b(_) => Array::fill(1, 0) };
+                let mutated_boxed = out_of_boxed.set(1, 222);
+                assert_eq(|_|"boxed union payload mutated", mutated_boxed.@(1), 222);;
+                assert_eq(
+                    |_|"boxed union witness",
+                    match boxed { a(x) => x.@(1), b(_) => -1 }, 0
+                );;
+
+                // An unboxed union still alive after its payload is read out.
+                let unboxed = UU::p(Array::fill(4, 0));
+                let out_of_unboxed = match unboxed { p(x) => x, q(_) => Array::fill(1, 0) };
+                let mutated_unboxed = out_of_unboxed.set(2, 333);
+                assert_eq(|_|"unboxed union payload mutated", mutated_unboxed.@(2), 333);;
+                assert_eq(
+                    |_|"unboxed union witness",
+                    match unboxed { p(x) => x.@(2), q(_) => -1 }, 0
+                );;
+
+                // An unboxed struct destructured while the struct is still alive.
+                let plain = S { xs : Array::fill(4, 0), n : 1 };
+                let S { xs : plain_field, n : _ } = plain;
+                assert_eq(|_|"unboxed struct field mutated", plain_field.set(3, 444).@(3), 444);;
+                assert_eq(|_|"unboxed struct witness", plain.@xs.@(3), 0);;
+
+                // A boxed struct destructured while the struct is still alive.
+                let boxed_struct = BS { xs : Array::fill(4, 0), n : 1 };
+                let BS { xs : boxed_field, n : _ } = boxed_struct;
+                assert_eq(|_|"boxed struct field mutated", boxed_field.set(3, 555).@(3), 555);;
+                assert_eq(|_|"boxed struct witness", boxed_struct.@xs.@(3), 0);;
+
+                // A closure capturing an array the enclosing scope also holds.
+                let captured = Array::fill(4, 0);
+                let writer = |k| captured.set(0, k);
+                assert_eq(|_|"capture mutated", writer(666).@(0), 666);;
+                assert_eq(|_|"capture witness", captured.@(0), 0);;
+
+                // One array stored in both fields of a tuple.
+                let twice = Array::fill(4, 0);
+                let pair = (twice, twice);
+                assert_eq(|_|"tuple field mutated", pair.@0.set(0, 777).@(0), 777);;
+                assert_eq(|_|"tuple field witness", pair.@1.@(0), 0);;
+
+                pure()
+            );
+        "#;
+        test_source(&source, Configuration::develop_mode());
+    }
+}

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -1,8 +1,11 @@
-// Integration tests for the RC IR term simplifier, checked through the `--emit-rc-ir` dump.
+// Tests for the RC IR term simplifier: what it removes, checked through the `--emit-rc-ir` dump, and
+// what the program it leaves behind computes.
+//
 // A read loop over `range(0, size).fold` lowers to a specialized fold driver whose loop-carried state
 // is the `Option` that `range`'s `advance` builds and `fold` immediately matches. The simplifier
 // cancels that union (case-of-case + case-of-known-constructor), so the driver keeps only the plain
-// `RangeIterator` two-scalar state and no union construction — the property these tests assert.
+// `RangeIterator` two-scalar state and no union construction — the property the integration tests
+// assert. The value tests compile and run programs whose shape drives the same rewrite from source.
 
 #[cfg(test)]
 mod integration_tests {
@@ -104,5 +107,47 @@ mod integration_tests {
             "the built executable did not run cleanly"
         );
         assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), "4950");
+    }
+}
+
+#[cfg(test)]
+mod value_tests {
+    use crate::{configuration::Configuration, tests::test_util::test_source};
+
+    /// A nest of matches whose every inner arm builds the same variant — the shape case-of-case
+    /// floats the outer match into — computes what the same program computes with the rewrite off.
+    #[test]
+    pub fn test_nested_matches_over_one_variant() {
+        let source = r#"
+            module Main;
+
+            f : I64 -> I64;
+            f = |n| (
+                match (if n % 5 == 0 { Option::some(n) } else { Option::some(n + 3) }) {
+                    some(v1) => (
+                        match (if v1 % 4 == 0 { Option::some(v1) } else { Option::some(v1 + 2) }) {
+                            some(v2) => (
+                                match (if v2 % 3 == 0 { Option::some(v2) } else { Option::some(v2 + 1) }) {
+                                    some(v3) => v3 * 3 + n,
+                                    none() => 0
+                                }
+                            ),
+                            none() => 0
+                        }
+                    ),
+                    none() => 0
+                }
+            );
+
+            main : IO ();
+            main = (
+                assert_eq(
+                    |_|"nested matches over one variant",
+                    Iterator::range(0, 5).map(f).to_array, [0, 16, 26, 30, 31]
+                );;
+                pure()
+            );
+        "#;
+        test_source(&source, Configuration::develop_mode());
     }
 }

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -14,14 +14,15 @@ mod integration_tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
+    /// The directory holding the case projects, `src/tests/test_simplify/cases` in the source tree.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_simplify/cases");
         path
     }
 
-    // Copy the test cases into a fresh temporary directory so parallel test runs do not conflict, and
-    // return the directory of the named case project.
+    /// Copy the test cases into a fresh temporary directory so parallel test runs do not conflict,
+    /// and return the directory of the named case project.
     fn setup_test_env(case: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let dst = temp_dir.path().to_path_buf();
@@ -30,9 +31,10 @@ mod integration_tests {
         (temp_dir, project_dir)
     }
 
-    // Build the case project at `max` (where the simplifier runs) with `--emit-rc-ir all`, returning
-    // the dumped RC IR of every module. The `range.fold` driver is a specialized `Std::Iterator`
-    // symbol, so the whole-program dump is needed to see it. Also leaves a runnable executable.
+    /// Build the case project at `max` (where the simplifier runs) with `--emit-rc-ir all`,
+    /// returning the dumped RC IR of every module. The `range.fold` driver is a specialized
+    /// `Std::Iterator` symbol, so the whole-program dump is needed to see it. Also leaves a runnable
+    /// executable.
     fn emit_all_rc_ir(project_dir: &Path) -> String {
         let output = fix_command_at_opt_level("build", "max")
             .arg("--emit-rc-ir")
@@ -52,7 +54,8 @@ mod integration_tests {
             .unwrap_or_else(|e| panic!("failed to read {}: {}", dump_path.display(), e))
     }
 
-    // The body of each `fn` block in the dump whose header line contains all of `needles`.
+    /// Each `fn` block of the dump whose header line contains all of `needles`: the header line
+    /// itself and every line up to the next `fn` header.
     fn fn_bodies_matching<'a>(dump: &'a str, needles: &[&str]) -> Vec<String> {
         let mut bodies = Vec::new();
         let mut current: Option<String> = None;
@@ -76,6 +79,10 @@ mod integration_tests {
         bodies
     }
 
+    /// The `range.fold` driver the simplifier leaves behind builds no union: the `Option` that
+    /// `range`'s `advance` returns and `fold` immediately matches is cancelled, so the loop-carried
+    /// state is the plain `RangeIterator` alone. The built program still sums the range, so the
+    /// removal leaves what the loop computes intact.
     #[test]
     fn test_range_fold_union_removed() {
         let (_temp_dir, project_dir) = setup_test_env("read_fold");

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -1,11 +1,12 @@
-// Tests for the RC IR term simplifier: what it removes, checked through the `--emit-rc-ir` dump, and
-// what the program it leaves behind computes.
+// Tests for the RC IR term simplifier: what it removes, read from the `--emit-rc-ir` dump, and what
+// the simplified program computes.
 //
 // A read loop over `range(0, size).fold` lowers to a specialized fold driver whose loop-carried state
 // is the `Option` that `range`'s `advance` builds and `fold` immediately matches. The simplifier
 // cancels that union (case-of-case + case-of-known-constructor), so the driver keeps only the plain
 // `RangeIterator` two-scalar state and no union construction — the property the integration tests
-// assert. The value tests compile and run programs whose shape drives the same rewrite from source.
+// assert. The value tests compile and run Fix programs written to drive the same rewrite, and check
+// what each one computes.
 
 #[cfg(test)]
 mod integration_tests {
@@ -114,8 +115,9 @@ mod integration_tests {
 mod value_tests {
     use crate::{configuration::Configuration, tests::test_util::test_source};
 
-    /// A nest of matches whose every inner arm builds the same variant — the shape case-of-case
-    /// floats the outer match into — computes what the same program computes with the rewrite off.
+    /// Checks the values a nest of matches computes when every inner arm builds the same variant.
+    /// That is the shape case-of-case floats the outer match into, and the rewrite has to leave
+    /// every value as the source computes it.
     #[test]
     pub fn test_nested_matches_over_one_variant() {
         let source = r#"

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -70,8 +70,8 @@ mod union_rc_shapes_tests {
     /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
     /// the references it holds live inside its variants and differ in shape from one variant to the
     /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
-    /// while a second binding keeps the array shared, makes the copy the modification takes reach
-    /// those units through two levels of unboxed aggregate. Run under memcheck.
+    /// while a second binding keeps the array shared, makes the modification copy an element, and
+    /// the copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
     #[test]
     pub fn test_nested_unboxed_union_shared_mod() {
         let source = r#"

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -156,11 +156,11 @@ type Guard = box struct { allowed : Array I64 };
 
 // A payload whose one reference-counting unit lies below its root. The second field keeps the
 // struct from being unwrapped down to the boxed value it holds.
-type One = unbox struct { only : Guard, tag : I64 };
+type Wrapped = unbox struct { held : Guard, tag : I64 };
 
-// The `pair` payload holds two units, the `one` payload holds a unit below its root, and `mark`
-// holds none.
-type Action = unbox union { pair : (Array I64, Array I64), one : One, mark : I64 };
+// The `pair` payload holds two units, the `wrapped` payload holds a unit below its root, and
+// `mark` holds none.
+type Action = unbox union { pair : (Array I64, Array I64), wrapped : Wrapped, mark : I64 };
 
 // Reads the union without consuming it. The recursion keeps the call out of line.
 peek : Action -> I64 -> I64;
@@ -171,57 +171,61 @@ peek = |action, n| (
 
 // Builds the union out of a pair that stays live beside it, then reads both back.
 via_pair : (Array I64, Array I64) -> I64 -> I64;
-via_pair = |both, n| (
+via_pair = |payload, n| (
     if n == 0 { 0 };
-    let action = Action::pair(both);
-    let seen = peek(action, 2);
-    let tagged = if action.is_pair { 1 } else { 0 };
-    let (first, second) = both;
-    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+    let action = Action::pair(payload);
+    let seen_in_call = peek(action, 2);
+    let seen_after_call = if action.is_pair { 1 } else { 0 };
+    let (first, second) = payload;
+    seen_in_call + seen_after_call
+        + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
 // The same for a payload whose unit lies below its root.
-via_one : One -> I64 -> I64;
-via_one = |one, n| (
+via_wrapped : Wrapped -> I64 -> I64;
+via_wrapped = |payload, n| (
     if n == 0 { 0 };
-    let action = Action::one(one);
-    let seen = peek(action, 2);
-    let tagged = if action.is_one { 1 } else { 0 };
-    seen + tagged + one.@tag + one.@only.@allowed.@size * 10 + one.@only.@allowed.@(0)
+    let action = Action::wrapped(payload);
+    let seen_in_call = peek(action, 2);
+    let seen_after_call = if action.is_wrapped { 1 } else { 0 };
+    seen_in_call + seen_after_call + payload.@tag
+        + payload.@held.@allowed.@size * 10 + payload.@held.@allowed.@(0)
 );
 
 // `Std::Option` is an unboxed union too, and a pair payload gives it the same shape.
-seen_option : Option (Array I64, Array I64) -> I64 -> I64;
-seen_option = |opt, n| (
+peek_option : Option (Array I64, Array I64) -> I64 -> I64;
+peek_option = |opt, n| (
     if n == 0 { if opt.is_some { 1 } else { 0 } };
-    seen_option(opt, n - 1)
+    peek_option(opt, n - 1)
 );
 
 via_option : (Array I64, Array I64) -> I64 -> I64;
-via_option = |both, n| (
+via_option = |payload, n| (
     if n == 0 { 0 };
-    let opt = Option::some(both);
-    let seen = seen_option(opt, 2);
-    let tagged = if opt.is_some { 1 } else { 0 };
-    let (first, second) = both;
-    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+    let opt = Option::some(payload);
+    let seen_in_call = peek_option(opt, 2);
+    let seen_after_call = if opt.is_some { 1 } else { 0 };
+    let (first, second) = payload;
+    seen_in_call + seen_after_call
+        + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
 // `Std::Result` likewise.
-seen_result : Result String (Array I64, Array I64) -> I64 -> I64;
-seen_result = |res, n| (
+peek_result : Result String (Array I64, Array I64) -> I64 -> I64;
+peek_result = |res, n| (
     if n == 0 { if res.is_ok { 1 } else { 0 } };
-    seen_result(res, n - 1)
+    peek_result(res, n - 1)
 );
 
 via_result : (Array I64, Array I64) -> I64 -> I64;
-via_result = |both, n| (
+via_result = |payload, n| (
     if n == 0 { 0 };
-    let res : Result String (Array I64, Array I64) = ok(both);
-    let seen = seen_result(res, 2);
-    let tagged = if res.is_ok { 1 } else { 0 };
-    let (first, second) = both;
-    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+    let res : Result String (Array I64, Array I64) = ok(payload);
+    let seen_in_call = peek_result(res, 2);
+    let seen_after_call = if res.is_ok { 1 } else { 0 };
+    let (first, second) = payload;
+    seen_in_call + seen_after_call
+        + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
 main : IO ();
@@ -232,7 +236,7 @@ main = (
     );;
     assert_eq(
         |_|"the boxed value below the payload's root is read back as it was built",
-        via_one(One { only : Guard { allowed : [5, 6] }, tag : 3 }, 1), 29
+        via_wrapped(Wrapped { held : Guard { allowed : [5, 6] }, tag : 3 }, 1), 29
     );;
     assert_eq(
         |_|"the pair an option holds is read back as it was built",
@@ -246,7 +250,7 @@ main = (
 );
 "#;
 
-    /// Both payloads are read back as they were built. A pair freed while the union still holds it
+    /// Every payload is read back as it was built. A pair freed while the union still holds it
     /// changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_union_payload_units_correctness() {

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -137,9 +137,15 @@ mod union_rc_shapes_tests {
     // payload it is given in place. Where that payload's own root is not a single unit — a pair of
     // boxed values, or an unboxed struct whose one boxed field sits a level down — the union's root
     // and the payload's units are different objects, and the count of each has to be kept where its
-    // own object is. The union below is built out of both shapes, each beside the payload it was
-    // built from, so that a reference of the payload lives on after the union is made and is read
-    // through both names.
+    // own object is.
+    //
+    // Each union below is read through a call that stays out of line, and read once more after that
+    // call returns, so that it reaches reference counting instead of being folded into the
+    // constructor that built it. The payload it was built from stays live beside it and is read
+    // back at the end. Freeing that payload early changes the answer for the pair; for the shape
+    // whose unit lies below its root the answer stays right either way, and what catches a key made
+    // for it is the assertion in `unit_of`, which the development-mode build these tests run under
+    // has in place.
     const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
 module Main;
 
@@ -153,39 +159,50 @@ type One = unbox struct { only : Guard };
 // holds none.
 type Action = unbox union { pair : (Array I64, Array I64), one : One, mark : I64 };
 
+// Reads the union without consuming it. The recursion keeps the call out of line.
+peek : Action -> I64 -> I64;
+peek = |action, n| (
+    if n == 0 { if action.is_pair { 1 } else { 0 } };
+    peek(action, n - 1)
+);
+
 // Builds the union out of a pair that stays live beside it, then reads both back.
-via_pair : (Array I64, Array I64) -> I64;
-via_pair = |both| (
+via_pair : (Array I64, Array I64) -> I64 -> I64;
+via_pair = |both, n| (
+    if n == 0 { 0 };
     let action = Action::pair(both);
+    let seen = peek(action, 2);
     let tagged = if action.is_pair { 1 } else { 0 };
     let (first, second) = both;
-    tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
 // The same for a payload whose unit lies below its root.
-via_one : Guard -> I64;
-via_one = |guard| (
+via_one : Guard -> I64 -> I64;
+via_one = |guard, n| (
+    if n == 0 { 0 };
     let action = Action::one(One { only : guard });
+    let seen = peek(action, 2);
     let tagged = if action.is_one { 1 } else { 0 };
-    tagged + guard.@allowed.@size * 10 + guard.@allowed.@(0)
+    seen + tagged + guard.@allowed.@size * 10 + guard.@allowed.@(0)
 );
 
 main : IO ();
 main = (
     assert_eq(
         |_|"the pair is read back as it was built",
-        via_pair((Array::fill(3, 7), Array::fill(4, 9))), 717
+        via_pair((Array::fill(3, 7), Array::fill(4, 9)), 1), 718
     );;
     assert_eq(
         |_|"the boxed value is read back as it was built",
-        via_one(Guard { allowed : [5, 6] }), 26
+        via_one(Guard { allowed : [5, 6] }, 1), 26
     );;
     pure()
 );
 "#;
 
-    /// Both payloads are read back as they were built. A payload freed while the union still holds
-    /// it changes the answer, so this catches it without Valgrind.
+    /// Both payloads are read back as they were built. A pair freed while the union still holds it
+    /// changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_union_payload_units_correctness() {
         let mut config = Configuration::develop_mode();

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -1,9 +1,14 @@
 // Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
-// then nobody reads, and an unboxed union nested inside unboxed aggregates.
+// then nobody reads, an unboxed union nested inside unboxed aggregates, and a union built out of a
+// payload whose root is not one reference-counting unit.
 
 #[cfg(test)]
 mod union_rc_shapes_tests {
-    use crate::{configuration::Configuration, tests::test_util::test_source};
+    use crate::{
+        configuration::{Configuration, ValgrindTool},
+        misc::{function_name, platform_valgrind_supported},
+        tests::test_util::test_source,
+    };
 
     #[test]
     pub fn test_discarded_operand_released_once() {
@@ -126,5 +131,79 @@ mod union_rc_shapes_tests {
             );
         "#;
         test_source(&source, Configuration::develop_mode());
+    }
+
+    // An unboxed union is one reference-counting unit, kept at its root, and building one lays the
+    // payload it is given in place. Where that payload's own root is not a single unit — a pair of
+    // boxed values, or an unboxed struct whose one boxed field sits a level down — the union's root
+    // and the payload's units are different objects, and the count of each has to be kept where its
+    // own object is. The union below is built out of both shapes, each beside the payload it was
+    // built from, so that a reference of the payload lives on after the union is made and is read
+    // through both names.
+    const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
+module Main;
+
+// A boxed value a payload carries, so that the payload holds a reference count.
+type Guard = box struct { allowed : Array I64 };
+
+// A payload whose reference-counting unit lies below its root.
+type One = unbox struct { only : Guard };
+
+// The `pair` payload holds two units, the `one` payload holds a unit below its root, and `mark`
+// holds none.
+type Action = unbox union { pair : (Array I64, Array I64), one : One, mark : I64 };
+
+// Builds the union out of a pair that stays live beside it, then reads both back.
+via_pair : (Array I64, Array I64) -> I64;
+via_pair = |both| (
+    let action = Action::pair(both);
+    let tagged = if action.is_pair { 1 } else { 0 };
+    let (first, second) = both;
+    tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+);
+
+// The same for a payload whose unit lies below its root.
+via_one : Guard -> I64;
+via_one = |guard| (
+    let action = Action::one(One { only : guard });
+    let tagged = if action.is_one { 1 } else { 0 };
+    tagged + guard.@allowed.@size * 10 + guard.@allowed.@(0)
+);
+
+main : IO ();
+main = (
+    assert_eq(
+        |_|"the pair is read back as it was built",
+        via_pair((Array::fill(3, 7), Array::fill(4, 9))), 717
+    );;
+    assert_eq(
+        |_|"the boxed value is read back as it was built",
+        via_one(Guard { allowed : [5, 6] }), 26
+    );;
+    pure()
+);
+"#;
+
+    /// Both payloads are read back as they were built, which a payload freed while the union still
+    /// holds it fails without Valgrind.
+    #[test]
+    pub fn test_union_payload_units_correctness() {
+        let mut config = Configuration::develop_mode();
+        config.set_valgrind(ValgrindTool::None);
+        test_source(UNION_PAYLOAD_UNITS_SOURCE, config);
+    }
+
+    /// The boxed values the payloads carry are freed exactly once and none of them leaks, checked
+    /// under Valgrind MemCheck.
+    #[test]
+    pub fn test_union_payload_units_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        test_source(UNION_PAYLOAD_UNITS_SOURCE, Configuration::develop_mode());
     }
 }

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -142,18 +142,21 @@ mod union_rc_shapes_tests {
     // Each union below is read through a call that stays out of line, and read once more after that
     // call returns, so that it reaches reference counting instead of being folded into the
     // constructor that built it. The payload it was built from stays live beside it and is read
-    // back at the end. Freeing that payload early changes the answer for the pair; for the shape
-    // whose unit lies below its root the answer stays right either way, and what catches a key made
-    // for it is the assertion in `unit_of`, which the development-mode build these tests run under
-    // has in place.
+    // back at the end. Freeing that payload early changes the answer for the shapes whose payload
+    // holds two units; for the shape whose unit lies below its root the answer stays right either
+    // way, and what catches a key made for it is the assertion in `unit_of`. That payload arrives as
+    // a parameter, so that the union's root is resolved from a value whose own root is not a unit,
+    // and it carries a second field, so that the struct around the boxed value survives to the RC
+    // IR.
     const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
 module Main;
 
 // A boxed value a payload carries, so that the payload holds a reference count.
 type Guard = box struct { allowed : Array I64 };
 
-// A payload whose reference-counting unit lies below its root.
-type One = unbox struct { only : Guard };
+// A payload whose one reference-counting unit lies below its root. The second field keeps the
+// struct from being unwrapped down to the boxed value it holds.
+type One = unbox struct { only : Guard, tag : I64 };
 
 // The `pair` payload holds two units, the `one` payload holds a unit below its root, and `mark`
 // holds none.
@@ -178,13 +181,47 @@ via_pair = |both, n| (
 );
 
 // The same for a payload whose unit lies below its root.
-via_one : Guard -> I64 -> I64;
-via_one = |guard, n| (
+via_one : One -> I64 -> I64;
+via_one = |one, n| (
     if n == 0 { 0 };
-    let action = Action::one(One { only : guard });
+    let action = Action::one(one);
     let seen = peek(action, 2);
     let tagged = if action.is_one { 1 } else { 0 };
-    seen + tagged + guard.@allowed.@size * 10 + guard.@allowed.@(0)
+    seen + tagged + one.@tag + one.@only.@allowed.@size * 10 + one.@only.@allowed.@(0)
+);
+
+// `Std::Option` is an unboxed union too, and a pair payload gives it the same shape.
+seen_option : Option (Array I64, Array I64) -> I64 -> I64;
+seen_option = |opt, n| (
+    if n == 0 { if opt.is_some { 1 } else { 0 } };
+    seen_option(opt, n - 1)
+);
+
+via_option : (Array I64, Array I64) -> I64 -> I64;
+via_option = |both, n| (
+    if n == 0 { 0 };
+    let opt = Option::some(both);
+    let seen = seen_option(opt, 2);
+    let tagged = if opt.is_some { 1 } else { 0 };
+    let (first, second) = both;
+    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
+);
+
+// `Std::Result` likewise.
+seen_result : Result String (Array I64, Array I64) -> I64 -> I64;
+seen_result = |res, n| (
+    if n == 0 { if res.is_ok { 1 } else { 0 } };
+    seen_result(res, n - 1)
+);
+
+via_result : (Array I64, Array I64) -> I64 -> I64;
+via_result = |both, n| (
+    if n == 0 { 0 };
+    let res : Result String (Array I64, Array I64) = ok(both);
+    let seen = seen_result(res, 2);
+    let tagged = if res.is_ok { 1 } else { 0 };
+    let (first, second) = both;
+    seen + tagged + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
 main : IO ();
@@ -194,8 +231,16 @@ main = (
         via_pair((Array::fill(3, 7), Array::fill(4, 9)), 1), 718
     );;
     assert_eq(
-        |_|"the boxed value is read back as it was built",
-        via_one(Guard { allowed : [5, 6] }, 1), 26
+        |_|"the boxed value below the payload's root is read back as it was built",
+        via_one(One { only : Guard { allowed : [5, 6] }, tag : 3 }, 1), 29
+    );;
+    assert_eq(
+        |_|"the pair an option holds is read back as it was built",
+        via_option((Array::fill(3, 7), Array::fill(4, 9)), 1), 718
+    );;
+    assert_eq(
+        |_|"the pair a result holds is read back as it was built",
+        via_result((Array::fill(3, 7), Array::fill(4, 9)), 1), 718
     );;
     pure()
 );

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -67,8 +67,8 @@ mod union_rc_shapes_tests {
         test_source(&source, Configuration::develop_mode());
     }
 
-    /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
-    /// the references it holds live inside its variants and differ in shape from one variant to the
+    /// An unboxed union is one reference-counting unit, counted on the union itself, while the
+    /// references it holds live inside its variants and differ in shape from one variant to the
     /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
     /// while a second binding keeps the array shared, makes the modification copy an element, and
     /// the copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
@@ -88,8 +88,8 @@ mod union_rc_shapes_tests {
                 num(i) => i
             };
 
-            // Cycles through the three variants, so that the units beneath one union's root differ
-            // from element to element.
+            // Cycles through the three variants, so that the units beneath one union differ from
+            // element to element.
             mk : I64 -> Payload;
             mk = |k| (
                 if k % 3 == 0 { Payload::arr(Array::fill(k + 1, k)) };

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -10,13 +10,13 @@ mod union_rc_shapes_tests {
         tests::test_util::test_source,
     };
 
+    /// Matching a union built on the spot lets the simplifier replace the match with the arm it
+    /// knows is taken, substituting the payload the construction was given. Where the arm then
+    /// ignores that payload — an arm binding nothing, a pattern binding a field the body never
+    /// reads — the substituted operand is left with no reader, and its reference has to be released
+    /// exactly once all the same. Run under memcheck.
     #[test]
     pub fn test_discarded_operand_released_once() {
-        // Matching a union built on the spot lets the simplifier replace the match with the arm it
-        // knows is taken, substituting the payload the construction was given. Where the arm then
-        // ignores that payload — an arm binding nothing, a pattern binding a field the body never
-        // reads — the substituted operand is left with no reader, and its reference has to be
-        // released exactly once all the same. Run under memcheck.
         let source = r#"
             module Main;
 
@@ -67,14 +67,13 @@ mod union_rc_shapes_tests {
         test_source(&source, Configuration::develop_mode());
     }
 
+    /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
+    /// the references it holds live inside its variants and differ in shape from one variant to the
+    /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
+    /// while a second binding keeps the array shared, makes the copy the modification takes reach
+    /// those units through two levels of unboxed aggregate. Run under memcheck.
     #[test]
     pub fn test_nested_unboxed_union_shared_mod() {
-        // An unboxed union is one reference-counting unit whose root is where its count is kept,
-        // while the references it holds live inside its variants and differ in shape from one
-        // variant to the next. Nesting such a union inside a struct and a tuple, and then modifying
-        // an array of them while a second binding keeps the array shared, makes the copy the
-        // modification takes reach those units through two levels of unboxed aggregate. Run under
-        // memcheck.
         let source = r#"
             module Main;
 

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -1,6 +1,6 @@
 // Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
 // then nobody reads, an unboxed union nested inside unboxed aggregates, and a union built out of a
-// payload that holds its reference-counting units below its own root.
+// payload that holds its reference-counting units below the payload itself.
 
 #[cfg(test)]
 mod union_rc_shapes_tests {
@@ -133,32 +133,31 @@ mod union_rc_shapes_tests {
         test_source(&source, Configuration::develop_mode());
     }
 
-    // An unboxed union is one reference-counting unit, kept at its root, and building one lays the
-    // payload it is given in place. Where the payload holds its units below its own root — a pair
-    // of boxed values, or an unboxed struct whose one boxed field sits a level down — the union's
-    // root and the payload's units are different objects, and the count of each has to be kept
-    // where its own object is.
+    // An unboxed union is one reference-counting unit, counted on the union itself, and building one
+    // lays the payload it is given in place. Where the payload's units sit below the payload itself
+    // — a pair of boxed values, or an unboxed struct whose one boxed field sits a level down — the
+    // union and those units are different objects, and the count of each has to be kept where its
+    // own object is.
     //
     // Each union below is read through a call that stays out of line, and read once more after that
     // call returns, so that it reaches reference counting instead of being folded into the
     // constructor that built it. The payload it was built from stays live beside it and is read
     // back at the end. For the shapes whose payload holds two units, freeing that payload early
-    // changes the answer. For the shape whose unit lies below its root the answer stays right
-    // either way, and the assertion in `unit_of` catches a key made for it. That payload
-    // arrives as a parameter, so the union's root resolves from a value that holds its unit below
-    // its root; it carries a second field so that the struct around the boxed value survives to
-    // the RC IR.
+    // changes the answer. For the shape whose unit sits one level down the answer stays right
+    // either way, and the assertion in `unit_of` catches a key made for it. That payload arrives as
+    // a parameter, so the union is resolved from a value whose own unit sits a level below it; it
+    // carries a second field so that the struct around the boxed value survives to the RC IR.
     const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
 module Main;
 
 // A boxed value a payload carries, so that the payload holds a reference count.
 type Guard = box struct { allowed : Array I64 };
 
-// A payload whose one reference-counting unit lies below its root. The second field keeps the
-// struct from being unwrapped down to the boxed value it holds.
+// A payload whose one reference-counting unit sits one level down, in `held`. The second field
+// keeps the struct from being unwrapped down to the boxed value it holds.
 type Wrapped = unbox struct { held : Guard, tag : I64 };
 
-// The `pair` payload holds two units, the `wrapped` payload holds a unit below its root, and
+// The `pair` payload holds two units, the `wrapped` payload holds one unit a level down, and
 // `mark` holds none.
 type Action = unbox union { pair : (Array I64, Array I64), wrapped : Wrapped, mark : I64 };
 
@@ -181,7 +180,7 @@ via_pair = |payload, n| (
         + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
 );
 
-// The same for a payload whose unit lies below its root.
+// The same for a payload whose unit sits one level down.
 via_wrapped : Wrapped -> I64 -> I64;
 via_wrapped = |payload, n| (
     if n == 0 { 0 };
@@ -235,7 +234,7 @@ main = (
         via_pair((Array::fill(3, 7), Array::fill(4, 9)), 1), 718
     );;
     assert_eq(
-        |_|"the boxed value below the payload's root is read back as it was built",
+        |_|"the boxed value one level below the payload is read back as it was built",
         via_wrapped(Wrapped { held : Guard { allowed : [5, 6] }, tag : 3 }, 1), 29
     );;
     assert_eq(

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -1,6 +1,6 @@
 // Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
 // then nobody reads, an unboxed union nested inside unboxed aggregates, and a union built out of a
-// payload whose root is not one reference-counting unit.
+// payload that holds its reference-counting units below its own root.
 
 #[cfg(test)]
 mod union_rc_shapes_tests {
@@ -134,20 +134,20 @@ mod union_rc_shapes_tests {
     }
 
     // An unboxed union is one reference-counting unit, kept at its root, and building one lays the
-    // payload it is given in place. Where that payload's own root is not a single unit — a pair of
-    // boxed values, or an unboxed struct whose one boxed field sits a level down — the union's root
-    // and the payload's units are different objects, and the count of each has to be kept where its
-    // own object is.
+    // payload it is given in place. Where the payload holds its units below its own root — a pair
+    // of boxed values, or an unboxed struct whose one boxed field sits a level down — the union's
+    // root and the payload's units are different objects, and the count of each has to be kept
+    // where its own object is.
     //
     // Each union below is read through a call that stays out of line, and read once more after that
     // call returns, so that it reaches reference counting instead of being folded into the
     // constructor that built it. The payload it was built from stays live beside it and is read
-    // back at the end. Freeing that payload early changes the answer for the shapes whose payload
-    // holds two units; for the shape whose unit lies below its root the answer stays right either
-    // way, and what catches a key made for it is the assertion in `unit_of`. That payload arrives as
-    // a parameter, so that the union's root is resolved from a value whose own root is not a unit,
-    // and it carries a second field, so that the struct around the boxed value survives to the RC
-    // IR.
+    // back at the end. For the shapes whose payload holds two units, freeing that payload early
+    // changes the answer. For the shape whose unit lies below its root the answer stays right
+    // either way, and the assertion in `unit_of` catches a key made for it. That payload
+    // arrives as a parameter, so the union's root resolves from a value that holds its unit below
+    // its root; it carries a second field so that the struct around the boxed value survives to
+    // the RC IR.
     const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
 module Main;
 

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -184,8 +184,8 @@ main = (
 );
 "#;
 
-    /// Both payloads are read back as they were built, which a payload freed while the union still
-    /// holds it fails without Valgrind.
+    /// Both payloads are read back as they were built. A payload freed while the union still holds
+    /// it changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_union_payload_units_correctness() {
         let mut config = Configuration::develop_mode();


### PR DESCRIPTION
Closes #399

`-O max` で、unbox union を payload から組み立てて、その payload の隣で読み直すプログラムが、解放済みメモリを読んで誤った値を返していた。診断は出ず、`-O none` と `-O basic` では正しく動く。原因は、参照を数える鍵がどの RC unit も指していなかったことである。union 自身の `origin` を、他のすべての演算と同じ規則で解くようにする。

## 前提: 3 つの語彙

`src/rc_ir/ownership.rs` は、参照カウントを論じるすべてのパスが答えを引く 1 つのモデルを置いている。書かれた仕様は [`rc-ownership-model.md`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md) にあり、語彙は 3 つである。

- **boxed leaf** — 値が持つ参照 1 つ。型から列挙するのは [`boxed_leaf_paths`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/leaf_map.rs#L28-L60)。消費と provenance は leaf の上で述べられる。
- **RC unit** — 参照カウント操作 1 つが対象にするもの。型から列挙するのは [`rc_units`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L591-L595)。boxed な値、closure の capture、unbox union、punched array がそれぞれ 1 unit である。unbox union が 1 unit なのは、その操作が variant を名指せず、タグで分岐するからである。
- **origin** — ある leaf の参照が属するオブジェクト。[`origin`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L231-L238) が別名の辺（move 束縛、unbox 集約の射影、union の payload、純粋な `Llvm` 射影）を遡って答える。

値の位置は `VarPath = (root, path)` で名指す。`root` は先頭にある変数、`path` はそこからのフィールド添字の列で、空の `path` はその値そのものを指す。以下「union 自身」「payload 自身」と書くのは、その空の `path` の位置のことである。

leaf の空間と unit の空間を橋渡しするのが [`truncate_to_unit`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L628-L650) で、leaf の path を、それを含む unit の path へ切り詰める。次の 3 つの型で、`rc_units` と `truncate_to_unit` が何を答えるかを挙げる。

```fix
type Guard   = box struct { allowed : Array I64 };
type Wrapped = unbox struct { held : Guard, tag : I64 };
type Action  = unbox union { pair : (Array I64, Array I64), wrapped : Wrapped, mark : I64 };
```

**Examples**

```
rc_units((Array I64, Array I64))              ->  [[0], [1]]  // Array 2 本がそれぞれ 1 unit
rc_units(Action)                              ->  [[]]        // unbox union は全体で 1 unit
rc_units(Wrapped)                             ->  [[0]]       // unit は 1 段下
rc_units(I64)                                 ->  []          // 参照を持たない

truncate_to_unit(Action, [0, 1])              ->  []          // variant の中の leaf は union 自身へ
truncate_to_unit(Wrapped, [0])                ->  [0]
truncate_to_unit((Array I64, Array I64), [])  ->  []          // 下へは伸びない
```

retain と release はこの unit の上で対にされる。対にする鍵を作るのが [`unit_key`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L661-L668) で、`origin` が答えた identity の path を `truncate_to_unit` で切り詰めたものを返す。

## 壊れていたもの

union の構築（[`InlineLLVMMakeUnionBody`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/fixstd/builtin.rs#L6054-L6058)）には専用の別名の辺があった。「union は payload をその場に敷くのだから、union 自身は payload 自身と同じオブジェクトである」という辺である。

その答えを鍵に変える [`unit_of`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L687-L714) は、path を `truncate_to_unit` に渡す。**この関数は path を下へ切り詰めることしかできない。** 最初の unit root (`is_rc_unit_root`) で止まるだけなので、空の path を渡すとループ本体が一度も回らず、空の path がそのまま返る（上の Examples の最後の行）。

payload 自身が unit でないとき、返る空の path はどの unit も指していない。`(Array I64, Array I64)` の unit は `[0]` と `[1]` で、空の path はその集合に入らない。同じことは、boxed なフィールドが 1 段下にある unbox struct（上の `Wrapped`）でも、closure（unit は capture、すなわち 1 段下）でも、参照を持たない `()` でも起きる。

## 直し方

**専用の辺を消す。** union 自身も、他のすべての `Llvm` 演算の結果と同じ規則で解かれる。すなわち、その path に provenance の記録が無ければ、**その下にあるすべての boxed leaf** から決める（[`origin_from_leaves_under`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L334-L372)、#401 で入った）。

union の構築が宣言する provenance は、構築された variant の leaf が payload の leaf、他の variant の leaf が ⊥（不在なので参照を持たない）である。だから union 自身の下にある leaf を畳むと、答えは **payload の unit 群**になる。それらが 1 つのオブジェクトに行き着けば [`Exactly`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L162)、複数に分かれれば、union 自身を identity とする [`Join`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L166-L169) になる。identity も候補も、どれも実在の unit である。

単一 unit の payload（boxed な値 1 つ、あるいは unbox union）については、この規則が返す答えは消した辺の答えと同じなので、変わるのは壊れていた形だけである。

## 関数ごとの変更

### [`origin_inner`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L242-L308) (`src/rc_ir/ownership.rs`)

**役割**: `origin` の本体。変数を束縛しているものの種類で分岐し、別名の辺を 1 つ遡る。プリミティブ演算（[`Binding::Llvm`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L37)）の腕では、その演算が宣言した provenance を引き、問われた path が単一のオペランド射影なら遡り、そうでなければ下の leaf から決める。

**変更**: `Binding::Llvm` の腕の先頭にあった、`InlineLLVMMakeUnionBody` を名指す早期 return を削除した。あわせて、それだけのために入っていた `InlineLLVMMakeUnionBody` の import も消えた。

**目的**: union 自身を、記録の無い path の一般規則で解かせる。

### `unit_of` (`src/rc_ir/ownership.rs`)

**役割**: `origin` の identity を、参照を数える鍵に変える。`root` の名前と、その型の unit まで切り詰めた path の組を返す。

**変更**: 返す前に、切り詰めた path が `root` の型の `rc_units` の要素であることを assert する。doc に「返す path は必ずその `root` の unit の 1 つである」を足した。

**目的**: 鍵が 1 つの unit を名指すという、この関数の doc が既に述べていた不変条件を、検査に変える。再発防止はこの assertion が担う。

### [`owns_object`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L580-L596) (`src/rc_ir/borrow.rs`)

**役割**: あるオブジェクトをこの版が自分のものとして持っているかを、所有 unit の集合から答える。

**変更**: コメントから、消した辺が作っていた具体例（「unbox tuple から作った union は空の path で tuple に行き着き、その unit はフィールドである」）を落とし、規則だけを述べる形にした。コードは変えていない。

**目的**: 起こり得なくなった形をコメントが例に挙げたままにしない。

### `rc-ownership-model.md` (`dev-docs/2026-06-28-unique-check-elim/`)

**役割**: このモデルの書かれた仕様。

**変更**: (1) `Binding::Llvm` の辺の記述から、union の構築の特例を落とし、一般規則でどう解かれるかを述べた。(2) 「`unit_key` が答える path は `root` の型の `rc_units` の要素である」という不変条件を第 1 節に足した。(3) 参照収支検査（未マージ）の除外規則を、新しい解決に合わせて書き直した。(4) punched フィールドについて、`boxed_leaf_paths` が降りると書いてあった 2 か所を、実装どおり（`rc_units` と同じく降りない）に直した。

## ユーザに見えるテキスト

この変更が足すユーザ可読のテキストは、assertion が破れたときのメッセージだけである。コンパイラ内部の不変条件なので、正しいコンパイラでは出ない。消した辺だけを戻したコンパイラでテストのプログラムを組み立てると、最初に届く形（payload が `(Array I64, Array I64)`）でこう出る。

```
thread '<unnamed>' panicked at src/rc_ir/ownership.rs:
the key `#v0#320[]` names no reference-counting unit of `(Std::Array Std::I64, Std::Array Std::I64)`, whose units are [[0], [1]]
```

`CHANGELOG.md` の項目は足していない。この欠陥は 1.4.0 の後に入ったもので（`ea90fa54`、1.4.0 の祖先ではない）、1.4.0 は再現プログラムに正しく `724` を返す。出荷されていない欠陥は変更履歴に載せない。

## 壊れた実行と直った実行

次のプログラムで追う。`peek` は再帰なので呼び出しは行内に畳まれず、union は参照カウントに届く。

```fix
type Action = unbox union { pair : (Array I64, Array I64), mark : I64 };

peek : Action -> I64 -> I64;
peek = |action, n| ( if n == 0 { if action.is_pair { 1 } else { 0 } }; peek(action, n - 1) );

via_pair : (Array I64, Array I64) -> I64 -> I64;
via_pair = |payload, n| (
    if n == 0 { 0 };
    let action = Action::pair(payload);
    let seen_in_call = peek(action, 2);
    let seen_after_call = if action.is_pair { 1 } else { 0 };
    let (first, second) = payload;
    seen_in_call + seen_after_call + first.@size * 100 + first.@(0) + second.@size * 100 + second.@(0)
);
```

参照カウントを挿入した直後の姿は、どちらのコンパイラでも同じである（`--emit-rc-ir all` の `rc_ir.pre.txt`）。

```
retain #v0#36                       // payload の参照をもう 1 つ作る
let v#43 = union_make_0(#v0#36)     // action
retain v#43
let app#45 = peek(v#43, v#44)       // seen_in_call
release v#43
```

[`split_rc_units`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L729-L736) が `retain #v0#36` を unit ごとに割り、[`borrow_ify`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L107-L227) が `peek` の borrow 版へ呼び出しを振り替えて、呼び出しの前の retain を落とし、後ろに release を残す。ここまでは両者同じである。

**壊れた実行。** [`cancel`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L835-L878) が retain と release を鍵の上で対にする。`unit_key(action, [])` は `origin(action, [])` の identity を切り詰めたもので、消す前の辺はここで payload 自身 `(#v0#36, [])` を答える。切り詰めても空の path のままで、これはどの unit も指さない。`action` への操作が作用する unit を数える [`acted_unit_keys`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L672-L683) も、この identity 1 つを返すだけである。payload の unit `(#v0#36, [0])` `(#v0#36, [1])` に立った retain は、どの操作からも「必要」と印を付けられず、`cancel` に消される。

```
release #v0#36.0                    // n == 0 の腕（早期 return）
release #v0#36.1
let v#43 = union_make_0(#v0#36)     // retain が 2 つとも消えている
let app#45 = peek#borrow(v#43, v#44)
let v#46 = union_is_0(v#43)
release v#43                        // ここで Array が 2 本とも解放される
...
let v#62 = array_get(v#61, first#52)   // 解放済みメモリの読み出し
```

`release v#43` は union を解放する。union の解放は生きている variant の参照を解放することなので、Array 2 本がここで消える。そのあとに `first` と `second` を読むので、valgrind は `Invalid read of size 8` を報告し、返る値は実行のたびに変わる。

**直った実行。** 分かれるのは `origin(action, [])` の答えである。その下の leaf から解くと、leaf は `#v0#36` の `[0]` と `[1]` へ射影されており、2 つの別のオブジェクトに行き着くので、答えは identity を `(action, [])` とする `Join` になる。`action` の型は union なので、この identity は実在の unit である。そのうえ `acted_unit_keys` は identity と候補の両方を返すので、`action` の release は payload の unit にも作用するものとして数えられる。payload の retain は「必要」と印が付き、`cancel` の対象から外れる。

```
retain #v0#36.0
retain #v0#36.1
let v#43 = union_make_0(#v0#36)
let app#45 = peek#borrow(v#43, v#44)
let v#46 = union_is_0(v#43)
release v#43                        // 増やした分を戻す
...
let v#62 = array_get(v#61, first#52)
release first#52                    // 最後の参照
```

Array はちょうど 1 度ずつ解放され、読みはすべて生きているメモリに当たる。

## テスト

`src/tests/test_union_rc_shapes.rs` に、`-O max` で誤答になる形と、鍵だけが壊れる形を 1 つのプログラムに畳んで置いた。

- payload が 2 つの unit を持つ形（自作の union、[`Std::Option`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/fixstd/std.fix#L2667)、[`Std::Result`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/fixstd/std.fix#L2743)）。分岐元のコンパイラでは 4 つの assert のうち 3 つが落ち、valgrind は `Invalid read of size 8` を 2 件出す。
- payload の unit が 1 段下にある形（boxed な値を持つ unbox struct）。この形は答えが変わらないので、捕まえるのは `unit_of` の assertion である。

2 つのテスト関数が同じソースを共有し、[`test_union_payload_units_correctness`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/tests/test_union_rc_shapes.rs#L255-L259) は valgrind 無しで値だけを見て、[`test_union_payload_units_memory_safety`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/tests/test_union_rc_shapes.rs#L264-L273) は MemCheck の下で走る。

`src/tests/test_simplify.rs` の `value_tests` に足した [`test_nested_matches_over_one_variant`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/tests/test_simplify.rs#L122-L154) は、この変更とは別に、バグハントが残したテストである（#404 の形が計算する値を固定する）。

## 実測

| 検査 | 結果 |
| --- | --- |
| #399 の再現（自作の union / `Option` / `Result`） | `-O none/basic/max/experimental` すべて正しい値、memcheck 0 件 |
| `cargo test --release`（既定 = `-O max`） | 1476 passed / 0 failed |
| speedtest コーパス 51 件の `.text` + `.rodata` | **51/51 バイト一致** |
| assertion のコンパイル時間 | 命令数で +0.05〜0.1%（3 ケースの `perf stat`） |
| minilib 16 本を memcheck の下で `fix test -O max` | 90 スイート / 2538 assertion / 失敗 0、15/16 が **0 errors** |

---

# 付録

## コーパスの比べ方

生成物の中の 2 つのハッシュ名（`fixruntime.<hash>.c` と `Module-<hash>`）がコンパイラのバージョン文字列を取り込むので、ファイル全体を比べると 51 件すべてが違って見える。`objcopy` で `.text` と `.rodata` を取り出して比べると一致する。**この比べ方が差を見つけられること自体を確認した**: 同じコンパイラの `-O max` と `-O basic` で同じケースを比べると、4,352 バイト対 73,840 バイトで違う。

## assertion のコンパイル時間

[`rc_units`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L591-L595) は型を歩いて Vec を作るので、鍵 1 つあたりその分が乗る。assertion の中身だけを外したコンパイラを作って `perf stat -e instructions` で比べた。

| ケース | assertion 無し | assertion 有り | 差 |
| --- | --- | --- | --- |
| cp_lib_segtree | 11,773,073,565 | 11,778,095,758 | +0.043% |
| binary_trees | 3,704,643,489 | 3,700,881,451 | -0.10% |
| fannkuch | 5,130,072,630 | 5,135,155,693 | +0.099% |

[`develop_mode`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/configuration.rs#L584-L594)（テストが有効にする開発時の設定）の下だけで走らせる案は、[`unit_of`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L687-L714) が [`Configuration`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/configuration.rs#L357-L468) を持たないので、[`unit_key`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L661-L668) / [`acted_unit_keys`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L672-L683) / [`CancelAnalysis`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L881-L892) / [`RewriteCtx`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L412-L433) へ引き回すことになる。上の差でそれに見合わないと判断した。

## minilib コーパスの memcheck

`fixlang_minilib` の 16 ライブラリ（90 スイート、2538 assertion）を、`[build.test]` に `memcheck = true` を入れて valgrind MemCheck の下で `fix test -O max` に掛けた。`-O max` を明示するのは、この変更が効く `cancel` が `max` 以上でしか走らないためである（各 lib が宣言するのは `basic`）。

失敗した assertion は 0。valgrind の結果は 16 本中 15 本が `ERROR SUMMARY: 0 errors`、`definitely lost: 0` で、残る `media` だけが 78 errors / 21 contexts を出す。

| lib | スイート | assertion | errors / contexts |
| --- | ---: | ---: | --- |
| common | 12 | 220 | 0 / 0 |
| binary | 3 | 52 | 0 / 0 |
| collection | 10 | 449 | 0 / 0（suppressed 3） |
| comonad | 7 | 43 | 0 / 0 |
| monad | 12 | 115 | 0 / 0 |
| text | 5 | 287 | 0 / 0 |
| app | 1 | 44 | 0 / 0 |
| random | 5 | 32 | 0 / 0 |
| io | 5 | 99 | 0 / 0 |
| xml | 3 | 222 | 0 / 0 |
| json | 1 | 45 | 0 / 0 |
| crypto | 7 | 39 | 0 / 0 |
| math | 9 | 769 | 0 / 0 |
| media | 3 | 39 | **78 / 21** |
| net | 5 | 69 | 0 / 0 |
| thread | 2 | 14 | 0 / 0 |

`media` の 78 errors はすべて libpng の中で起きる。1 件の `Invalid write of size 8` は `png_image_write_to_memory` が、minilib のテストが確保した 12 バイトのブロックの offset 8 へ 8 バイト書くもので、残りは libpng が初期化しなかったメッセージバッファを読む `Conditional jump` である。**分岐元 (`3d128e6f`) のコンパイラで同じ lib を走らせても 78 errors / 21 contexts で、`definitely lost` は両者 0** である。

分岐元と突き合わせたのは `media` / `thread` / `collection` / `io` の 4 本で、errors・contexts・suppressed・`definitely lost`・`possibly lost` がすべて一致する。ただ `thread` の `possibly lost` だけは、**どちらのコンパイラでも走るたびに 10 ブロック (3,278 B) と 11 ブロック (3,550 B) の間で揺れる**（差の 272 B は glibc が `pthread_create` で確保する TLS ブロック 1 つ）。分岐元で 3 回走らせて 10 / 11 / 10 を観測した。`definitely lost` はどの走行でも 0 である。

`collection` の suppressed 3 は、`Std::Iterator::advance` が union の padding を投機的に読む既知の偽陽性で、各プロジェクトの `valgrind.supp` が抑えている。

## テストが分岐元で落ちることの確認

`src/rc_ir/ownership.rs` だけを分岐元 (`3d128e6f`) に戻してビルドすると、新しいテスト 2 本がどちらも落ちる。戻すと通る。最初に書いたテストは union をその場で読むだけの形で、**分岐元でも通ってしまった**（[`simplify`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/simplify.rs#L53-L64) が構築ごと畳むので参照カウントに届かない）。行外の呼び出しを通して読み、その呼び出しの後にもう一度読む形にして初めて、この欠陥に届く。

## 作者に委ねる指摘

コードレビューとバグハントが出した、この変更の範囲外の項目。

- [`owns_object`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L580-L596) (`src/rc_ir/borrow.rs`) が使う [`units_under`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L735-L751)（ある path の下にある unit の列挙）は、この変更のあと常に 1 要素になる可能性が高い。path が複数 unit にまたがる唯一の作り手が、消した辺だったからである。`assert_eq!(units_under(...).len(), 1)` を置いて全スイートを走らせると 1 度も発火しなかった。畳んで [`truncate_to_unit`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L628-L650) 1 回の照会にできるが、別ファイルの単純化なので判断を委ねる。
- unit root まで降りる規則（closure は capture へ、[`is_rc_unit_root`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/ast/types.rs#L1405-L1412) で止まる、[`is_fully_unboxed`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/ast/types.rs#L1376-L1395) の下へは行かない、[`unpunched_field_types`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/ast/types.rs#L1064-L1071) で降りる）が 4 か所に別々に綴られている（[`rc_units_go`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L599-L623)、`truncate_to_unit`、[`subtree_type`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/ownership.rs#L755-L764)、[`param_ownership_shape`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L277-L325) の中の `go`）。unit の種類を足すとき 4 か所を直すことになり、1 つ落とすと今回と同じ種類の壊れた鍵ができる。
- [`Ownerships`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L58-L60) / そのフィールド [`own`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L59) は **leaf** を持ち、隣の [`owned_units`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/borrow.rs#L884) は **unit** を持つ。粒度の違う 2 つの `Set<VarPath>` が名前で区別されていない（`OwnedLeaves` / `owned_leaves` の提案）。

## バグハントが見つけた別件

この変更のあと `src/rc_ir/` を対象に走らせたバグハントが、既存の欠陥を 2 件出した。どちらもこの変更とは無関係で、issue にしてある。

- **#404**: 入れ子の `match` で [`simplify`](https://github.com/tttmmmyyyy/fixlang/blob/5031ad44aafaf251a2a87b7f0a2e10f7bd29cece/src/rc_ir/simplify.rs#L53-L64) が外側の `match` を腕ごとに複製し、深さに対して指数的にコンパイル時間が増える（79 行で 15 秒、89 行で 209 秒、1.4.0 は 3 秒未満）。1.4.0 からの退行。
- **#405**: 自分自身を参照するグローバル値が診断なしに通り、実行時に SIGSEGV で落ちる（1.4.0 でも再現）。仕様であるとの判断で、not planned として閉じた。
