### PR TITLE
所有権モデルの仕様書: 借用化直後の不変条件を実装に合わせる

### DIFF
--- a/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
+++ b/dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md
@@ -81,8 +81,14 @@ RC IR 上で「どの構文がどの参照を消費するか」の仕様。実�
 |---|---|
 | `insert_rc` 直後 | 全 `Retain`/`Release` は path `[]`・`RcState::Unknown`。全パラメータ/capture が `Own`。各 binding の各参照はどのパスでもちょうど 1 回消費される |
 | `split_rc_units` 直後 | 同上、ただしキーが `(binding, unit)`。全 RC ノードの path が `rc_units(v.ty)` の要素 |
-| `borrow_ify` 直後 | `borrowed_units` に載る unit と、それに根を持つ値は**消費も RC 操作もされない**（`owns_unit` が判定）。それ以外は各パスちょうど 1 回消費 |
-| `cancel` / `specialize` 直後 | **binding 単位の線形性は失われる**。`cancel` は `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）のキーで別 binding をまたいで retain/release を対消滅させる。消えるのは retain 1 個と、その retain が上げた参照をちょうど覆う release 群（`acted_references`）である。成立するのは **(root オブジェクト, unit) 単位の参照数保存**: 所有パラメータ/capture unit を 1、borrowed を 0 で初期化し、producer で +1・消費/`Release` で -1 したカウンタが、どのパスでも負にならず関数出口で 0 |
+| `borrow_ify` 直後 | `borrowed_units` に載る unit の参照、およびそれに根を持つ値の参照は、**呼び出し元から借りたままである**（`owns_unit` が判定）。処分するのは呼び出し元であり、関数の側にはその `Release` も消費も無い。借りた値を所有側の引数位置へ渡すときだけ、その呼び出しの直前に `Retain` が置かれて参照がもう 1 つ作られ、消費されるのはその新しい参照である（`call_rc`）。それ以外は各パスちょうど 1 回消費 |
+| `cancel` / `specialize` 直後 | **binding 単位の線形性は失われる**。`cancel` は `unit_key`（`origin` の identity を `truncate_to_unit` で切り詰めたもの）のキーで別 binding をまたいで retain/release を対消滅させる。消えるのは retain 1 個と、その retain が上げた参照をちょうど覆う release 群（`acted_references`）である。成立するのは **(root オブジェクト, unit) 単位の参照数保存**: 所有パラメータ/capture unit を 1、borrowed を 0 で初期化し、producer と `Retain` で +1、消費と `Release` で -1 したカウンタが、どのパスでも負にならず関数出口で 0 |
+
+借用版が借りた値を所有側の引数位置へ渡す状況は、次のときに生じる。所有権の推論は、呼び出し先の**元の関数**
+について推論中の所有権を読んで「この位置は消費しない」と判定し、引数を借用可能なままにする。一方、版の振り分けは
+呼び出しごとに行われ、末尾位置の呼び出しが所有引数を持つ場合は借用版へ回されない（後置の `Release` が末尾呼び出しを
+末尾でなくするため）。回されなかった呼び出し先は全パラメータを所有する元の版なので、借りた値がそこでは消費される。
+`call_rc` の `Retain` はその差を埋める。
 
 `specialize` は RC ノードを素通しコピーし、`assuming_unique` は `LLVMGen` を差し替えるだけなので、消費モデルは
 特殊化の前後で不変（`result_prov` を force-unique 有無で変える op は存在しない）。


### PR DESCRIPTION
RC IR の所有権・消費モデルの仕様書 `dev-docs/2026-06-28-unique-check-elim/rc-ownership-model.md` が、
借用化の直後に成り立つ不変条件を実装と違う形で述べていた。文書だけの変更で、コードには触れていない。

## 何が書いてあったか

この文書の §4「ステージごとの不変条件」は、RC IR を書き換える各パスの直後に何が成り立つかを 1 行ずつ
述べる表である。RC 挿入・借用化・相殺・特殊化がこのモデルを共有しており、参照収支検査の仕様も同じ表の上に
乗っている。

借用化 (`src/rc_ir/borrow.rs` の `borrow_ify`) の行はこう書いてあった。

> `borrowed_units` に載る unit と、それに根を持つ値は**消費も RC 操作もされない**（`owns_unit` が判定）。
> それ以外は各パスちょうど 1 回消費

## なぜ誤りか

借用化は、関数が読むだけのパラメータを「借用」に変える。借用したパラメータの参照は呼び出し元のものなので、
関数はそれを解放しない。ここまでは表のとおりである。

しかし借用化には、呼び出し側で引き受ける参照カウントを入れる部分がある。`RewriteCtx::call_rc` は、
呼び出し先が所有する引数位置へ**借用した値**を渡すとき、その呼び出しの直前に `Retain` を置く。
`borrow.rs` の冒頭のモジュールコメント自身が「a retain before it for a borrowed value passed to an
owning position」と書いており、そちらが正しい。したがって「借用 unit は RC 操作されない」は成り立たない。

実物でも確認した (付録)。

## どういうときにその形になるか

一見すると矛盾して見える。借用した値を所有側の位置へ渡すなら、それは消費なので、所有権の推論は
そのパラメータを最初から「所有」にするはずではないか。

そうならないのは、**推論と版の振り分けが別の情報を見ている**からである。

- 所有権の推論 (`infer_ownership`) は、呼び出し先の**元の関数**について推論中の所有権を読む。
  読むだけの関数の引数位置は「消費しない」と判定されるので、そこへ渡す値は借用可能なままになる。
- 版の振り分け (`RewriteCtx::route`) は呼び出しごとに行われ、**末尾位置の呼び出しが所有引数を持つ場合は
  借用版へ回さない**。借用版は呼び出しの後に `Release` を要するので、回すと末尾呼び出しが末尾でなくなる
  （`routing_is_safe` がこれを見る）。

回されなかった呼び出しの相手は全パラメータを所有する元の版なので、そこでは借りた値が消費される。
`call_rc` の `Retain` はこの差を埋めており、呼び出し元から借りた参照はそのまま返され、消費されるのは
`Retain` が作った新しい参照のほうである。

## 直したもの

1. **`borrow_ify` の行**を、パスが実際に保つ不変条件に書き換えた。呼び出し元の参照は呼び出し元のものの
   まま返ること、借用した値の消費は同じ呼び出し側が `Retain` で払うこと。
2. **表の下に段落を 1 つ追加**して、上記の「推論と振り分けが別の情報を見る」機構を述べた。これが無いと、
   RC IR のダンプで借用パラメータへの `retain` を見た読み手がそれを欠陥と読む。
3. **`cancel` / `specialize` の行の参照保存カウンタに `Retain` を足した**。このカウンタは借用 unit を 0 で
   初期化し、「どのパスでも負にならず関数出口で 0」を要求する。上記の消費で -1 されるので、`Retain` を
   +1 の源に数えなければカウンタ自身が負になる。文書内の整合を取るための同じ修正である。

## 検証

コードに触れていないので、テストの結果は変わらない (`cargo test --release` = 152 + 1515 passed / 0 failed)。
`CHANGELOG.md` への追記は無い。利用者から見える振る舞いは変わらない。

## 付録: 実物

借用版の中で借用パラメータが `Retain` される形を、この機構から組み立てて `--emit-rc-ir` で確認した。

```
module Main;

