### PR TITLE
型検査キャッシュの鍵に名前空間が入っていることを押さえる

### DIFF
--- a/src/elaboration/typecheckcache.rs
+++ b/src/elaboration/typecheckcache.rs
@@ -241,7 +241,7 @@ impl TypeCheckCache for MemoryCache {
 
 #[cfg(test)]
 mod tests {
-    use super::FileCache;
+    use super::{entity_identity, FileCache};
     use crate::{
         ast::name::FullName,
         ast::types::{type_tyvar_star, Scheme},
@@ -284,6 +284,24 @@ mod tests {
             cache.cache_file_name(&name, &i64_scheme, "0"),
             cache.cache_file_name(&name, &i64_scheme, "1"),
             "an entry keeps its file when the sources it depends on change",
+        );
+    }
+
+    /// The namespace a value is written under is part of the entity its entry belongs to. Two
+    /// values of one module, each under a namespace of its own, agree on their remaining name, on
+    /// their type, and on the sources they are checked from, so the namespace alone tells their
+    /// entries apart. Every cache reads the entity through `entity_identity`, so pinning it here
+    /// reaches the entries held in memory as well as those given a file.
+    #[test]
+    fn entities_of_names_differing_only_in_namespace_stay_apart() {
+        let scheme = Scheme::from_type(make_i64_ty());
+        let in_a = FullName::from_strs(&["Main", "A"], "answer");
+        let in_b = FullName::from_strs(&["Main", "B"], "answer");
+
+        assert_ne!(
+            entity_identity(&in_a, &scheme),
+            entity_identity(&in_b, &scheme),
+            "two values whose names differ in the namespace alone meet in one entry",
         );
     }
 }


### PR DESCRIPTION
型検査キャッシュにテストを 1 本足す。実装は変えない。

## 型検査キャッシュとエンティティ

`fix` は、グローバル値ひとつを型検査した結果（型のついた式）をキャッシュに預け、同じ値が同じ条件で再び求められたときに、検査をやり直さずに取り出す。取り出した式はそのまま組み込まれ、型検査を通らない。ある値の求めに別の値の式が返れば、誰も何も報告しないまま、その値は自分が書いていない本体を持つ。

どの求めがどのエントリに当たるかを決めるのは、`src/elaboration/typecheckcache.rs` の `entity_identity` である。この関数は、値の完全名と、検査に用いた型とを 1 つの文字列にまとめる。キャッシュの実装は 2 つあり、どちらもこの文字列でエントリを引く。

- `FileCache` — エントリごとにファイルを 1 つ作り、実行をまたいで残す。`fix build` と `fix check` が使う。ファイル名は、この文字列と依存ソースのハッシュから取ったダイジェストに、人が読むための名前を前置したもの。人が読むための名前は完全名から作る。
- `MemoryCache` — エントリをメモリに置き、プロセスが生きているあいだ持つ。LSP サーバが使う。引くのはこの文字列だけで、ファイル名は関わらない。

## 足すテスト

`entities_of_names_differing_only_in_namespace_stay_apart` は、1 つのモジュールの中で名前空間だけが異なる 2 つの値 — `Main::A::answer` と `Main::B::answer` — が別々のエンティティであることを表明する。この 2 つは、名前空間を除いた名前も、型も、検査に用いるソースも一致するので、両者を分けているのは名前空間だけである。

## なぜ足すか

キャッシュの鍵の構成要素のうち、名前空間だけにテストが無かった。同じファイルの既存 2 本が見ているのは、

- 葉の名前が文字で異なる組 — フィールドアクセサ `@b` と、利用者が書いた値 `_b`
- 型が異なる組と、依存ソースのハッシュが異なる組

であり、いずれも名前空間には触れない。

`entity_identity` が完全名ではなく葉の名前だけを持つように 1 行を変えてスイート全体を走らせたところ、**1,643 件すべてが緑のまま**だった。`FileCache` は人が読むための名前を完全名から作るので、バッチコンパイルはこの変更に気づかない。気づかないまま壊れるのは `MemoryCache`、すなわち LSP である。

このテストは、その 1 行の変更で赤になる。同じファイルの他の 2 本は緑のままである。

```
assertion `left != right` failed: two values whose names differ in the namespace alone meet in one entry
  left: "answer\nStd::I64"
 right: "answer\nStd::I64"
```

## 差分が触れる関数

- `entities_of_names_differing_only_in_namespace_stay_apart`（新規）— `entity_identity` を 2 つの名前について直接呼び、返る文字列が異なることを表明する。上記の性質を押さえるのがこのテストの役割である。
- `mod tests` の `use` — `entity_identity` を取り込む 1 語を足す。

利用者から見える振る舞いは変わらないので、`CHANGELOG.md` のエントリは無い。
