### PR TITLE
1 つのパラメータの参照カウント単位ごとに所有権が決まることを留めるテスト

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod test_assert;
 mod test_associated_type;
 mod test_basic;
 mod test_bool_union;
+mod test_borrow_unit_ownership;
 mod test_borrowed_union_field;
 mod test_build_exit_status;
 mod test_check;

--- a/src/tests/test_borrow_unit_ownership.rs
+++ b/src/tests/test_borrow_unit_ownership.rs
@@ -1,0 +1,80 @@
+//! Ownership at the granularity borrow-ification decides it: one parameter whose reference-counting
+//! units are owned and borrowed separately.
+
+#[cfg(test)]
+mod borrow_unit_ownership_tests {
+    use crate::{
+        configuration::Configuration,
+        misc::{function_name, platform_valgrind_supported},
+        tests::test_util::test_source,
+    };
+
+    /// Each reference-counting unit of one parameter is disposed of exactly once when the units are
+    /// owned and borrowed separately.
+    ///
+    /// Borrow-ification answers ownership one reference-counting unit at a time, so a parameter
+    /// holding several units can be owned at one of them and borrowed at the others. `take_middle`
+    /// is that shape: of the three units its parameter holds, it reads one, hands one to its caller,
+    /// and drops the third. An answer given for the whole parameter instead either releases a unit
+    /// the function borrows, freeing it while the caller still holds it, or keeps one the function
+    /// owns. A second name for the value stays live across both calls, so the caller does still hold
+    /// it.
+    ///
+    /// A released borrowed unit leaves the computed values intact here, so this runs under Valgrind
+    /// MemCheck, which is what reports it.
+    #[test]
+    pub fn test_units_of_one_parameter_get_separate_ownership() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        let source = r#"
+            module Main;
+
+            type Cell = box struct { v : Array I64, w : I64 };
+            type Trio = struct { x : Array I64, y : Array I64, z : Cell };
+
+            // Reads `x`, hands `y` out, and drops `z`: the three units of one parameter get three
+            // different fates.
+            take_middle : Trio -> Array I64;
+            take_middle = |t| (
+                let Trio { x : ax, y : ay, z : _az } = t;
+                let head = Iterator::range(0, ax.@size).fold(0, |i, s| s + ax.@(i) * (i + 1));
+                ay.set(0, head)
+            );
+
+            // Reads every unit and hands nothing out.
+            survey : Trio -> I64;
+            survey = |t| (
+                let a = Iterator::range(0, t.@x.@size).fold(0, |i, s| s + t.@x.@(i));
+                let b = Iterator::range(0, t.@y.@size).fold(0, |i, s| s + t.@y.@(i) * 2);
+                a + b + t.@z.@w + t.@z.@v.@(0)
+            );
+
+            make_trio : I64 -> Trio;
+            make_trio = |s| Trio {
+                x : Array::from_map(4, |i| i + s),
+                y : Array::from_map(3, |i| i * 2 + s),
+                z : Cell { v : Array::from_map(2, |i| i + s), w : s }
+            };
+
+            main : IO ();
+            main = (
+                let t = make_trio(5);
+                let u = t;
+                let s1 = survey(u);
+                let m = take_middle(u);
+                let s2 = survey(t);
+                assert_eq(|_|"reading is repeatable", s1, s2);;
+                assert_eq(|_|"the middle unit was taken", m.@(0), 70);;
+                assert_eq(|_|"the source keeps its middle unit", t.@y.@(0), 5);;
+                assert_eq(|_|"the whole answer", s1 + m.@(0) + t.@y.@(0), 153);;
+                pure()
+            );
+        "#;
+        test_source(source, Configuration::develop_mode());
+    }
+}


### PR DESCRIPTION
バグハントが確認した不変条件を留めるテストを 1 本足す。動作の変更は無い。

## 何を留めるのか

RC IR の借用化 (`src/rc_ir/borrow.rs` の `borrow_ify`) は、関数のパラメータのどれを呼び出し側から
借りるだけにできるかを決める。借りたパラメータは呼び出し先が解放せず、呼び出し側が持ち続けるので、
一意性解析から見て値が `Unique` のまま保たれる。

