### PR TITLE
レビュー清掃 (#406): unit 列挙の重複、名前、変更の周りの doc

### DIFF
--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -125,7 +125,8 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     for func in prog.funcs.values() {
         // `f_own`: every parameter and capture unit is owned.
         owned_units.extend(param_capture_units(func, type_env));
-        // `f_borrow`: a fresh clone whose owned units are the inferred ones, clamped to units.
+        // `f_borrow`: a fresh clone whose owned units are the inferred owned leaves, each truncated
+        // to its unit.
         if let Some(bref) = borrow_versions.get(&func.name) {
             let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
             for p in &func.params {

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -63,7 +63,7 @@ struct Ownerships {
 /// leaf `Borrow`, then repeatedly demote to `Own` any leaf that a consume site traces back to, until
 /// nothing changes. Demotion is monotone (`Borrow` to `Own` only), so it terminates.
 fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
-    let vars: Map<FuncRef, VarTable> = prog
+    let var_tables: Map<FuncRef, VarTable> = prog
         .funcs
         .values()
         .map(|f| (f.name.clone(), VarTable::of(f)))
@@ -73,7 +73,7 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
     loop {
         let mut changed = false;
         for func in prog.funcs.values() {
-            let vars = &vars[&func.name];
+            let vars = &var_tables[&func.name];
             let mut consumed = vec![];
             collect_consumes(&func.body, vars, prog, &own, type_env, &mut consumed);
             for (var, path) in consumed {
@@ -1051,20 +1051,20 @@ impl<'a> CancelAnalysis<'a> {
         pending_in: &PendingRetains,
         arm_exits: &[PendingRetains],
     ) -> PendingRetains {
-        let n = arm_exits.len();
-        let mut arms_pending: Map<NodeId, usize> = Map::default();
+        let arm_count = arm_exits.len();
+        let mut pending_arm_count: Map<NodeId, usize> = Map::default();
         for exit in arm_exits {
             let mut seen: Set<NodeId> = Set::default();
             for stack in exit.values() {
                 for &retain in stack {
                     if seen.insert(retain) {
-                        *arms_pending.entry(retain).or_default() += 1;
+                        *pending_arm_count.entry(retain).or_default() += 1;
                     }
                 }
             }
         }
-        for (&retain, &count) in &arms_pending {
-            if count != n {
+        for (&retain, &count) in &pending_arm_count {
+            if count != arm_count {
                 self.needed_retains.insert(retain);
             }
         }
@@ -1075,7 +1075,7 @@ impl<'a> CancelAnalysis<'a> {
             let kept: Vec<NodeId> = stack
                 .iter()
                 .copied()
-                .filter(|retain| arms_pending.get(retain) == Some(&n))
+                .filter(|retain| pending_arm_count.get(retain) == Some(&arm_count))
                 .collect();
             if !kept.is_empty() {
                 merged.insert(key.clone(), kept);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -24,8 +24,8 @@
 //! Borrow-ification and cancellation both work one reference-counting unit at a time, so
 //! `split_rc_units` first normalizes the lowered reference counting to that granularity: it
 //! decomposes a whole-value or subtree `Retain`/`Release` into one node per unit — a boxed leaf, a
-//! closure capture, or an unboxed-union root (a union is one unit, since a physical refcount
-//! operation on it must dispatch on the tag rather than name a variant).
+//! closure capture, or an unboxed union (a union is one unit, since a physical refcount operation on
+//! it must dispatch on the tag rather than name a variant).
 //!
 //! Borrow-ification leaves the caller with a retain before a borrow call and a release after it,
 //! bracketing the call with no consume between. `cancel` removes those net-zero brackets: a retain is

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -124,11 +124,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     let mut clones: Vec<(FuncRef, RcFunc, Map<FullName, FullName>)> = vec![];
     for func in prog.funcs.values() {
         // `f_own`: every parameter and capture unit is owned.
-        for p in func.params.iter().chain(func.capture.iter()) {
-            for unit in rc_units(&p.ty, type_env) {
-                owned_units.insert((p.name.clone(), unit));
-            }
-        }
+        owned_units.extend(param_capture_units(func, type_env));
         // `f_borrow`: a fresh clone whose owned units are the inferred ones, clamped to units.
         if let Some(bref) = borrow_versions.get(&func.name) {
             let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
@@ -207,16 +203,10 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
 
     // Annotate every version with the parameter/capture units it borrows (those not in `owned_units`).
     for func in funcs.values_mut() {
-        let mut borrowed = Set::default();
-        for p in func.params.iter().chain(func.capture.iter()) {
-            for unit in rc_units(&p.ty, type_env) {
-                let unit_path = (p.name.clone(), unit);
-                if !owned_units.contains(&unit_path) {
-                    borrowed.insert(unit_path);
-                }
-            }
-        }
-        func.borrowed_units = borrowed;
+        func.borrowed_units = param_capture_units(func, type_env)
+            .into_iter()
+            .filter(|unit_path| !owned_units.contains(unit_path))
+            .collect();
     }
 
     RcProgram {
@@ -269,6 +259,20 @@ fn param_names_and_types(func: &RcFunc) -> Vec<(FullName, Arc<TypeNode>)> {
         .iter()
         .chain(func.capture.iter())
         .map(|p| (p.name.clone(), p.ty.clone()))
+        .collect()
+}
+
+/// Every reference-counting unit of a function's parameters and capture, each as the
+/// `(variable, unit path)` pair the owned and borrowed unit sets are keyed by.
+fn param_capture_units(func: &RcFunc, type_env: &TypeEnv) -> Vec<VarPath> {
+    func.params
+        .iter()
+        .chain(func.capture.iter())
+        .flat_map(|p| {
+            rc_units(&p.ty, type_env)
+                .into_iter()
+                .map(|unit| (p.name.clone(), unit))
+        })
         .collect()
 }
 

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -53,9 +53,10 @@ use crate::rc_ir::ownership::{
 use crate::rc_ir::rename::fresh_rename_function;
 use std::sync::Arc;
 
-/// The result of borrow inference: which parameter leaves are `Own` (all others are `Borrow`), keyed
-/// by the parameter variable's name and the leaf path.
+/// The result of borrow inference: which parameter leaves each function of the program owns.
 struct Ownerships {
+    /// The parameter leaves inferred `Own`, keyed by the parameter variable's name and the leaf
+    /// path. A leaf absent from it is `Borrow`.
     own: Set<VarPath>,
 }
 
@@ -101,9 +102,8 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> Ownerships {
 
 /// Borrow-ify a program: materialize a borrowing version of every function with a borrowable
 /// parameter, route each direct call to a version, rewrite the reference counting accordingly, and
-/// annotate every output version with the parameter/capture units it borrows (`RcFunc::borrowed_units`,
-/// whose owned complement `cancel` reads to find each call's consume sites and the RC IR dump reads
-/// for its shapes).
+/// annotate every output version with the parameter/capture units it borrows
+/// (`RcFunc::borrowed_units`).
 pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     let ownerships = infer_ownership(prog, type_env);
 
@@ -883,9 +883,15 @@ pub fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
 
 /// The forward must-analysis for one function: it decides which retain and release nodes to delete.
 struct CancelAnalysis<'a> {
+    /// This function's variables: what binds each one and its type, which decide the unit key a
+    /// retain and a release pair on.
     vars: &'a VarTable,
+    /// The whole program, so a call resolves to its callee's parameters.
     prog: &'a RcProgram,
+    /// The parameter/capture units the program's functions own, which decide which argument
+    /// positions of a call consume.
     owned_units: &'a Set<VarPath>,
+    /// The type definitions, for resolving a value's type to its reference-counting units.
     type_env: &'a TypeEnv,
     /// Retains that are load-bearing on some path, so they cannot be cancelled.
     needed_retains: Set<NodeId>,

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -650,9 +650,9 @@ pub(crate) fn truncate_to_unit(
 }
 
 /// The reference-counting unit a leaf belongs to, as an object identity: its `origin`'s identity,
-/// clamped to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
-/// retain and a payload consume land in the same bucket (without which a payload consume could not
-/// keep the union retain needed, and a later union release would wrongly cancel it).
+/// truncated to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
+/// retain and a consume of the payload get the same key: the consume marks that retain as needed,
+/// and cancellation keeps it together with the union release that un-bumps it.
 ///
 /// This is the key a retain and a release are paired on, and the key a reference count is kept
 /// under, so it must name one object: a leaf whose object is path-dependent keys to the match

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -764,14 +764,19 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
 }
 
 /// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
-/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `what` names the
-/// walk in the message an out-of-range index aborts with.
-fn field_type_at(ty: &Arc<TypeNode>, idx: usize, type_env: &TypeEnv, what: &str) -> Arc<TypeNode> {
+/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `walk_name` names
+/// the walk in the message an out-of-range index aborts with.
+fn field_type_at(
+    ty: &Arc<TypeNode>,
+    idx: usize,
+    type_env: &TypeEnv,
+    walk_name: &str,
+) -> Arc<TypeNode> {
     let fields = ty.field_types(type_env);
     assert!(
         idx < fields.len(),
         "{}: path index {} out of range ({} fields)",
-        what,
+        walk_name,
         idx,
         fields.len()
     );

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -266,8 +266,8 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             // several sources) is a producer, stopping here. An `Llvm` op is never partially applied,
             // so a well-formed `result_prov` names only real argument indices (`args[j]` else panics).
             // A path whose own record does not name an object is handled by
-            // `origin_from_leaves_under`: a reference-counting unit path may name the root of an
-            // unboxed union, which is a subtree whose provenance is declared on the leaves beneath.
+            // `origin_from_leaves_under`: a reference-counting unit path may name an unboxed union
+            // itself, whose provenance is declared on the leaves of its variants.
             match decl.leaf_origins_at(path).and_then(as_arg_projection) {
                 Some((j, p)) => origin(vars, type_env, &args[j].name, &p),
                 None => {
@@ -310,16 +310,16 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
 /// The object a value denotes at a path whose own record does not name one: the objects the leaves
 /// beneath that path reach.
 ///
-/// A reference-counting unit path may name the root of an unboxed union, whose provenance is
-/// declared one level down, on the leaves of its variants, so a reader that stops at the root finds
-/// nothing recorded and takes the value for one produced on the spot — its own to release, when it
-/// may be an operand's. The leaves beneath decide instead. A leaf recorded as `⊥` belongs to a
+/// A reference-counting unit path may name an unboxed union itself, whose provenance is declared one
+/// level down, on the leaves of its variants, so a reader that stops at the union finds nothing
+/// recorded and takes the value for one produced on the spot — its own to release, when it may be an
+/// operand's. The leaves beneath decide instead. A leaf recorded as `⊥` belongs to a
 /// variant the value does not have and holds no reference, so it names no object and is passed
 /// over; a leaf produced here rather than projected names this value itself. A leaf that records
 /// several sources holds one per path it can be reached by, and each of them names an object.
 ///
 /// The answer is exact where the leaves agree on one unit. Where they reach several, or where one
-/// of them is a value produced here rather than a projection, every object the root may denote is
+/// of them is a value produced here rather than a projection, every object the value may denote is
 /// reported together, so that a reader whose answer has to hold on all paths — whether this
 /// version owns the value — sees them all. `None` where no leaf names an object.
 ///
@@ -327,7 +327,7 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
 /// * `here` - the value's own identity, which is what it denotes on any path the leaves leave open.
 ///
 /// # Examples
-/// At the root of `unbox union { wait : Guard, pair : (Guard, Guard), mark : I64 }` read out of one
+/// Asked for `unbox union { wait : Guard, pair : (Guard, Guard), mark : I64 }` itself, read out of one
 /// borrowed node, the `wait` leaf is `⊥` and both `pair` leaves project out of that node, so the
 /// answer is `Exactly` the node's object. Give one of those two leaves a second operand and the
 /// answer becomes a `Join` naming both.
@@ -595,7 +595,7 @@ pub(crate) fn rc_units(ty: &Arc<TypeNode>, type_env: &TypeEnv) -> Vec<FieldPath>
 }
 
 /// Descend a type, pushing onto `out` the path of each unit root reached. `path` is the field path
-/// from the value's root down to `ty`, which each pushed unit is named relative to.
+/// from the whole value down to `ty`, which each pushed unit is named relative to.
 fn rc_units_go(
     ty: &Arc<TypeNode>,
     type_env: &TypeEnv,
@@ -640,7 +640,7 @@ pub(crate) fn truncate_to_unit(
         }
         if cur.is_rc_unit_root(type_env) {
             // A boxed value, an unboxed union, or a punched array is one unit; a leaf below it (a
-            // boxed leaf under a union variant, or the punched array's inner array) keys to its root.
+            // boxed leaf under a union variant, or the punched array's inner array) keys to that unit.
             break;
         }
         out.push(idx);
@@ -650,7 +650,7 @@ pub(crate) fn truncate_to_unit(
 }
 
 /// The reference-counting unit a leaf belongs to, as an object identity: its `origin`'s identity,
-/// truncated to the unit. A leaf below an unboxed union keys to the union root, so a whole-union
+/// truncated to the unit. A leaf below an unboxed union keys to the union itself, so a whole-union
 /// retain and a consume of the payload get the same key: the consume marks that retain as needed,
 /// and cancellation keeps it together with the union release that un-bumps it.
 ///
@@ -764,8 +764,8 @@ fn subtree_type(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Opt
 }
 
 /// The type of field `idx` of `ty`, where the walk that reached `ty` has established it to be an
-/// unboxed struct/tuple, so that a well-formed unit/root path index is in range. `walk_name` names
-/// the walk in the message an out-of-range index aborts with.
+/// unboxed struct/tuple, so that a well-formed unit or leaf path index is in range. `walk_name`
+/// names the walk in the message an out-of-range index aborts with.
 fn field_type_at(
     ty: &Arc<TypeNode>,
     idx: usize,

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -14,14 +14,15 @@ mod integration_tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
+    /// The directory holding the case projects, `src/tests/test_simplify/cases` in the source tree.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_simplify/cases");
         path
     }
 
-    // Copy the test cases into a fresh temporary directory so parallel test runs do not conflict, and
-    // return the directory of the named case project.
+    /// Copy the test cases into a fresh temporary directory so parallel test runs do not conflict,
+    /// and return the directory of the named case project.
     fn setup_test_env(case: &str) -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let dst = temp_dir.path().to_path_buf();
@@ -30,9 +31,10 @@ mod integration_tests {
         (temp_dir, project_dir)
     }
 
-    // Build the case project at `max` (where the simplifier runs) with `--emit-rc-ir all`, returning
-    // the dumped RC IR of every module. The `range.fold` driver is a specialized `Std::Iterator`
-    // symbol, so the whole-program dump is needed to see it. Also leaves a runnable executable.
+    /// Build the case project at `max` (where the simplifier runs) with `--emit-rc-ir all`,
+    /// returning the dumped RC IR of every module. The `range.fold` driver is a specialized
+    /// `Std::Iterator` symbol, so the whole-program dump is needed to see it. Also leaves a runnable
+    /// executable.
     fn emit_all_rc_ir(project_dir: &Path) -> String {
         let output = fix_command_at_opt_level("build", "max")
             .arg("--emit-rc-ir")
@@ -52,7 +54,8 @@ mod integration_tests {
             .unwrap_or_else(|e| panic!("failed to read {}: {}", dump_path.display(), e))
     }
 
-    // The body of each `fn` block in the dump whose header line contains all of `needles`.
+    /// Each `fn` block of the dump whose header line contains all of `needles`: the header line
+    /// itself and every line up to the next `fn` header.
     fn fn_bodies_matching<'a>(dump: &'a str, needles: &[&str]) -> Vec<String> {
         let mut bodies = Vec::new();
         let mut current: Option<String> = None;
@@ -76,6 +79,10 @@ mod integration_tests {
         bodies
     }
 
+    /// The `range.fold` driver the simplifier leaves behind builds no union: the `Option` that
+    /// `range`'s `advance` returns and `fold` immediately matches is cancelled, so the loop-carried
+    /// state is the plain `RangeIterator` alone. The built program still sums the range, so the
+    /// removal leaves what the loop computes intact.
     #[test]
     fn test_range_fold_union_removed() {
         let (_temp_dir, project_dir) = setup_test_env("read_fold");

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -70,8 +70,8 @@ mod union_rc_shapes_tests {
     /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
     /// the references it holds live inside its variants and differ in shape from one variant to the
     /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
-    /// while a second binding keeps the array shared, makes the copy the modification takes reach
-    /// those units through two levels of unboxed aggregate. Run under memcheck.
+    /// while a second binding keeps the array shared, makes the modification copy an element, and
+    /// the copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
     #[test]
     pub fn test_nested_unboxed_union_shared_mod() {
         let source = r#"

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -67,8 +67,8 @@ mod union_rc_shapes_tests {
         test_source(&source, Configuration::develop_mode());
     }
 
-    /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
-    /// the references it holds live inside its variants and differ in shape from one variant to the
+    /// An unboxed union is one reference-counting unit, counted on the union itself, while the
+    /// references it holds live inside its variants and differ in shape from one variant to the
     /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
     /// while a second binding keeps the array shared, makes the modification copy an element, and
     /// the copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
@@ -88,8 +88,8 @@ mod union_rc_shapes_tests {
                 num(i) => i
             };
 
-            // Cycles through the three variants, so that the units beneath one union's root differ
-            // from element to element.
+            // Cycles through the three variants, so that the units beneath one union differ from
+            // element to element.
             mk : I64 -> Payload;
             mk = |k| (
                 if k % 3 == 0 { Payload::arr(Array::fill(k + 1, k)) };

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -10,13 +10,13 @@ mod union_rc_shapes_tests {
         tests::test_util::test_source,
     };
 
+    /// Matching a union built on the spot lets the simplifier replace the match with the arm it
+    /// knows is taken, substituting the payload the construction was given. Where the arm then
+    /// ignores that payload — an arm binding nothing, a pattern binding a field the body never
+    /// reads — the substituted operand is left with no reader, and its reference has to be released
+    /// exactly once all the same. Run under memcheck.
     #[test]
     pub fn test_discarded_operand_released_once() {
-        // Matching a union built on the spot lets the simplifier replace the match with the arm it
-        // knows is taken, substituting the payload the construction was given. Where the arm then
-        // ignores that payload — an arm binding nothing, a pattern binding a field the body never
-        // reads — the substituted operand is left with no reader, and its reference has to be
-        // released exactly once all the same. Run under memcheck.
         let source = r#"
             module Main;
 
@@ -67,14 +67,13 @@ mod union_rc_shapes_tests {
         test_source(&source, Configuration::develop_mode());
     }
 
+    /// An unboxed union is one reference-counting unit whose root is where its count is kept, while
+    /// the references it holds live inside its variants and differ in shape from one variant to the
+    /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
+    /// while a second binding keeps the array shared, makes the copy the modification takes reach
+    /// those units through two levels of unboxed aggregate. Run under memcheck.
     #[test]
     pub fn test_nested_unboxed_union_shared_mod() {
-        // An unboxed union is one reference-counting unit whose root is where its count is kept,
-        // while the references it holds live inside its variants and differ in shape from one
-        // variant to the next. Nesting such a union inside a struct and a tuple, and then modifying
-        // an array of them while a second binding keeps the array shared, makes the copy the
-        // modification takes reach those units through two levels of unboxed aggregate. Run under
-        // memcheck.
         let source = r#"
             module Main;
 


### PR DESCRIPTION
Refs #399

PR #406 のコードレビューが、変更したファイルの**変更箇所の外**に見つけた清掃。base はその #406 のブランチなので、#406 の差分は読むときにこの清掃を含まない。

## 関数の param と capture の unit 列挙を 1 か所にする

[`borrow_ify`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L107-L218)（各関数の param と capture のうち借りているだけのものを注釈し、呼び出しを borrow 版へ振り替えるパス）が、同じ列挙を 2 か所で綴っていた。所有する RC unit の集合を作るところと、[`borrowed_units`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ast.rs#L79)（その関数が借りている unit の注釈）を書くところである。

```rust
for p in func.params.iter().chain(func.capture.iter()) {
    for unit in rc_units(&p.ty, type_env) { ... }
}
```

[`param_capture_units`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L268-L278) に括り出し、両方をそれに乗せた。param と capture が持つ RC unit を、上の 2 つの集合が鍵にしているのと同じ `(変数, unit の path)` の組で返す。

**Examples** — param が `x : (Array I64, Array I64)` と `y : I64` の 2 つ、capture 無しの関数 `f` に対して

```
param_capture_units(f)  ->  [(x, [0]), (x, [1])]   // Array 2 本。y は参照を持たないので現れない
```

由来する規約: 「2 つ目の複製が現れた時点で関数化する」。

なお同じ列挙の 3 つ目が `ownership.rs` の [`all_owned_units`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L718-L731) にある（`borrowed_units` の補集合を取る形）。ファイルをまたぐ移動になるので、こちらは触っていない。

## 名前を、それが持つものに合わせる

- [`field_type_at`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L769-L784)（型の 1 段下のフィールドの型を返し、path が型と食い違えば中断する）の引数 `what` -> `walk_name`。渡すのは呼び出し元の walk の名前（[`truncate_to_unit`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L628-L650) / [`subtree_type`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L755-L764)）で、中断メッセージに載る。doc の該当文も合わせた。
- [`infer_ownership`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L66-L99)（不動点で param の所有を推論するパス）の `vars: Map<FuncRef, VarTable>` -> `var_tables`。このプロジェクトで `vars` は 1 関数の [`VarTable`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L50-L62)（その関数の変数が何に束縛されているかの表）を指す語で、直後に `let vars = &var_tables[&func.name];` と影を作っていた。
- [`CancelAnalysis`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L886-L903)（retain と release を鍵の上で対にして消す [`cancel`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L840-L883) の走査状態）の [`merge`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L1056-L1092)（`match` の腕の出口を合流させる関数）で、`n` -> `arm_count`、`arms_pending` -> `pending_arm_count`。前者は arms / exits / retains のどれの個数か名前から決まらず、後者は `Map<NodeId, usize>` なのに「pending な arms の集合」と読める。

## doc コメントの無い item に doc を書く

- [`Ownerships`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L57-L61) のフィールド [`own`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/borrow.rs#L60)（`Own` と推論された param の leaf。載っていない leaf は `Borrow`）と、`CancelAnalysis` の 4 フィールド (`vars` / `prog` / `owned_units` / `type_env`)。
- `src/tests/test_simplify.rs` の helper 4 つ。[`get_test_cases_dir`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/tests/test_simplify.rs#L18-L22) には doc が無かったので、どのディレクトリを指すかを書いた。`setup_test_env` / `emit_all_rc_ir` / [`fn_bodies_matching`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/tests/test_simplify.rs#L59-L80) は説明が `//` にあったので `///` へ移し、`fn_bodies_matching` には返す block の切れ目（`fn` のヘッダ行を含み、次の `fn` のヘッダまで）を足した。
- [`test_range_fold_union_removed`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/tests/test_simplify.rs#L87-L118) に、このテストが突く観点（`simplify` が通ったあとの `range.fold` driver は union を作らず、loop 変数は `RangeIterator` だけになる。それでいて和は 4950 のまま）を書いた。
- `src/tests/test_union_rc_shapes.rs` の [`test_discarded_operand_released_once`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/tests/test_union_rc_shapes.rs#L19-L68) と [`test_nested_unboxed_union_shared_mod`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/tests/test_union_rc_shapes.rs#L76-L133) で、観点を述べたコメントが本体の中にあったものを、項目の上の `///` へ移した。

## 読み手のコードが持つ名で呼び、英語を平易に言う

コードレビューのスキルに後から入った 2 つの規約による。前者は「言い換えを置かず、読み手が検索できる識別子を置く」、後者は「非母語話者が読むので、長い文と珍しい語を避ける」。

- [`unit_key`](https://github.com/tttmmmyyyy/fixlang/blob/fc6c26ffabfb023a33b5e4a51a7bf51c6a4f0e4c/src/rc_ir/ownership.rs#L661-L668)（leaf の参照を数える鍵を返す）の doc から、コードが持たない語 "bucket" を外し、`truncate_to_unit` と「同じ鍵になる」というコード自身の語彙にした。あわせて、否定形の反実仮想（"without which a payload consume could not keep the union retain needed, ..."）を肯定形の説明に置き換えた。
- `borrow_ify` の中の行コメント "clamped to units" を、その直下が呼ぶ `truncate_to_unit` の語に合わせた。
- `test_nested_unboxed_union_shared_mod` の doc で、入れ子になった節（"makes the copy the modification takes reach those units through two levels of unboxed aggregate"）を 2 つの節に分けた。

## どの root のことかを言う

`root` は 3 つの別のものに使われていた。`VarPath` の先頭にある変数（コードの `root`）、unit が始まる型の位置（`is_rc_unit_root`）、そして値そのもの（path `[]`）である。3 つ目はコードが名前を持たないもので、`unit_key` の doc の "keys to the union root"、`borrow.rs` のモジュール doc の "an unboxed-union root"、`origin_from_leaves_under` の doc の "may name the root of an unboxed union" / "a reader that stops at the root"、`rc_units_go` の "from the value's root down to `ty`" がそれにあたる。どれも "the union itself" / "the whole value" と言えば済むので、そう書き換えた。`root` は変数の意味だけに残り、型の位置は `unit root` のままである。

由来する規約: 「読み手のコードが持つ名で呼ぶ。コードが名前を持たないものは、語を作らずそれが何かを言う」。

## マージの仕方

このプルリクエストの base は #406 のブランチなので、次のどちらでもよい。

- このプルリクエストを #406 のブランチへマージしてから、#406 を `main` へマージする（`main` へのマージは 1 回）。
- #406 を `main` へマージし、そのブランチを削除する。GitHub は base ブランチが消えたプルリクエストをその base の base（`main`）へ張り替えるので、このプルリクエストは `main` 向けの独立したものになる。
