### PR TITLE
スキル改定: PR 本文のリンク対象を絞り、dev-doc の例の規則を doc コメント側と揃える

### DIFF
--- a/.claude/skills/devdoc/SKILL.md
+++ b/.claude/skills/devdoc/SKILL.md
@@ -66,13 +66,13 @@ Type and trait definitions pack much of the information about a computation, and
 
 ## An example of input and output
 
-A declaration says what a function accepts and returns; what it computes is left to the prose. Write that sentence, then read it as the reader will — taking an input they have in mind, can they say what comes back? Where the sentence leaves them guessing, one input and the output it produces settles it in a line, and settles it more exactly than a second sentence would. Head the line with **Examples**, so the reader sees at a glance that what follows is a case rather than the rule:
+A declaration says what a function accepts and returns; what it computes is left to the prose. Add one input and the output it produces when the pair would carry the reader to the behavior faster than that prose does. The prose does not have to be incomplete for that to hold: a concrete pair is read at a glance, where a rule has to be applied before it answers anything. So the question is which one the reader gets there on, not whether the prose is sufficient. Head the line with **Examples**, so the reader sees at a glance that what follows is a case rather than the rule:
 
 **Examples**
 
 ```
-split(",", "a,,b")    ->  ["a", "", "b"]
-is_prefix("", "abc")  ->  true
+split(",", "a,b")   ->  ["a", "b"]
+split(",", "a,,b")  ->  ["a", "", "b"]
 ```
 
 The gap an example closes is usually one of these:
@@ -80,7 +80,10 @@ The gap an example closes is usually one of these:
 - **A transformation** leaves open what the output is made of: which parts of the input survive, in what order, and what an empty or repeated part becomes.
 - **A predicate** leaves open where the line falls: the reflexive case, the empty case, and — when two arguments share a type — which of the two the question is about.
 - **An encoding, a generated name, a formatted string** leaves open the shape of the result, which is the whole content of the function.
+- **Several rules the reader has to add up**: each is stated on its own, and the answer is what they come to together.
 
-So choose the input that answers the open question rather than a typical one: an empty collection, a boundary, an element the function drops, the case where the answer flips.
+Choose the input a reader would meet first — the ordinary call rather than a boundary. The example is what the reader carries away from the paragraph, so it has to show the function doing its usual work. Add a second only where the ordinary one leaves a boundary open: what an empty or repeated part becomes, which side of the line an endpoint falls on.
+
+Keep it to what a glance holds — a line or two. An example needing a paragraph of setup says the prose should carry the behavior instead.
 
 Where the name and the type already carry the behavior — reading a field, replacing a field, constructing a value, performing an effect — state the meaning they leave unsaid and stop there.

--- a/.claude/skills/pr-message/SKILL.md
+++ b/.claude/skills/pr-message/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-message
-description: 'Conventions for writing a pull request body, added on top of the devdoc skill: explain the role, the change, and the purpose of every function the diff touches, link every name it mentions to the implementation on GitHub, quote every text the change shows to a user, and explain a bug fix by tracing the program state through the failing run and the fixed run. Use when: writing or revising a pull request body.'
+description: 'Conventions for writing a pull request body, added on top of the devdoc skill: explain the role, the change, and the purpose of every function the diff touches, link every item the change adds or modifies to its implementation on GitHub, quote every text the change shows to a user, and explain a bug fix by tracing the program state through the failing run and the fixed run. Use when: writing or revising a pull request body.'
 ---
 
 # Writing a pull request body
@@ -31,19 +31,24 @@ The body is read before the diff, and it has to make the diff make sense. So the
 
 When one mechanical change lands identically in many functions — a renamed parameter, an argument threaded through a call chain — describe the change once and name the functions it lands in. Every function is still covered, without the repetition.
 
-## Link every name to its implementation
+## Link every item the change adds or modifies
 
