### PR TITLE
バグハントが残したテスト (#406): container が読み出しの後も持つ参照 2 本

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod test_predicate_deduction;
 mod test_preliminary_commands;
 mod test_provenance;
 mod test_punched_array;
+mod test_rc_ir_aliasing;
 mod test_sanitize_setting;
 mod test_shared_boxed_swap;
 mod test_signal;

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -170,4 +170,71 @@ main = (
         let config = Configuration::develop_mode();
         test_source(BORROWED_UNION_FIELD_SOURCE, config);
     }
+
+    const DROPPED_UNION_FIELD_SOURCE: &str = r#"
+module Main;
+
+// A boxed value a variant of the union carries, so that the union holds a reference count.
+type Guard = box struct { allowed : Array U8 };
+
+// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+type Pair = unbox struct { first : Guard, second : Guard };
+
+// One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
+// root is resolved where a single leaf lies beneath it, where several do, and where none does.
+type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
+
+type Node = unbox struct { action : Action, n : I64 };
+
+// Reads the union out of a node it is handed and lets it die without consuming it. The node is only
+// read here, so the reading version borrows it and takes no reference of its own; the union has to
+// be recognized as the caller's rather than as a value produced here.
+glance : I64 -> Node -> I64;
+glance = |k, node| (
+    let action = node.@action;
+    eval action;
+    if k <= 0 { node.@n };
+    node.@n + glance(k - 1, node)
+);
+
+// The same, with the union asked about by a borrowing getter before it is dropped.
+sniff : I64 -> Node -> I64;
+sniff = |k, node| (
+    let action = node.@action;
+    if action.is_mark { node.@n };
+    if k <= 0 { 100 };
+    1 + sniff(k - 1, node)
+);
+
+main : IO ();
+main = (
+    let single = Node { action : Action::wait(Guard { allowed : ['a'] }), n : 5 };
+    let several = Node { action : Action::pair(Pair {
+        first : Guard { allowed : ['b'] }, second : Guard { allowed : ['c'] }
+    }), n : 2 };
+    let scalar = Node { action : Action::mark(9), n : 1 };
+    assert_eq(|_|"one leaf beneath the union's root", glance(3, single), 20);;
+    assert_eq(|_|"several leaves beneath the union's root", glance(3, several), 8);;
+    assert_eq(|_|"no leaf beneath the union's root", glance(3, scalar), 4);;
+    assert_eq(|_|"dropped after a borrowing getter", sniff(3, several), 103);;
+    assert_eq(|_|"dropped by the getter's own arm", sniff(3, scalar), 1);;
+    pure()
+);
+"#;
+
+    /// The boxed values a borrowed node carries survive a reader that reads the union out of it and
+    /// drops it without consuming it, and none of them leaks. Checked under Valgrind MemCheck: the
+    /// release that falls twice frees a value nothing reads afterwards, so the answers stay right.
+    #[test]
+    pub fn test_dropped_union_field_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        let config = Configuration::develop_mode();
+        test_source(DROPPED_UNION_FIELD_SOURCE, config);
+    }
 }

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -181,14 +181,14 @@ type Guard = box struct { allowed : Array U8 };
 type Pair = unbox struct { first : Guard, second : Guard };
 
 // One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
-// root is resolved where a single leaf lies beneath it, where several do, and where none does.
+// root is resolved with one leaf beneath it, with several, and with none.
 type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
 
 type Node = unbox struct { action : Action, n : I64 };
 