この判断は**パラメータ単位ではなく、参照カウントの単位 (reference-counting unit) ごと**に下される。
1 つの値が複数の単位を持つことがあるからである。たとえば

```
type Trio = struct { x : Array I64, y : Array I64, z : Cell };
```

は unbox な構造体なので、`x`・`y`・`z` の 3 つがそれぞれ独立に参照カウントされる単位になる。
`Trio` を 1 つ受け取る関数が、`x` は読むだけ、`y` は呼び出し側へ返す、`z` は捨てる、という使い方を
すれば、1 つのパラメータの中で 3 つの単位の所有権が別々に決まる。

この粒度を失うとどうなるか。所有権をパラメータ全体でまとめて答えると、両方向に壊れる。
借りている単位まで所有していることにすれば、呼び出し先が呼び出し側の持ち物を解放する。
所有している単位まで借りていることにすれば、関数の本体はその参照を渡してしまうのに誰も解放を
引き受けない。前者は解放済みメモリへのアクセスになる。

## なぜ足すのか

この軸が壊れたときにスイートの誰が落ちるかを、実装を壊してフルスイートを回して測った。
所有権をパラメータ全体で答えるように変えると、赤くなるのは
`test_external_projects` の `cp_library` / `regexp` / `subprocess` の 3 本だけである。
いずれも外部リポジトリを取得してビルドする統合テストで、ピン留めしたリビジョンに依存する。
軽い持ち主がリポジトリ内に 1 つも無い。

## テストの中身

`src/tests/test_borrow_unit_ownership.rs` を新設し、`src/tests/mod.rs` に登録する。
テストは 1 本、`test_units_of_one_parameter_get_separate_ownership`。

Fix プログラムは 3 つの関数を定義し、すべて `main` から呼ぶ。

- `make_trio : I64 -> Trio` — 3 つの単位を持つ値を作る。
- `take_middle : Trio -> Array I64` — パラメータを分解し、`x` を読み、`y` を呼び出し側へ返し、
  `z` に名前を付けずに捨てる。**1 つのパラメータの 3 単位に 3 通りの運命を与える**のがこの関数である。
- `survey : Trio -> I64` — 全単位を読むだけで、何も外へ渡さない。

`main` は値を作って**もう 1 つの名前を束縛し**、`survey`・`take_middle`・`survey` の順に呼ぶ。
2 つ目の名前があるので、`take_middle` が借りている間も呼び出し側は本当にその値を持っている。
最後に 4 つの表明を置く: 読みが繰り返せること、取り出した単位の中身、元の値がその単位を保っていること、
そして合計。

## Valgrind の下で走る理由

所有権をパラメータ全体で答える変異を掛けたとき、**この 4 つの表明はすべて通る**。
解放済みの領域が読み出された時点でも中身が残っているためで、壊れていることは値には出ない。
出るのは MemCheck の `Invalid read` / `Invalid write` であり、
`Configuration::develop_mode()` がそれを有効にする。したがって Valgrind を切った「正しさ版」の
双子は足していない。足しても緑のままで、何も検出しないからである。

`platform_valgrind_supported()` を見て skip する前置きは、同じ形が
`test_union_rc_shapes.rs` などにあるものをそのまま踏襲した。

## 検証

- 変異を掛けない状態で緑。
- 所有権をパラメータ全体で答える変異の下で赤 (`The program exited with non-zero code: 1` = MemCheck)。
- 変異を戻してフルスイート: `cargo test --release` が 152 + **1515 passed / 0 failed**。

`CHANGELOG.md` への追記は無い。利用者から見える振る舞いは変わらない。

## 付録: この形はインライン化を生き延びる必要がある

借用化を狙うテストを書くときの落とし穴を記録しておく。小さい関数は `-O max` でインライン化されて
呼び出しごと消えるため、`#borrow` 版がそもそも生成されない。実際、同じ波で試した
「共有した配列を小さな reader に通す」形は 4 本とも `Main` モジュールの RC IR ダンプに `#borrow` を
1 つも残さず、狙った経路に一度も届いていなかった。

このテストの `take_middle` / `survey` は `Iterator::range(...).fold(...)` を含む本体を持ち、
RC IR のダンプでパラメータの所有権注釈が `(borrow, own, own)` / `(own, borrow, own)` の形で
出ることを確認してある。
