### PR TITLE
レビュー清掃 (#416): unit_step が置き換えた語を落とす

### DIFF
--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -260,7 +260,7 @@ fn borrow_funcref(name: &FuncRef) -> FuncRef {
     FuncRef { name: n }
 }
 
-/// Whether any of a function's parameter leaves is borrowable (not in the inferred owned set).
+/// Whether any of a function's parameter leaves is one borrow inference left `Borrow`.
 fn func_has_borrowable_param(
     func: &RcFunc,
     owned_leaves: &OwnedLeaves,

--- a/src/rc_ir/codegen.rs
+++ b/src/rc_ir/codegen.rs
@@ -297,8 +297,8 @@ impl<'c, 'm> Generator<'c, 'm> {
 
     /// Project the whole object `obj` down `path` to the sub-object naming one reference-counting
     /// unit. Each index descends one unboxed struct/tuple field — or a closure's capture field — so
-    /// the path stops at the unit itself: a boxed leaf, an unboxed union, or a closure capture. The
-    /// empty path names the whole value, returning `obj` unchanged. The caller retains or releases
+    /// the path stops at the unit itself, which is whatever `unit_step` answers `Unit` or `Capture`
+    /// for. The empty path names the whole value, returning `obj` unchanged. The caller retains or releases
     /// the returned sub-object as a whole, which reference-counts exactly that unit (a boxed leaf
     /// directly, a union by tag dispatch).
     fn project_rc_unit(&mut self, obj: Object<'c>, path: &[usize]) -> Object<'c> {

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -339,7 +339,7 @@ fn origin_from_leaves_under(
     path: &[usize],
     here: &VarPath,
 ) -> Option<Origin> {
-    // The leaves of one unit root usually project out of one operand unit, so the operand units are
+    // The leaves of one unit usually project out of one operand unit, so the operand units are
     // gathered before any of them is followed back: resolving each distinct one once keeps a chain
     // of aliases from being walked once per leaf.
     let mut operand_units: Set<(usize, FieldPath)> = Set::default();
@@ -794,7 +794,7 @@ fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPa
         return (root.clone(), path.clone());
     };
     let truncated = truncate_to_unit(ty, path, type_env);
-    // Truncation only descends, so an identity whose path stops above every unit root of its type
+    // Truncation only descends, so an identity whose path stops above every unit of its type
     // comes out naming no unit at all. A retain under such a key pairs with no release of the
     // object, so cancellation drops it and the object is freed while it is still held. The check
     // sits here, where every key is made.


### PR DESCRIPTION
PR #416 のコードレビューが、変更したファイルの**変更箇所の外**に見つけた清掃。base は #416 のブランチなので、#416 の差分は読むときにこの清掃を含まない。コメントだけの変更である。

## `unit_step` が置き換えた語を落とす

`is_rc_unit_root` は #416 で `unit_step` に畳まれて無くなったので、それを指していた「unit root」という語は指す先を失った。2 か所を「unit」に直した。

- `origin_from_leaves_under` の中のコメント（"The leaves of one unit root usually project out of one operand unit"）
- `unit_of` の assertion の前のコメント（"an identity whose path stops above every unit root of its type"）

由来する規約: 「読み手のコードが持つ名で呼ぶ」。

## unit の種類の部分列挙を、答えを持つ場所への参照にする

`project_rc_unit` の doc が unit の種類を "a boxed leaf, an unboxed union, or a closure capture" と 3 つだけ挙げていた（実際は `Array` と punched array もある）。数え上げをやめ、`unit_step` が `Unit` か `Capture` と答えるもの、と述べる形にした。列挙が 1 か所にあれば、種類が増えたときに古い列挙が残らない。

## 補集合による定義を肯定形にする

`func_has_borrowable_param` の doc の "is borrowable (not in the inferred owned set)" を "is one borrow inference left `Borrow`" に。参照先の集合は #416 で `OwnedLeaves` に改名されており、補集合で述べる必要はもう無い。

由来する規約: 「肯定形で書く」。

## マージの仕方

このプルリクエストの base は #416 のブランチなので、次のどちらでもよい。

- このプルリクエストを #416 のブランチへマージしてから、#416 を `main` へマージする（`main` へのマージは 1 回）。
- #416 を `main` へマージし、そのブランチを削除する。GitHub は base ブランチが消えたプルリクエストをその base の base（`main`）へ張り替えるので、このプルリクエストは `main` 向けの独立したものになる。
