### PR TITLE
レビュー清掃 (#422): 網羅しない match、借用版の略語、変更の周りの doc

### DIFF
--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -1,5 +1,5 @@
-//! Borrow-ification over the RC IR: rewriting `Own` parameters that a function only
-//! reads to `Borrow`, so the caller keeps ownership across the call and no retain is needed before a
+//! Borrow-ification over the RC IR: an `Own` parameter that a function only reads becomes a
+//! `Borrow` parameter, so the caller keeps ownership across the call and needs no retain before a
 //! non-last use — which is what keeps a value `Unique` for the uniqueness analysis.
 //!
 //! Lowering makes every parameter `Own` (the callee releases it). Borrow-ification has three parts:
@@ -34,7 +34,7 @@
 //! borrow-ification exists.
 //!
 //! Which construct consumes which reference, and which object a reference belongs to, is the shared
-//! model in `ownership`: inference, rewrite, and cancellation all read it, so they agree.
+//! model in `ownership`, so every part of this pass gives the same answer.
 
 use crate::ast::name::FullName;
 use crate::ast::program::TypeEnv;
@@ -262,7 +262,7 @@ fn borrow_funcref(name: &FuncRef) -> FuncRef {
     FuncRef { name: borrow_name }
 }
 
-/// Whether any of a function's parameter leaves is one borrow inference left `Borrow`.
+/// Whether borrow inference left any of a function's parameter leaves `Borrow`.
 fn func_has_borrowable_param(
     func: &RcFunc,
     owned_leaves: &OwnedLeaves,
@@ -357,8 +357,8 @@ fn param_ownership_shape(
 
 // --- tail-call recognition ---
 
-/// The variables bound to an `App` or `Match` in tail position: a call in tail position must not be
-/// turned into a non-tail one by an after-call release, so routing consults this set.
+/// The variables bound to an `App` or `Match` in tail position. Such a call must not be turned into
+/// a non-tail one by an after-call release.
 fn tail_result_vars(body: &RcExprNode) -> Set<FullName> {
     let mut out = Set::default();
     mark_tail(body, true, &mut out);
@@ -576,11 +576,11 @@ impl<'a> RewriteCtx<'a> {
     }
 
     /// Whether routing this call to the borrow version removes a reference count it would otherwise
-    /// need, for at least one argument unit. Routing helps a unit that the borrow version borrows and
-    /// that would otherwise be retained: a borrowed value (which an owning callee makes the caller
-    /// retain before the call) or an owned value used again after the call (whose retain-before the
-    /// borrow cancels). An owned value at its last use is moved either way, so borrowing it removes no
-    /// retain and only delays its release; it is not a benefit.
+    /// need, for at least one argument unit. Routing helps a unit that the borrow version borrows
+    /// and that would otherwise be retained. Two kinds qualify: a borrowed value, which an owning
+    /// callee makes the caller retain before the call, and an owned value used again after the
+    /// call, whose retain-before the borrow cancels. An owned value at its last use is moved either
+    /// way, so borrowing it removes no retain and only delays its release.
     fn routing_saves_retain(
         &self,
         borrow_version: &FuncRef,
@@ -766,9 +766,8 @@ fn rhs_uses(name: &FullName, rhs: &RcRhs) -> bool {
 // --- unit normalization ---
 
 /// Decompose every `Retain`/`Release` into one node per reference-counting unit its path covers, so
-/// borrow-ification and cancellation both see reference counting at unit granularity. A path that
-/// already names a single unit is unchanged; a whole-value retain on a fully-unboxed value (a no-op)
-/// disappears.
+/// that every later pass sees reference counting at unit granularity. A path that already names a
+/// single unit is unchanged; a whole-value retain on a fully-unboxed value (a no-op) disappears.
 pub fn split_rc_units(prog: &mut RcProgram, type_env: &TypeEnv) {
     for func in prog.funcs.values_mut() {
         func.body = split_body(&func.body, type_env);
@@ -886,8 +885,7 @@ enum UnBump {
 }
 
 /// Take a release's references off the innermost retain pending for `key`, where that retain bumped
-/// all of them. A retain the release leaves nothing outstanding of is un-bumped whole, and stops
-/// being pending.
+/// all of them. A retain left with nothing outstanding is un-bumped whole, and stops being pending.
 fn un_bump(pending: &mut PendingRetains, key: &VarPath, un_bumped: &References) -> UnBump {
     // A release with nothing pending for `key` disposes of a reference the walk did not add — an
     // owned parameter, or a value produced here — so it un-bumps no retain.
@@ -914,8 +912,8 @@ fn un_bump(pending: &mut PendingRetains, key: &VarPath, un_bumped: &References) 
 }
 
 /// A node's identity within one tree: the address of its expression, stable while the tree is
-/// borrowed. The analysis records which nodes to drop by identity, and the deletion pass, walking the
-/// same borrowed tree, recognizes them by the same identity.
+/// borrowed. Nodes to drop are recorded under this identity and recognized by it again in a later
+/// walk over the same borrowed tree.
 type NodeId = usize;
 
 /// The `NodeId` of a node: the address of its boxed `RcExpr`.
@@ -1063,8 +1061,8 @@ impl<'a> CancelAnalysis<'a> {
             RcExpr::Release(v, path, _, k) => {
                 let key = self.unit_key(&v.name, path);
                 // A release of a value whose object is path-dependent un-bumps a retain of that same
-                // value, so it pairs on the identity; on the other objects it may be, it is a drop
-                // that no pending retain of theirs may be cancelled across.
+                // value, so it pairs on the identity. On the other objects it may be, it is a drop:
+                // a retain of one of them that is still pending cannot be cancelled across it.
                 for other in self.acted_unit_keys(&v.name, path) {
                     if other != key {
                         self.consume_unit(&mut pending, other);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -385,7 +385,9 @@ fn mark_tail(node: &RcExprNode, in_tail: bool, out: &mut Set<FullName>) {
                         mark_tail(&arm.body, is_tail, out);
                     }
                 }
-                _ => {}
+                // A tail-position result is bound by a call or a match, so the remaining shapes —
+                // a call out of tail position included — leave the set alone.
+                RcRhs::App(..) | RcRhs::Var(..) | RcRhs::Closure(..) | RcRhs::Llvm(..) => {}
             }
             mark_tail(k, in_tail, out);
         }
@@ -403,7 +405,13 @@ fn trivially_returns(k: &RcExprNode, x: &FullName) -> bool {
     match k.expr.as_ref() {
         RcExpr::Ret(v) => v.name == *x,
         RcExpr::Let(s, RcRhs::Var(y), k2) if y.name == *x => trivially_returns(k2, &s.name),
-        _ => false,
+        // A binding of anything but a rename of `x`, and every other construct, is a real operation
+        // that breaks the chain.
+        RcExpr::Let(..)
+        | RcExpr::Retain(..)
+        | RcExpr::Release(..)
+        | RcExpr::Destructure(..)
+        | RcExpr::Eval(..) => false,
     }
 }
 

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -144,8 +144,8 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
         owned_units.extend(param_capture_units(func, type_env));
         // `f_borrow`: a fresh clone whose owned units are the inferred owned leaves, each truncated
         // to its unit.
-        if let Some(bref) = borrow_versions.get(&func.name) {
-            let (clone, rename) = clone_func(func, bref.clone(), &mut rename_counter);
+        if let Some(borrow_version) = borrow_versions.get(&func.name) {
+            let (clone, rename) = clone_func(func, borrow_version.clone(), &mut rename_counter);
             for p in &func.params {
                 for leaf in boxed_leaf_paths(&p.ty, type_env) {
                     if owned_leaves.owns(&p.name, &leaf) {
@@ -154,7 +154,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
                     }
                 }
             }
-            clones.push((bref.clone(), clone, rename));
+            clones.push((borrow_version.clone(), clone, rename));
         }
     }
 
@@ -164,8 +164,8 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     for func in prog.funcs.values() {
         callee_params.insert(func.name.clone(), param_names_and_types(func));
     }
-    for (bref, clone, _) in &clones {
-        callee_params.insert(bref.clone(), param_names_and_types(clone));
+    for (borrow_version, clone, _) in &clones {
+        callee_params.insert(borrow_version.clone(), param_names_and_types(clone));
     }
 
     // Rewrite every version's body: route its calls and adjust the reference counting.
@@ -183,7 +183,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
         f_own.body = ctx.rewrite(&f_own.body);
         funcs.insert(f_own.name.clone(), f_own);
     }
-    for (bref, mut clone, _) in clones {
+    for (borrow_version, mut clone, _) in clones {
         let ctx = RewriteCtx::new(
             &clone,
             true,
@@ -193,7 +193,7 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
             type_env,
         );
         clone.body = ctx.rewrite(&clone.body);
-        funcs.insert(bref, clone);
+        funcs.insert(borrow_version, clone);
     }
 
     // Globals are param-less function bodies: route and rewrite them the same way (as `f_own`).
@@ -257,9 +257,9 @@ pub fn param_ownership_shapes(
 /// The name of a function's borrow version: its name with a `#borrow` suffix. No lowered name ends in
 /// `#borrow`, so this stays globally unique.
 fn borrow_funcref(name: &FuncRef) -> FuncRef {
-    let mut n = name.name.clone();
-    n.name.push_str("#borrow");
-    FuncRef { name: n }
+    let mut borrow_name = name.name.clone();
+    borrow_name.name.push_str("#borrow");
+    FuncRef { name: borrow_name }
 }
 
 /// Whether any of a function's parameter leaves is one borrow inference left `Borrow`.
@@ -559,11 +559,11 @@ impl<'a> RewriteCtx<'a> {
         let orig = FuncRef {
             name: callee.name.clone(),
         };
-        if let Some(bref) = self.borrow_versions.get(&orig) {
-            if self.routing_is_safe(x, args) && self.routing_saves_retain(bref, args, k) {
-                let mut c = callee.clone();
-                c.name = bref.name.clone();
-                return c;
+        if let Some(borrow_version) = self.borrow_versions.get(&orig) {
+            if self.routing_is_safe(x, args) && self.routing_saves_retain(borrow_version, args, k) {
+                let mut routed = callee.clone();
+                routed.name = borrow_version.name.clone();
+                return routed;
             }
         }
         callee.clone()
@@ -581,18 +581,22 @@ impl<'a> RewriteCtx<'a> {
     /// retain before the call) or an owned value used again after the call (whose retain-before the
     /// borrow cancels). An owned value at its last use is moved either way, so borrowing it removes no
     /// retain and only delays its release; it is not a benefit.
-    fn routing_saves_retain(&self, bref: &FuncRef, args: &[RcVar], k: &RcExprNode) -> bool {
-        // `bref` is a borrow version, and `borrow_ify` registers every version's parameters, so it is a
-        // key here.
-        let bparams = &self.callee_params[bref];
+    fn routing_saves_retain(
+        &self,
+        borrow_version: &FuncRef,
+        args: &[RcVar],
+        k: &RcExprNode,
+    ) -> bool {
+        // `borrow_ify` registers the parameters of every version, so a borrow version is a key here.
+        let borrow_params = &self.callee_params[borrow_version];
         args.iter().enumerate().any(|(arg_idx, arg)| {
-            let last_use = !used_later(&arg.name, k);
+            let is_last_use = !used_later(&arg.name, k);
             rc_units(&arg.ty, self.type_env).iter().any(|unit| {
                 // `arg_idx` is in range since `args.len() <= params.len()`.
                 let callee_borrows = !self
                     .owned_units
-                    .contains(&(bparams[arg_idx].0.clone(), unit.clone()));
-                callee_borrows && !(self.owns_unit(arg, unit) && last_use)
+                    .contains(&(borrow_params[arg_idx].0.clone(), unit.clone()));
+                callee_borrows && !(self.owns_unit(arg, unit) && is_last_use)
             })
         })
     }
@@ -642,7 +646,7 @@ impl<'a> RewriteCtx<'a> {
         callee: &RcVar,
         args: &[RcVar],
     ) -> (Vec<(RcVar, FieldPath)>, Vec<(RcVar, FieldPath)>) {
-        let cparams = self.callee_params.get(&FuncRef {
+        let params = self.callee_params.get(&FuncRef {
             name: callee.name.clone(),
         });
         let mut before = vec![];
@@ -651,11 +655,11 @@ impl<'a> RewriteCtx<'a> {
             for unit in rc_units(&arg.ty, self.type_env) {
                 // An unresolved (indirect) callee owns every position (the all-`Own` ABI); a resolved
                 // one is indexed by `arg_idx`, which is in range since `args.len() <= params.len()`.
-                let callee_owns = match cparams {
+                let callee_owns = match params {
                     None => true,
-                    Some(ps) => self
+                    Some(params) => self
                         .owned_units
-                        .contains(&(ps[arg_idx].0.clone(), unit.clone())),
+                        .contains(&(params[arg_idx].0.clone(), unit.clone())),
                 };
                 let arg_owned = self.owns_unit(arg, &unit);
                 if !callee_owns && arg_owned {
@@ -719,8 +723,8 @@ fn rc_node(
 }
 
 /// Wrap a continuation in a `Retain` (or `Release`) of each given unit.
-fn prepend_rc(items: Vec<(RcVar, FieldPath)>, is_release: bool, k: RcExprNode) -> RcExprNode {
-    items.into_iter().rev().fold(k, |cont, (var, path)| {
+fn prepend_rc(units: Vec<(RcVar, FieldPath)>, is_release: bool, k: RcExprNode) -> RcExprNode {
+    units.into_iter().rev().fold(k, |cont, (var, path)| {
         rc_node(is_release, var, path, RcState::Unknown, cont, &None)
     })
 }

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -426,7 +426,11 @@ fn collect_consumes_go<F: Fn(&RcVar, &FieldPath) -> bool>(
                         collect_consumes_go(&arm.body, vars, prog, type_env, owns, out);
                     }
                 }
-                _ => rhs_consumes(rhs, &x.ty, vars, prog, type_env, owns, out),
+                // A match holds the only sub-expressions a right-hand side can carry, so every
+                // other shape consumes within itself.
+                RcRhs::Var(..) | RcRhs::App(..) | RcRhs::Closure(..) | RcRhs::Llvm(..) => {
+                    rhs_consumes(rhs, &x.ty, vars, prog, type_env, owns, out)
+                }
             }
             collect_consumes_go(k, vars, prog, type_env, owns, out);
         }

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -51,7 +51,8 @@ enum Binding {
     Join(Vec<RcVar>),
 }
 
-/// The variables of one function, as `origin` and the consume walk read them.
+/// The variables of one function, enough to trace a leaf back to the object it belongs to and to
+/// resolve a call to its callee's parameters.
 pub(crate) struct VarTable {
     /// What binds each variable, which `origin` follows back to the object a leaf belongs to.
     bindings: Map<FullName, Binding>,
@@ -86,7 +87,7 @@ impl VarTable {
         vars
     }
 
-    /// A table with no variable in it, to be filled by the constructor that knows what to put there.
+    /// An empty table, which a constructor fills.
     fn empty() -> VarTable {
         VarTable {
             bindings: Map::default(),
@@ -165,19 +166,20 @@ fn returned_var(node: &RcExprNode) -> &RcVar {
 pub(crate) enum Origin {
     /// The leaf denotes exactly this object.
     Exactly(VarPath),
-    /// The leaf denotes one of `candidates`, chosen by the path taken. `identity` names the match
-    /// binding that joins them: every alias chain through that binding agrees on the name, so it is
-    /// the name to use where one name for the value is required.
+    /// The leaf denotes one of several objects, chosen by the path taken.
     Join {
+        /// The match binding that joins the candidates. Every alias chain through that binding
+        /// agrees on this name, so it is the name to use where one name for the value is required.
         identity: VarPath,
+        /// Every object the leaf may denote, one per path the match can take.
         candidates: Set<VarPath>,
     },
 }
 
 impl Origin {
-    /// The one name for the value, for a reader that pairs operations on it — reference-count
-    /// cancellation pairs a retain with the release that un-bumps it, and only a single identity can
-    /// decide that. Two leaves with the same identity hold the same reference.
+    /// The one name for the value, for a reader that pairs two operations on it — a retain with the
+    /// release that un-bumps it — which only a single name can decide. Two leaves with the same
+    /// identity hold the same reference.
     pub(crate) fn identity(&self) -> &VarPath {
         match self {
             Origin::Exactly(p) => p,
@@ -248,8 +250,8 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
     let here = || Origin::Exactly((var.clone(), path.to_vec()));
     match vars.bindings.get(var) {
         // A name the table does not bind is a global — a function a direct call names, or a global
-        // value read as an atom — which this function's variables alias nothing of. So it is its own
-        // origin, as a parameter and a producer are.
+        // value read as an atom. No variable of this function aliases one, so it is its own origin,
+        // as a parameter and a producer are.
         None | Some(Binding::Param) | Some(Binding::Producer) => here(),
         Some(Binding::Move(y)) => origin(vars, type_env, &y.name, path),
         Some(Binding::Join(arm_results)) => {
@@ -276,11 +278,11 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             match decl.leaf_origins_at(path).and_then(as_arg_projection) {
                 Some((j, p)) => origin(vars, type_env, &args[j].name, &p),
                 None => {
-                    // Taking the value for its own object where the leaves beneath name none is
-                    // safe because that happens only for a value holding no reference: either the
-                    // path covers no boxed leaf, or every leaf beneath it is `⊥`, which an operation
-                    // declares for the variants a union does not have and for the result of one that
-                    // aborts. A release is keyed to a reference, so none is keyed to this answer.
+                    // The leaves beneath name no object only for a value that holds no reference:
+                    // either the path covers no boxed leaf, or every leaf beneath it is `⊥`, which
+                    // an operation declares for the variants a union does not have and for the
+                    // result of one that aborts. Taking the value for its own object is safe there,
+                    // since a release is keyed to a reference and none is keyed to this answer.
                     let here_identity = (var.clone(), path.to_vec());
                     origin_from_leaves_under(vars, type_env, &decl, args, path, &here_identity)
                         .unwrap_or_else(here)
@@ -317,7 +319,7 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
 ///
 /// A reference-counting unit path may name an unboxed union itself, whose provenance is declared one
 /// level down, on the leaves of its variants, so a reader that stops at the union finds nothing
-/// recorded and takes the value for one produced on the spot — its own to release, when it may be an
+/// recorded and would read the value as one produced here — its own to release, when it may be an
 /// operand's. The leaves beneath decide instead. A leaf recorded as `⊥` belongs to a
 /// variant the value does not have and holds no reference, so it names no object and is passed
 /// over; a leaf produced here rather than projected names this value itself. A leaf that records
@@ -449,8 +451,7 @@ fn collect_consumes_go<F: Fn(&RcVar, &FieldPath) -> bool>(
 /// The container leaves a `Destructure` consumes. A boxed container is released whole, so every boxed
 /// leaf of it goes; an unboxed container moves each named field's leaves into that field's variable,
 /// an alias whose consume is attributed to the field variable, so only a dropped (unnamed) field's
-/// leaves go. This is the model code generation implements (`ObjectFieldType::get_struct_fields`), and
-/// every reader of the consume model shares it.
+/// leaves go. This is the model code generation implements (`ObjectFieldType::get_struct_fields`).
 pub(crate) fn destructure_consumes(
     container: &RcVar,
     fields: &[(usize, RcVar)],
@@ -597,8 +598,8 @@ fn push_boxed_leaves(
 ///
 /// Which types carry a unit is one rule, and every walk over units takes its step from here, so a
 /// new kind of unit is stated once and every walk follows it. A walk that a new kind left behind
-/// would produce a path that names no unit, which reference counting then keys an operation to,
-/// freeing the object while it is still held.
+/// would produce a path that names no unit; reference counting would key an operation to that path
+/// and free the object while it is still held.
 pub(crate) enum UnitStep {
     /// The value holds no reference, so no unit sits here or below it.
     NoUnit,

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -10,6 +10,14 @@ mod union_rc_shapes_tests {
         tests::test_util::test_source,
     };
 
+    /// Compile and run a source with Valgrind switched off, leaving the program's own assertions to
+    /// decide the outcome.
+    fn test_source_without_valgrind(source: &str) {
+        let mut config = Configuration::develop_mode();
+        config.set_valgrind(ValgrindTool::None);
+        test_source(source, config);
+    }
+
     /// Matching a union built on the spot lets the simplifier replace the match with the arm it
     /// knows is taken, substituting the payload the construction was given. Where the arm then
     /// ignores that payload — an arm binding nothing, a pattern binding a field the body never
@@ -252,9 +260,7 @@ main = (
     /// changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_union_payload_units_correctness() {
-        let mut config = Configuration::develop_mode();
-        config.set_valgrind(ValgrindTool::None);
-        test_source(UNION_PAYLOAD_UNITS_SOURCE, config);
+        test_source_without_valgrind(UNION_PAYLOAD_UNITS_SOURCE);
     }
 
     /// The boxed values the payloads carry are freed exactly once and none of them leaks, checked
@@ -327,9 +333,7 @@ main = (
     /// while the union still holds it changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_payload_taken_twice_correctness() {
-        let mut config = Configuration::develop_mode();
-        config.set_valgrind(ValgrindTool::None);
-        test_source(PAYLOAD_TAKEN_TWICE_SOURCE, config);
+        test_source_without_valgrind(PAYLOAD_TAKEN_TWICE_SOURCE);
     }
 
     /// The arrays a payload taken out twice holds are freed exactly once and none of them leaks,
@@ -380,9 +384,7 @@ main = (
     /// the union changes the answer, so this catches it without Valgrind.
     #[test]
     pub fn test_union_dropped_whole_correctness() {
-        let mut config = Configuration::develop_mode();
-        config.set_valgrind(ValgrindTool::None);
-        test_source(UNION_DROPPED_WHOLE_SOURCE, config);
+        test_source_without_valgrind(UNION_DROPPED_WHOLE_SOURCE);
     }
 
     /// The array a union held twice is freed exactly once and does not leak, checked under Valgrind

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -1,6 +1,6 @@
-// Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
-// then nobody reads, an unboxed union nested inside unboxed aggregates, and a union built out of a
-// payload that holds its reference-counting units below the payload itself.
+//! Reference counting around unions that the RC IR rewrites: an operand a rewrite substitutes and
+//! then nobody reads, an unboxed union nested inside unboxed aggregates, and a union built out of a
+//! payload that holds its reference-counting units below the payload itself.
 
 #[cfg(test)]
 mod union_rc_shapes_tests {
@@ -77,9 +77,9 @@ mod union_rc_shapes_tests {
 
     /// An unboxed union is one reference-counting unit, counted on the union itself, while the
     /// references it holds live inside its variants and differ in shape from one variant to the
-    /// next. Nesting such a union inside a struct and a tuple, and then modifying an array of them
-    /// while a second binding keeps the array shared, makes the modification copy an element, and
-    /// the copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
+    /// next. This nests such a union inside a struct and a tuple, then modifies an array of them
+    /// while a second binding keeps that array shared. The modification copies an element, and the
+    /// copy reaches those units two levels of unboxed aggregate down. Run under memcheck.
     #[test]
     pub fn test_nested_unboxed_union_shared_mod() {
         let source = r#"
@@ -147,13 +147,13 @@ mod union_rc_shapes_tests {
     // own object is.
     //
     // Each union below is read through a call that stays out of line, and read once more after that
-    // call returns, so that it reaches reference counting instead of being folded into the
-    // constructor that built it. The payload it was built from stays live beside it and is read
-    // back at the end. For the shapes whose payload holds two units, freeing that payload early
-    // changes the answer. For the shape whose unit sits one level down the answer stays right
-    // either way, and the assertion in `unit_of` catches a key made for it. That payload arrives as
-    // a parameter, so the union is resolved from a value whose own unit sits a level below it; it
-    // carries a second field so that the struct around the boxed value survives to the RC IR.
+    // call returns, so that the simplifier leaves it standing as a value reference counting acts
+    // on. The payload it was built from stays live beside it and is read back at the end. For the
+    // shapes whose payload holds two units, freeing that payload early changes the answer. For the
+    // shape whose unit sits one level down the answer stays right either way, and the assertion in
+    // `unit_of` catches a key made for it. That payload arrives as a parameter, so the union is
+    // resolved from a value whose own unit sits a level below it; it carries a second field so that
+    // the struct around the boxed value survives to the RC IR.
     const UNION_PAYLOAD_UNITS_SOURCE: &str = r#"
 module Main;
 


### PR DESCRIPTION
Refs #418

#422 のレビューが、変更のまわり（触れたファイルの、hunk の外）で見つけた清掃をまとめたもの。
#422 の diff を読みやすく保つため、変更そのものとは別の PR に分けてある。base は #422 のブランチ。

対象は #422 が触れた 3 ファイル: `src/rc_ir/borrow.rs`、`src/rc_ir/ownership.rs`、
`src/tests/test_union_rc_shapes.rs`。

## 網羅しない match を網羅させる

catch-all で受けている match は、variant が増えたときコンパイラが何も言わずに新しい variant を
catch-all へ落とす。3 か所を全 variant の列挙に置き換えた。列挙した先の動作は catch-all と同じなので、
挙動は構成上変わらない。

- `borrow.rs` の `mark_tail`: `RcRhs` に対する `_ => {}`。tail 位置の結果は call か match が束縛するので、
  残りの形（tail 位置でない call を含む）は集合に触れない。
- `borrow.rs` の `trivially_returns`: `RcExpr` に対する `_ => false`。`x` の rename 以外の束縛と、
  それ以外の構文は、すべて連鎖を断つ実際の操作である。
- `ownership.rs` の `collect_consumes_go`: `RcRhs` に対する `_ => rhs_consumes(...)`。
  3 つの中でこれだけは、取り漏らすと消費解析が誤る。右辺が部分式を持つのは match だけなので、
  他の形はすべて自分の中で消費する。

## ファイル内で重複していた手順を関数にする

`test_union_rc_shapes.rs` に「Valgrind を切って走らせる」設定（`Configuration::develop_mode()` +
`set_valgrind(ValgrindTool::None)` + `test_source`）が 3 か所あったので、`test_source_without_valgrind`
に括り出した。

Valgrind スキップの前置き（`platform_valgrind_supported()` を見て `eprintln!` して `return`）も同じ
ファイルに 3 か所あるが、こちらは括り出していない。同じ定型がリポジトリ全体で約 15 ファイル・
約 30 か所にあり、置き場は `src/tests/test_util.rs` になる。このファイルだけ直すと他と不揃いになる。
`function_name!()` が展開先の関数名を返すので、共有版はテスト名を引数で受け取る形になる。

## 借用版の略語を綴る

`borrow.rs` は借用版を "borrow version" と呼び（`borrow_versions`、`is_borrow_version`）、
その一方で局所変数では `bref` / `bparams` と縮めていて、`bref` にはそれを説明するコメントが付いていた。
綴りを本文と揃えた。いずれも局所束縛・引数の改名で、スコープは 1 つの関数本体に収まる。

- `bref` -> `borrow_version`（`borrow_ify`、`route`、`routing_saves_retain`）。説明のコメントは不要になった。
- `bparams` -> `borrow_params`（`routing_saves_retain`）。
- `cparams` -> `params`、`Some(ps)` -> `Some(params)`（`call_rc`）。`c` が callee / clone / call の
  どれか読めない。フィールド `self.callee_params` と同じ名前にすると 1 関数の中で 2 義になるので `params`。
- `route` の `let mut c = callee.clone()` -> `routed`。返すのは借用版へ張り替えた callee である。
- `borrow_funcref` の `let mut n = name.name.clone()` -> `borrow_name`。`n` は個数に読める。
- `routing_saves_retain` の `last_use` -> `is_last_use`。bool なのに名詞で、使用箇所を指すように読める。
- `prepend_rc` の引数 `items` -> `units`。doc も対象も unit である。

## コメントの規約を変更の周りへ

`comment-style` の規約のうち、次に当たるものを直した。編集はすべて散文で、コードには触れていない。

- **呼び出し元の列挙を落とす** — `borrow.rs` のモジュール doc、`split_rc_units`、`tail_result_vars`、
  `ownership.rs` の `VarTable`、`Origin::identity`、`destructure_consumes`。
  「1 つのモデルがなぜ 1 つなのか」を述べている箇所（`ownership.rs` のモジュール doc、`unit_key`、
  `borrow.rs` のモジュール doc の `split_rc_units` を紹介する文）は、落とすと理由が消えるので残した。
- **肯定形で書く** — `routing_saves_retain` の末尾の「it is not a benefit」、
  `UNION_PAYLOAD_UNITS_SOURCE` の「instead of being folded into the constructor that built it」。
- **平文の英語** — `borrow.rs` のモジュール冒頭（"reads to" で garden-path になっていた）、`un_bump`、
  `NodeId`、`Release` の分岐、`routing_saves_retain` の入れ子括弧。`ownership.rs` の `origin_inner`、
  `origin_from_leaves_under`、`UnitStep`、`VarTable::empty`。`test_nested_unboxed_union_shared_mod` の doc。
- **doc コメントの補完** — `Origin::Join` の `identity` と `candidates`。同ファイルの
  `UnitStep::Capture` / `UnitStep::Fields` はフィールドごとに doc を持っている。
- **ファイル冒頭** — `test_union_rc_shapes.rs` の冒頭 3 行が `//` で、`#[cfg(test)]` を挟むため何も
  文書化していなかった。`//!` にした。

## 著者に委ねる指摘

レビューが挙げた中で、この PR で直していないもの。

1. **`ownership.rs` の `units_under` / `subtree_type`** — `subtree_type` が返す `None` が 3 つの状況を
   畳んでいる。(a) path がちょうど unit を指す（closure の capture path）、(b) path が unit より下へ
   降りる（union の variant 内の leaf など。`owns_object` が実際に渡す）、(c) path の途中で
   `UnitStep::NoUnit` に達する。(a) と (b) は正当な入力だが、(c) のとき `units_under` が返す
   `vec![path.clone()]` は「参照を 1 つも持たない path」であり、`split_rc` がそれを RC ノードにすると、
   #422 が `acted_references` に置いた assert が原因から遠い場所で落ちる。
   `subtree_type` の答えを `UnitStep` ごとに分け、`NoUnit` に途中で達したときだけ型と path を添えて
   abort するのが案。挙動が変わるので、この PR の範囲外とした。
2. **Valgrind スキップの前置き**（上記）。置き場が `src/tests/test_util.rs` で、約 15 ファイルに渡る。
3. **`rewrite_inner` / `split_body_inner` / `drop_nodes_inner` の重複** — 3 つとも `Let` / `Let(Match)` /
   `Destructure` / `Eval` / `Ret` を同じ形で組み直しており、違うのは各々が特別扱いする 1 - 2 個の
   ノードだけ。共通化には高階の rebuild walker が要り、シグネチャの変更を伴う。
4. **`CancelAnalysis::merge` の計算量** — アーム数の 2 乗 x retain 数。アーム数は union の variant 数
   なのでユーザが決められる。アームごとの exit を 1 回走査して `Map<NodeId, (count, References)>` に
   畳めば線形になる。
5. **item 名** — `RewriteCtx::tail` -> `tail_results`、`Origin::acted_on` -> `acted_objects`
   （`acted_unit_keys` / `acted_references` と揃う）、`borrow_funcref` -> `borrow_version_ref`。
   テストの Fix 宣言 `mk` -> `make_payload`、`size_of` -> `value_of`（`num(i) => i` の variant で
   「size」が成り立たない）。
6. **`CHANGELOG.md` の `## [Unreleased]`** — 番号を持たないエントリが 4 件（`_` パターン / 型
   ワイルドカードの 2 件、`_` の hover、`String::from_bytes` の修正）。番号があるなら付ける。
   また `fix run` and `fix test` no longer crash on startup in debug builds of `fix` のエントリは
   「released builds were unaffected」と自ら述べており、リリース版の利用者は踏めない。どこまで遡るかは
   著者判断。

## 検証

`cargo test --release` で 152 + 1511 件、失敗 0。