-The body names functions for a reader who has never opened them, so it also says where each one lives. Every name the body mentions that this repository defines carries a link to its implementation, written as a Markdown link whose visible text is the name:
+The body names functions for a reader who has never opened them, so it also says where each one lives. A link is written as a Markdown link whose visible text is the name:
 
 > the pass [`request_inline_into_callers`](https://github.com/tttmmmyyyy/fixlang/blob/43883c7abbf8f3b19730f28f067093ec780b6372/src/optimization/inline.rs#L77-L85) marks each global whose body is small enough …
 
 The visible text is the name alone, so the prose goes on referring to the code by name and the reader who wants the source is one click from it. A bare URL standing on its own line is rendered as a code excerpt instead, which puts a block of code where a sentence belongs.
 
+The links sit where the body covers what the change did to the code, which is two places:
+
+- **Each entry of the function coverage above** — every changed function and every added one.
+- **Each other item the change adds or modifies**, where the body covers it: a type, a trait, a field, a constant.
+
+Those are the names the reader opens the source for, and each of them gets exactly one link. Every other mention stays plain text — a name the body brings in to explain the surroundings is read rather than opened.
+
 - **Pin every link to a commit hash.** Push the branch, take `git rev-parse HEAD`, and build all of them on that hash. A hash names the same lines forever and keeps resolving after the branch is deleted; a branch name in the path drifts with the next commit and resolves to nothing once the branch is gone.
 - **Span the definition**: `#L<signature>-L<closing>`, from the signature line to the line that closes the body. GitHub highlights that span, so the click lands on the whole function.
-- **Link the first mention of a name** and leave the rest of its mentions plain. The body and the appendix each get one, since either is read on its own.
 - **A function the change deletes is linked at the commit the branch forked from** (`git merge-base HEAD main`), where it still stands.
-- The same form serves a type, a trait, a field, or a constant the body names. A name defined elsewhere — a function of a crate, an LLVM API — stays plain text.
 - **Re-pin when the body is revised after further commits are pushed**, so the lines the links point at are the ones the body describes.
 
 The two line numbers are mechanical — the signature line, then the first line closing a block at the signature's own indentation:


### PR DESCRIPTION
2 つのスキル文書の改定です。どちらも「文章をどう書くか」の規約で、コンパイラのコードには触れません。

## 1. pr-message: リンクを貼る対象を、変更・追加した項目に絞る

`.claude/skills/pr-message/SKILL.md` は PR 本文の書き方の規約で、`devdoc` スキルの上に載っています。その中の 1 節が、本文が名前を出したときに GitHub の実装へリンクを貼る規則を定めています。

**変更前**は、対象が「本文が言及する名前のうち、このリポジトリが定義するものすべて」でした。

> The body names functions for a reader who has never opened them, so it also says where each one lives. Every name the body mentions that this repository defines carries a link to its implementation, written as a Markdown link whose visible text is the name:
>
> - **Link the first mention of a name** and leave the rest of its mentions plain. The body and the appendix each get one, since either is read on its own.
> - The same form serves a type, a trait, a field, or a constant the body names. A name defined elsewhere — a function of a crate, an LLVM API — stays plain text.

回数の規則は「最初の言及に 1 つ、以降は素のまま」「本文と付録がそれぞれ 1 つずつ」でした。これだと、周辺の事情を説明するために持ち出しただけの名前にもリンクが付きます。読み手はリンクを見ても、その名前がこの変更の対象なのか、背景として出てきただけなのかを区別できません。

**変更後**は、貼る場所を 2 つに定めました。

> The links sit where the body covers what the change did to the code, which is two places:
>
> - **Each entry of the function coverage above** — every changed function and every added one.
> - **Each other item the change adds or modifies**, where the body covers it: a type, a trait, a field, a constant.
>
> Those are the names the reader opens the source for, and each of them gets exactly one link. Every other mention stays plain text — a name the body brings in to explain the surroundings is read rather than opened.

1 つ目の「関数一覧」は、pr-message が別に定めている節で、diff が触れた関数それぞれについて役割・変更・目的を書くところです。そこに並ぶ名前が、読み手がソースを開く名前でもあります。2 つ目は、関数以外で変更・追加された項目（型・トレイト・フィールド・定数）です。

回数の規則は、この 2 か所が対象ごとに 1 回ずつ現れることから決まるので、「最初の言及」という別立ての規則は消えました。「他リポジトリで定義された名前は素のまま」という一文も、対象が「この変更が追加・変更した項目」になった時点で言うまでもないので消しています。

節の見出しも対象に合わせました: `## Link every name to its implementation` -> `## Link every item the change adds or modifies`。frontmatter の `description` も同じ言い換えです。

コミットハッシュに固定する・定義全体を span で指す・削除された関数は分岐元のコミットで指す・本文を書き直したら貼り直す、という機械的な規則はそのままです。

## 2. devdoc: 入出力の例の規則を、doc コメント側と揃える

「関数の説明に入出力の例を 1 つ添える」という規約は、この repository に 2 か所あります。

- `.claude/skills/devdoc/SKILL.md` の `An example of input and output` — `dev-docs/` の文書・PR 本文・issue 本文の散文が対象。
- `.claude/skills/code-review/SKILL.md` の `comment-style` アスペクトの `# Examples` — Rust の doc コメントが対象。

この 2 つは、これまで**同じコミットで一緒に**改定されてきました (`8caf658e`, `efcca242`, `5760d4ad` はいずれも両方のファイルを触っています)。ところが直近の 2 コミット `9bc29cd1` と `addd32aa` が code-review 側だけを触ったため、内容が食い違ったまま残っていました。食い違いは 4 点です。

| 論点 | devdoc（改定前） | code-review（現行） |
| --- | --- | --- |
| 例を付ける条件 | 散文を読んだ読み手が、手元の入力に対する戻り値を言えないとき | 入出力の対が散文より速く読み手を behavior へ運ぶとき。散文が不完全である必要はない |
| 選ぶ入力 | 開いた問いに答える入力。空の集合、境界、関数が落とす要素、答えが反転する場合 | 読み手が最初に出会う普通の呼び出し。境界は、普通の呼び出しが残した問いに対して 2 つ目として足す |
| 埋める穴の種類 | 3 つ | 4 つ（「複数の規則を足し合わせる」が加わった） |
| 長さの上限 | なし | 一目で収まる 1〜2 行 |

devdoc 側を現行の code-review 側に合わせました。例示も、境界だけを並べた `split(",", "a,,b")` と `is_prefix("", "abc")` から、普通の呼び出しを先に置く形に差し替えています。

```
split(",", "a,b")   ->  ["a", "b"]
split(",", "a,,b")  ->  ["a", "", "b"]
```

理由づけの一文だけ、devdoc の媒体に合わせて言い換えました。code-review は「散文を飛ばす読み手の前に例が出るから、例は関数が普段する仕事を見せる」と書いています。devdoc は本文に `Readable front to back`（本文は前から一度で読めること）を要求しているので、散文を飛ばす読み手を前提にできません。そこで「例は読み手がその段落から持ち帰るものだから」としています。

> Choose the input a reader would meet first — the ordinary call rather than a boundary. The example is what the reader carries away from the paragraph, so it has to show the function doing its usual work.

## 付録: この PR の経緯

2 つのコミットは一度 `main` に直接入れました。`main` 上では `3baf15ce` で revert してあり、このブランチはその上に同じ 2 つを cherry-pick したものです。したがって `main` の履歴は「適用 -> revert」で閉じており、実際に効くのはこの PR のマージです。