// `read` は読むだけ (Borrow)、`own` は消費される (Own)。再帰なのでインライン化を生き延びる。
g : I64 -> Array I64 -> Array I64 -> Array I64;
g = |n, read, own| (
    if n <= 0 { own };
    let s = Iterator::range(0, read.@size).fold(0, |i, acc| acc + read.@(i) * (i + 3));
    g(n - 1, read, own.set(0, s))
);

// `p` は借用位置にしか届かないので借用可能。`g` の呼び出しは末尾位置で、所有引数を渡す。
mid : I64 -> Array I64 -> Array I64;
mid = |k, p| (
    if k <= 0 { g(2, p, Array::fill(3, 0)) };
    mid(k - 1, p)
);

main : IO ();
main = (
    let a = [5, 6, 7];
    let b = mid(2, a);
    let c = mid(1, a);
    println $ (b.@(0) + c.@(0) + a.@(0)).to_string
);
```

`fix run -f main.fix -O max --emit-rc-ir Main` の出力より (抜粋):

```
fn Main::mid#…#funptr2#borrow(#v0#66#b12 : Std::I64 [unboxed] {u},
                              #v1#67#b13 : Std::Array Std::I64 [arg1] {borrow}) -> Std::Array Std::I64:
    …
            retain #v1#67#b13
            let app#78#b25 : Std::Array Std::I64 [fresh]
                = Main::g#…#funptr3#u1#l1(v#71#b18, #v1#67#b13, v#77#b24)
            ret app#78#b25
```

パラメータの注釈は `{borrow}` で、その値に対する `retain` が所有側の呼び出しの直前に立っている。

この形を作るには関数がインライン化を生き延びる必要がある。小さい reader は `-O max` で溶けて
`#borrow` 版がそもそも生成されないので、`g` と `mid` はどちらも再帰にしてある。
