### PR TITLE
どのコードの名前を使うかは、読み手が決める

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -988,13 +988,15 @@ State what *is*, not what *isn't*. Two anti-patterns to catch, both applying to 
 
 **Rewrite** (a) and (b) into the affirmative equivalent. When the negation carries no residual information once affirmed, drop the sentence.
 
-#### Name a thing the way the code names it — [Rust + Markdown]
+#### Name a thing the way the reader's own code names it — [Rust + Markdown]
 
-An identifier the code carries — a type, a field, a function, a variant — is vocabulary the reader already shares with the text, and it is a word they can search for. Write `FullName`, not "the full name"; `CTypeShape`, not "the shape a C declaration carries". A paraphrase makes a second name for one thing and cuts the reader's way back to the code, and a paraphrase translated into another language cuts it twice.
+An identifier the reader's code carries is vocabulary they already share with the text, and a word they can search for. In a Rust comment that is the compiler's: write `FullName`, not "the full name"; `CTypeShape`, not "the shape a C declaration carries". A paraphrase makes a second name for one thing and cuts the way back to the code, and a translated paraphrase cuts it twice.
 
-Where the code names nothing, say what the thing is rather than inventing a word for it. A word coined to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has nowhere to look it up. The test: can the sentence be written without the coined word? It usually can, and is shorter for it.
+**Which code that is follows from who reads the text.** A Fix programmer reading the manual or `CHANGELOG.md` shares Fix's names — `FFI_EXPORT`, `I8`, `Std::Array::get_size` — and shares nothing with the compiler's source, so a compiler identifier there names something they cannot reach. Say what they can see instead. (`Write changelog entries for the user` says the same of the changelog, from the other side.)
 
-**Rewrite**: put the identifier where a paraphrase of it stands, and what it stands for where a coined word stands.
+Where the reader's code names nothing, say what the thing is rather than inventing a word for it. A word coined to carry a concept through a few paragraphs — a "position" for a parameter or a result, a "slot", a "unit" — means nothing to a reader who meets it once and has nowhere to look it up. The test: can the sentence be written without the coined word? It usually can, and is shorter for it.
+
+**Rewrite**: put the reader's identifier where a paraphrase of it stands, and what it stands for where a coined word stands.
 
 #### Reference by name, not by line or section number — [Rust + Markdown]
 

--- a/.claude/skills/devdoc/SKILL.md
+++ b/.claude/skills/devdoc/SKILL.md
@@ -43,7 +43,7 @@ Write the doc in the implementers' language. It does not have to be English.
 
 Where that language is English, write it plainly: a reader need not be a native speaker, and a long sentence or a rare word costs them more than it costs a native reader.
 
-Name a thing the way the code names it: write `FullName`, not "the full name". An identifier is vocabulary the reader already shares and can search for, while a paraphrase — a translated one above all — makes a second name for one thing. Where the code names nothing, say what the thing is rather than coining a word for it: a word invented for a few paragraphs gives the reader nowhere to look it up.
+Name a thing the way the reader's own code names it. A doc addressed to the implementers shares the compiler's names, so write `FullName`, not "the full name": an identifier is vocabulary they already have and can search for, while a paraphrase — a translated one above all — makes a second name for one thing. Where their code names nothing, say what the thing is rather than coining a word for it: a word invented for a few paragraphs gives the reader nowhere to look it up.
 
 ## Audience and self-containedness
 


### PR DESCRIPTION
PR #409 が入れた `Name a thing the way the code names it` は、**どのコードかを言っていない**。そのままだと `CHANGELOG.md` や `Document.md` にも `FullName` と書けという意味になり、既存の changelog の規約が禁じている「コンパイラの内部を主語にする」を、この規約が要求してしまう。

# 何が問題か

#409 の規約は、識別子を使う理由を「読み手が既に共有している語彙で、検索できるから」と述べている。**その理由が成り立つかどうかは、誰が読むかで決まる。**

Fix プログラマはコンパイラのソースを開かない。`Document.md` に `FullName` と書いても、その読み手が辿り着ける先は無い。彼らが共有しているのは Fix の名前である。

| 文 | 読み手 | 使う識別子 |
|---|---|---|
| Rust のコメント、dev doc、PR 本文 | コンパイラの開発者 | `FullName`、`CTypeShape` |
| `Document.md`、`CHANGELOG.md` | Fix プログラマ | `FFI_EXPORT`、`I8`、`Std::Array::get_size` |

# 書き足したもの

見出しを `Name a thing the way the reader's own code names it` に変え、段落を 1 つ足した。

> **Which code that is follows from who reads the text.** A Fix programmer reading the manual or `CHANGELOG.md` shares Fix's names — `FFI_EXPORT`, `I8`, `Std::Array::get_size` — and shares nothing with the compiler's source, so a compiler identifier there names something they cannot reach. Say what they can see instead. (`Write changelog entries for the user` says the same of the changelog, from the other side.)

最後の括弧で、既存の changelog 規約との関係を断ってある。あちらは「コンパイラの内部を主語にするな」と禁止の側から、こちらは「読み手が持つ名前を使え」と指示の側から、同じことを述べている。2 つが競合しないことが読めば分かるようにした。

`devdoc` の `Language` も同じ形にした。あちらは読み手が常に実装者なので、コンパイラの識別子を使う側だけを述べている。

# 変更の範囲

`.claude/skills/code-review/SKILL.md` の `comment-style` の 1 規約（見出しと 1 段落）と、`.claude/skills/devdoc/SKILL.md` の 1 段落。規約の総数は増えない。