### PR TITLE
読み手が持っているコードの名前で呼ぶ

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -988,15 +988,13 @@ State what *is*, not what *isn't*. Two anti-patterns to catch, both applying to 
 
 **Rewrite** (a) and (b) into the affirmative equivalent. When the negation carries no residual information once affirmed, drop the sentence.
 
-#### Don't coin a term for one document — [Rust + Markdown]
+#### Name a thing the way the code names it — [Rust + Markdown]
 
-A word invented to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has no definition to go to. In a document that is translated, it survives as a word that means nothing in the other language either.
+An identifier the code carries — a type, a field, a function, a variant — is vocabulary the reader already shares with the text, and it is a word they can search for. Write `FullName`, not "the full name"; `CTypeShape`, not "the shape a C declaration carries". A paraphrase makes a second name for one thing and cuts the reader's way back to the code, and a paraphrase translated into another language cuts it twice.
 
-The test: can the sentence be written without the coined word? It usually can, and is shorter for it.
+Where the code names nothing, say what the thing is rather than inventing a word for it. A word coined to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has nowhere to look it up. The test: can the sentence be written without the coined word? It usually can, and is shorter for it.
 
-**Keep** a term the code itself names — a type, a field, a variant — since the reader can go and read what it is.
-
-**Rewrite**: replace the coined word with what it stands for.
+**Rewrite**: put the identifier where a paraphrase of it stands, and what it stands for where a coined word stands.
 
 #### Reference by name, not by line or section number — [Rust + Markdown]
 

--- a/.claude/skills/devdoc/SKILL.md
+++ b/.claude/skills/devdoc/SKILL.md
@@ -43,7 +43,7 @@ Write the doc in the implementers' language. It does not have to be English.
 
 Where that language is English, write it plainly: a reader need not be a native speaker, and a long sentence or a rare word costs them more than it costs a native reader.
 
-Do not coin a word to carry a concept through a few paragraphs: a reader who meets it once has nothing to attach it to. Say what the thing is; the sentence is usually shorter for it. A term the code itself names is different, since the reader can go and read what it is.
+Name a thing the way the code names it: write `FullName`, not "the full name". An identifier is vocabulary the reader already shares and can search for, while a paraphrase — a translated one above all — makes a second name for one thing. Where the code names nothing, say what the thing is rather than coining a word for it: a word invented for a few paragraphs gives the reader nowhere to look it up.
 
 ## Audience and self-containedness
 


### PR DESCRIPTION
PR #403 が入れた `Don't coin a term for one document` は、「コードが名前を持つ語は例外として許す」という書き方だった。順序が逆である。**識別子は最初に手を伸ばすもの**で、造語を避けるのはその裏側にすぎない。

# 1. 識別子を第一にする

エージェントが書いた doc コメントに、こういう文があった。

> それが指す完全名を 1 つ返す

`完全名` はコードの `FullName` を訳したものである。#403 の規約はこれを止められない — 造語ではないし、コードの名前でもないからである。だが**これは実害がある**。

- **読み手が grep できない。** `完全名` を検索してもコードには何も見つからない
- **1 つのものに 2 つ目の名前ができる。** 読み手は `完全名` と `FullName` が同じものだと自分で気づく必要がある
- **翻訳を通ると帰り道が二重に切れる。** 英語版で "the full name" と書き、日本語版で `完全名` と訳すと、コードの `FullName` からは 2 段離れる

正しくは:

> それが指す `FullName` を 1 つ返す

# 2. どのコードかは、読み手が決める

第 1 版はここを言っていなかった。そのままだと、**`CHANGELOG.md` や `Document.md` に `FullName` と書け**という意味になる。Fix プログラマはコンパイラのソースを開かないので、そこに書かれた識別子は**読み手が辿り着けないものを指している**。既存の changelog の規約が禁じている「コンパイラの内部を主語にする」を、この規約が要求してしまう形だった。

どのコードを共有しているかは、その文を誰が読むかで決まる。

| 文 | 読み手 | 使う識別子 |
|---|---|---|
| Rust のコメント、dev doc、PR 本文 | コンパイラの開発者 | `FullName`、`CTypeShape` |
| `Document.md`、`CHANGELOG.md` | Fix プログラマ | `FFI_EXPORT`、`I8`、`Std::Array::get_size` |

# 書き直した規約

> #### Name a thing the way the reader's own code names it — [Rust + Markdown]
>
> An identifier the reader's code carries is vocabulary they already share with the text, and a word they can search for. In a Rust comment that is the compiler's: write `FullName`, not "the full name"; `CTypeShape`, not "the shape a C declaration carries". A paraphrase makes a second name for one thing and cuts the way back to the code, and a translated paraphrase cuts it twice.
>
> **Which code that is follows from who reads the text.** A Fix programmer reading the manual or `CHANGELOG.md` shares Fix's names — `FFI_EXPORT`, `I8`, `Std::Array::get_size` — and shares nothing with the compiler's source, so a compiler identifier there names something they cannot reach. Say what they can see instead. (`Write changelog entries for the user` says the same of the changelog, from the other side.)
>
> Where the reader's code names nothing, say what the thing is rather than inventing a word for it. A word coined to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has nowhere to look it up. The test: can the sentence be written without the coined word? It usually can, and is shorter for it.

造語の禁止は、コードが名前を持たない場合の話として最後の段落に下がった。#403 にあった **Keep** の一文（「コードが名前を持つ語は残してよい」）は消えた。第 1 段落がその内容を、許可ではなく指示として述べているためである。

`devdoc` の `Language` も同じ形に直した。あちらは読み手が常に実装者なので、コンパイラの識別子を使う側だけを述べている。

# 変更の範囲

`.claude/skills/code-review/SKILL.md` の `comment-style` の 1 規約と、`.claude/skills/devdoc/SKILL.md` の `Language` の 1 段落。規約の総数は増えない。