-// Reads the union out of a node it is handed and lets it die without consuming it. The node is only
-// read here, so the reading version borrows it and takes no reference of its own; the union has to
-// be recognized as the caller's rather than as a value produced here.
+// Reads the union out of a node it is handed and drops it without consuming it. This function only
+// reads the node, so it is given the node borrowed, and the union read out of it has to be
+// recognized as the caller's.
 glance : I64 -> Node -> I64;
 glance = |k, node| (
     let action = node.@action;
@@ -197,7 +197,7 @@ glance = |k, node| (
     node.@n + glance(k - 1, node)
 );
 
-// The same, with the union asked about by a borrowing getter before it is dropped.
+// The same, with the borrowing getter `is_mark` reading the union before it is dropped.
 sniff : I64 -> Node -> I64;
 sniff = |k, node| (
     let action = node.@action;
@@ -223,8 +223,9 @@ main = (
 "#;
 
     /// The boxed values a borrowed node carries survive a reader that reads the union out of it and
-    /// drops it without consuming it, and none of them leaks. Checked under Valgrind MemCheck: the
-    /// release that falls twice frees a value nothing reads afterwards, so the answers stay right.
+    /// drops it without consuming it, and none of them leaks. This runs under Valgrind MemCheck
+    /// because a double release here frees a value nothing reads afterwards, so the assertions on
+    /// their own still pass.
     #[test]
     pub fn test_dropped_union_field_memory_safety() {
         if !platform_valgrind_supported() {

--- a/src/tests/test_borrowed_union_field.rs
+++ b/src/tests/test_borrowed_union_field.rs
@@ -1,18 +1,17 @@
 // Memory-safety tests for a union read out of an aggregate the reading function only borrows.
 //
 // An unboxed union is one reference-counting unit: an operation on it dispatches on the tag rather
-// than naming a variant, so its reference count is kept at the union's root. Its provenance,
-// though, is recorded one level down, on the leaves of its variants. A reader that asks where the
-// union at that root came from therefore finds nothing recorded and would take it for a value
-// produced on the spot — its own to release — when it is really the caller's, read out of a
-// borrowed parameter. The release then falls twice: once in the callee that never took a
-// reference, once in the caller that did.
+// than naming a variant, so its reference count is kept on the union itself. Its provenance, though,
+// is recorded one level down, on the leaves of its variants. A reader that asks where the union came
+// from therefore finds nothing recorded and would take it for a value produced on the spot — its own
+// to release — when it is really the caller's, read out of a borrowed parameter. The release then
+// falls twice: once in the callee that never took a reference, once in the caller that did.
 //
 // The program below has that shape: a node of an array carries an unboxed union with boxed
 // variants, a function reads the union out of a node it is handed and only looks at it, and the
 // walk that hands the nodes over is a loop whose state carries an array. Two of the union's
 // variants carry a boxed value: one carries a single one, and one carries a pair of them, so that
-// the root is resolved both where a single leaf lies beneath it and where several have to agree on
+// the union is resolved both with a single leaf beneath it and with several that have to agree on
 // the object they come from.
 
 #[cfg(test)]
@@ -29,7 +28,7 @@ module Main;
 // A boxed value a variant of the union carries, so that the union holds a reference count.
 type Guard = box struct { allowed : Array U8 };
 
-// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+// Two boxed values in one variant, so that the union has several leaves beneath it.
 type Pair = unbox struct { first : Guard, second : Guard };
 
 // The union the node carries: one variant holds a boxed value, one a pair of them, and one only a
@@ -177,11 +176,11 @@ module Main;
 // A boxed value a variant of the union carries, so that the union holds a reference count.
 type Guard = box struct { allowed : Array U8 };
 
-// Two boxed values in one variant, so that the union's root has several leaves beneath it.
+// Two boxed values in one variant, so that the union has several leaves beneath it.
 type Pair = unbox struct { first : Guard, second : Guard };
 
-// One variant holds a boxed value, one a pair of them, and one only a number, so that the union's
-// root is resolved with one leaf beneath it, with several, and with none.
+// One variant holds a boxed value, one a pair of them, and one only a number, so that the union is
+// resolved with one leaf beneath it, with several, and with none.
 type Action = unbox union { wait : Guard, pair : Pair, mark : I64 };
 
 type Node = unbox struct { action : Action, n : I64 };
@@ -213,9 +212,9 @@ main = (
         first : Guard { allowed : ['b'] }, second : Guard { allowed : ['c'] }
     }), n : 2 };
     let scalar = Node { action : Action::mark(9), n : 1 };
-    assert_eq(|_|"one leaf beneath the union's root", glance(3, single), 20);;
-    assert_eq(|_|"several leaves beneath the union's root", glance(3, several), 8);;
-    assert_eq(|_|"no leaf beneath the union's root", glance(3, scalar), 4);;
+    assert_eq(|_|"one leaf beneath the union", glance(3, single), 20);;
+    assert_eq(|_|"several leaves beneath the union", glance(3, several), 8);;
+    assert_eq(|_|"no leaf beneath the union", glance(3, scalar), 4);;
     assert_eq(|_|"dropped after a borrowing getter", sniff(3, several), 103);;
     assert_eq(|_|"dropped by the getter's own arm", sniff(3, scalar), 1);;
     pure()

--- a/src/tests/test_rc_ir_aliasing.rs
+++ b/src/tests/test_rc_ir_aliasing.rs
@@ -1,14 +1,16 @@
-// A value reached through a union, a struct, a closure or a tuple keeps the reference its container
-// holds, so mutating what is read out of it copies rather than writes in place. Each case keeps a
-// witness alive across the mutation and asserts the witness is unchanged.
+// A value read out of a union, a struct, a closure or a tuple keeps the reference its container
+// holds, so mutating that value copies it and leaves the container's own copy as it was. Each case
+// keeps the container alive across the mutation and asserts that what it holds still reads as it
+// did.
 
 #[cfg(test)]
 mod rc_ir_aliasing_tests {
     use crate::{configuration::Configuration, tests::test_util::test_source};
 
-    /// Reading a value out of each kind of container and mutating it leaves the container's own copy
-    /// as it was, for a union built on the spot, a boxed and an unboxed union, a boxed and an
-    /// unboxed struct, a closure capture, and one array stored in both fields of a tuple.
+    /// Reading a value out of a container and mutating it leaves the container's own copy as it was.
+    /// The containers covered are an `Option::some` built on the spot, a boxed and an unboxed union,
+    /// a boxed and an unboxed struct, a closure capture, and one array stored in both fields of a
+    /// tuple.
     #[test]
     pub fn test_container_keeps_its_reference_across_a_read_out() {
         let source = r#"
@@ -25,7 +27,7 @@ mod rc_ir_aliasing_tests {
                 let base = Array::fill(4, 0);
                 let taken = match Option::some(base) { some(x) => x.set(0, 111), none() => base };
                 assert_eq(|_|"payload mutated", taken.@(0), 111);;
-                assert_eq(|_|"payload witness", base.@(0), 0);;
+                assert_eq(|_|"payload unchanged", base.@(0), 0);;
 
                 // A boxed union still alive after its payload is read out.
                 let boxed = BU::a(Array::fill(4, 0));
@@ -33,7 +35,7 @@ mod rc_ir_aliasing_tests {
                 let mutated_boxed = out_of_boxed.set(1, 222);
                 assert_eq(|_|"boxed union payload mutated", mutated_boxed.@(1), 222);;
                 assert_eq(
-                    |_|"boxed union witness",
+                    |_|"boxed union payload unchanged",
                     match boxed { a(x) => x.@(1), b(_) => -1 }, 0
                 );;
 
@@ -43,7 +45,7 @@ mod rc_ir_aliasing_tests {
                 let mutated_unboxed = out_of_unboxed.set(2, 333);
                 assert_eq(|_|"unboxed union payload mutated", mutated_unboxed.@(2), 333);;
                 assert_eq(
-                    |_|"unboxed union witness",
+                    |_|"unboxed union payload unchanged",
                     match unboxed { p(x) => x.@(2), q(_) => -1 }, 0
                 );;
 
@@ -51,25 +53,25 @@ mod rc_ir_aliasing_tests {
                 let plain = S { xs : Array::fill(4, 0), n : 1 };
                 let S { xs : plain_field, n : _ } = plain;
                 assert_eq(|_|"unboxed struct field mutated", plain_field.set(3, 444).@(3), 444);;
-                assert_eq(|_|"unboxed struct witness", plain.@xs.@(3), 0);;
+                assert_eq(|_|"unboxed struct field unchanged", plain.@xs.@(3), 0);;
 
                 // A boxed struct destructured while the struct is still alive.
                 let boxed_struct = BS { xs : Array::fill(4, 0), n : 1 };
                 let BS { xs : boxed_field, n : _ } = boxed_struct;
                 assert_eq(|_|"boxed struct field mutated", boxed_field.set(3, 555).@(3), 555);;
-                assert_eq(|_|"boxed struct witness", boxed_struct.@xs.@(3), 0);;
+                assert_eq(|_|"boxed struct field unchanged", boxed_struct.@xs.@(3), 0);;
 
                 // A closure capturing an array the enclosing scope also holds.
                 let captured = Array::fill(4, 0);
                 let writer = |k| captured.set(0, k);
                 assert_eq(|_|"capture mutated", writer(666).@(0), 666);;
-                assert_eq(|_|"capture witness", captured.@(0), 0);;
+                assert_eq(|_|"capture unchanged", captured.@(0), 0);;
 
                 // One array stored in both fields of a tuple.
                 let twice = Array::fill(4, 0);
                 let pair = (twice, twice);
                 assert_eq(|_|"tuple field mutated", pair.@0.set(0, 777).@(0), 777);;
-                assert_eq(|_|"tuple field witness", pair.@1.@(0), 0);;
+                assert_eq(|_|"tuple field unchanged", pair.@1.@(0), 0);;
 
                 pure()
             );

--- a/src/tests/test_rc_ir_aliasing.rs
+++ b/src/tests/test_rc_ir_aliasing.rs
@@ -1,0 +1,79 @@
+// A value reached through a union, a struct, a closure or a tuple keeps the reference its container
+// holds, so mutating what is read out of it copies rather than writes in place. Each case keeps a
+// witness alive across the mutation and asserts the witness is unchanged.
+
+#[cfg(test)]
+mod rc_ir_aliasing_tests {
+    use crate::{configuration::Configuration, tests::test_util::test_source};
+
+    /// Reading a value out of each kind of container and mutating it leaves the container's own copy
+    /// as it was, for a union built on the spot, a boxed and an unboxed union, a boxed and an
+    /// unboxed struct, a closure capture, and one array stored in both fields of a tuple.
+    #[test]
+    pub fn test_container_keeps_its_reference_across_a_read_out() {
+        let source = r#"
+            module Main;
+
+            type BU = box union { a : Array I64, b : I64 };
+            type UU = unbox union { p : Array I64, q : I64 };
+            type S = struct { xs : Array I64, n : I64 };
+            type BS = box struct { xs : Array I64, n : I64 };
+
+            main : IO ();
+            main = (
+                // A union built on the spot, whose payload the enclosing scope also holds.
+                let base = Array::fill(4, 0);
+                let taken = match Option::some(base) { some(x) => x.set(0, 111), none() => base };
+                assert_eq(|_|"payload mutated", taken.@(0), 111);;
+                assert_eq(|_|"payload witness", base.@(0), 0);;
+
+                // A boxed union still alive after its payload is read out.
+                let boxed = BU::a(Array::fill(4, 0));
+                let out_of_boxed = match boxed { a(x) => x, b(_) => Array::fill(1, 0) };
+                let mutated_boxed = out_of_boxed.set(1, 222);
+                assert_eq(|_|"boxed union payload mutated", mutated_boxed.@(1), 222);;
+                assert_eq(
+                    |_|"boxed union witness",
+                    match boxed { a(x) => x.@(1), b(_) => -1 }, 0
+                );;
+
+                // An unboxed union still alive after its payload is read out.
+                let unboxed = UU::p(Array::fill(4, 0));
+                let out_of_unboxed = match unboxed { p(x) => x, q(_) => Array::fill(1, 0) };
+                let mutated_unboxed = out_of_unboxed.set(2, 333);
+                assert_eq(|_|"unboxed union payload mutated", mutated_unboxed.@(2), 333);;
+                assert_eq(
+                    |_|"unboxed union witness",
+                    match unboxed { p(x) => x.@(2), q(_) => -1 }, 0
+                );;
+
+                // An unboxed struct destructured while the struct is still alive.
+                let plain = S { xs : Array::fill(4, 0), n : 1 };
+                let S { xs : plain_field, n : _ } = plain;
+                assert_eq(|_|"unboxed struct field mutated", plain_field.set(3, 444).@(3), 444);;
+                assert_eq(|_|"unboxed struct witness", plain.@xs.@(3), 0);;
+
+                // A boxed struct destructured while the struct is still alive.
+                let boxed_struct = BS { xs : Array::fill(4, 0), n : 1 };
+                let BS { xs : boxed_field, n : _ } = boxed_struct;
+                assert_eq(|_|"boxed struct field mutated", boxed_field.set(3, 555).@(3), 555);;
+                assert_eq(|_|"boxed struct witness", boxed_struct.@xs.@(3), 0);;
+
+                // A closure capturing an array the enclosing scope also holds.
+                let captured = Array::fill(4, 0);
+                let writer = |k| captured.set(0, k);
+                assert_eq(|_|"capture mutated", writer(666).@(0), 666);;
+                assert_eq(|_|"capture witness", captured.@(0), 0);;
+
+                // One array stored in both fields of a tuple.
+                let twice = Array::fill(4, 0);
+                let pair = (twice, twice);
+                assert_eq(|_|"tuple field mutated", pair.@0.set(0, 777).@(0), 777);;
+                assert_eq(|_|"tuple field witness", pair.@1.@(0), 0);;
+
+                pure()
+            );
+        "#;
+        test_source(&source, Configuration::develop_mode());
+    }
+}


### PR DESCRIPTION
Refs #399

PR #406 のあとに `src/rc_ir/` を対象として走らせたバグハントが、疑って書いたが**通った**テスト 2 本。どちらも「疑って、確認できた」性質を固定するだけのもので、取り込むかどうかを判断してほしい。

同じハントが見つけた欠陥は #404（入れ子の `match` でコンパイル時間が深さに対して指数的に増える）と #405（自分自身を参照するグローバル値が実行時に SIGSEGV。仕様として閉じた）に出してある。

## [`test_dropped_union_field_memory_safety`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/tests/test_borrowed_union_field.rs#L229-L239)

置き場所は `src/tests/test_borrowed_union_field.rs`。unbox union を、借りているだけの node から読み出し、**消費せずに落とす**形。union の下に boxed leaf が 1 つある variant、2 つある variant、1 つも無い variant の 3 つを、同じプログラムで通す。

既存の 2 テスト（[`test_borrowed_union_field_correctness`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/tests/test_borrowed_union_field.rs#L152-L156) と [`test_borrowed_union_field_memory_safety`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/tests/test_borrowed_union_field.rs#L161-L171)）はこの軸を 130 行の walk プログラム 1 本で見ており、こちらは同じ軸の最小形にあたる。

このテストが何を守っているかは、[`origin_from_leaves_under`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/rc_ir/ownership.rs#L334-L372)（provenance の記録が無い path の origin を、その下の leaf から決める規則。#401 で入った）を外すと分かる。外すと [`origin`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/rc_ir/ownership.rs#L231-L238) は、borrow した node から読み出した union を、その場で作られた値（自分で release すべき値）と答える。ハントはこの状態でテストが valgrind エラーで落ちることを実測している。

## [`test_container_keeps_its_reference_across_a_read_out`](https://github.com/tttmmmyyyy/fixlang/blob/86d32f5c0a8c855b063856605941fbc145b8916c/src/tests/test_rc_ir_aliasing.rs#L15-L80)

新しいファイル `src/tests/test_rc_ir_aliasing.rs`。container から読み出した値を変更したとき、container 自身の持ち分が変わらないことを、7 つの形で見る: その場で作った `Option::some`、boxed union、unbox union、unbox struct、boxed struct、closure の capture、同じ Array を両フィールドに置いた tuple。それぞれ container を変更の向こう側まで生かして読み直す。

各形は既存のテストがどこかで触れているが、「container の参照は読み出しの後も生きている」という 1 つの問いの下に 7 つ並べたものは無い。重なりのほうが大きいと判断するなら、このプルリクエストは閉じてもらってかまわない。

## コメントの語彙

3 本目のコミットは、この 2 ファイルのコメントから「値そのもの」を指す `root` を落としたものである（"the union's root has several leaves beneath it" -> "the union has several leaves beneath it" など）。`root` は `VarPath` の先頭にある変数を指す語なので、値そのものにも同じ語を当てると 1 つの語が 2 つのものを指すことになる。同じ書き換えを #406 と #407 でも行っている。
