### PR TITLE
mark_threaded の保証がいつまで続くかを文書に書く

### DIFF
--- a/Document.md
+++ b/Document.md
@@ -2425,7 +2425,7 @@ There are also some things to note in the implementation on the Fix side.
     - To achieve this, the Fix function that is called from the foreign language and receives a pointer should be an `IO` action (like `get_fix_array_element` above). By executing the `IO` action returned by `boxed_from_retained_ptr` in it, it is guaranteed that the received pointer is converted to a Fix value only once.
     - If you don't follow the above, the optimization by the Fix compiler may cause the number of times the pointer is received from the foreign language and the number of calls to `boxed_from_retained_ptr` to not match.
 - Fix's reference counting is not thread-safe by default. Therefore, if you distribute a pointer received from Fix to multiple threads on the foreign language side, data races may occur regarding the increment and decrement of the reference counter.
-    - To avoid this, call `Std::mark_threaded : a -> a` on the boxed type value before calling `boxed_to_retained_ptr` to set the reference counting to thread-safe mode.
+    - To avoid this, call `Std::mark_threaded : a -> a` on the boxed type value immediately before calling `boxed_to_retained_ptr`, with nothing in between, to set the reference counting to thread-safe mode. See [Multithreading](#multithreading) for why the two calls belong together.
 
 ### Accessing fields of Fix's struct value from C
 
@@ -2494,9 +2494,10 @@ The project being built decides the setting, so a library that needs multi-threa
 
 A Fix value reaches another thread as a pointer to a boxed value, so wrap a value of an unboxed type in `Std::Box`. Handing a value over then goes as follows.
 
-- `Std::mark_threaded` puts the reference counters of all values reachable from a value into multi-threaded mode, in which they are updated atomically. Call it on the value, and carry on with the value it returns.
-- Call `Std::FFI::boxed_to_retained_ptr` on the returned value to get a pointer to it, and pass the pointer to the threading library with `FFI_CALL_IO`.
+- `Std::mark_threaded` puts the reference counters of all values reachable from a value into multi-threaded mode, in which they are updated atomically.
+- Call `Std::FFI::boxed_to_retained_ptr` on the value `Std::mark_threaded` returned to get a pointer to it, and pass the pointer to the threading library with `FFI_CALL_IO`. **Hand that value straight to `Std::FFI::boxed_to_retained_ptr`, and do nothing else with it in between**: multi-threaded mode is a state stored in the object, and an operation on the value — reading it included — can return the object to single-threaded mode. `Std::mark_threaded`'s own documentation states the rule and why.
 - From the entry point of the thread, call a Fix function exported by `FFI_EXPORT` and give it the pointer. An exported function receives a boxed parameter as such a pointer, and `Std::FFI::boxed_from_retained_ptr` turns a `Ptr` back into a boxed value.
+- Sending a value on to a further thread goes through `Std::mark_threaded` again, whatever the value's history: a value that arrived from another thread is in multi-threaded mode when it arrives, and an operation this thread performs on it can return it to single-threaded mode.
 
 The pointer carries the responsibility for the reference count described in [Managing ownership of Fix's boxed value in a foreign language](#managing-ownership-of-fixs-boxed-value-in-a-foreign-language).
 

--- a/src/docs/std_mark_threaded.md
+++ b/src/docs/std_mark_threaded.md
@@ -2,7 +2,19 @@ Traverses all values reachable from the given value, and changes the reference c
 
 Building a program that calls this function requires multi-threading to be enabled by the `--threaded` compiler option or by the `threaded` field of the project file of the program being built. A library that calls this function is used by turning multi-threading on there.
 
-Call this before the value becomes reachable from another thread, and let the call finish before the pointer is handed over. The mode this sets is what every thread's reference counting reads, so a value already reachable from a second thread when the call runs is counted in one mode by one thread and in another by the other, and the counts each thread makes are lost to the other.
+# How a value reaches another thread
+
+A value reaches another thread as a pointer: `Std::FFI::boxed_to_retained_ptr` turns a boxed value into a `Ptr`, and that pointer is what a threading library such as pthread is handed. A value of an unboxed type is wrapped in `Std::Box` first, so that there is a boxed value to take the pointer of. The whole sequence is therefore: wrap the value if its type is unboxed, call this function on it, call `Std::FFI::boxed_to_retained_ptr` on what this function returns, and hand the pointer over.
+
+# Hand the result over immediately
+
+**Pass the value this function returns straight to `Std::FFI::boxed_to_retained_ptr`, and do nothing else with it in between.** The multi-threaded mode is a state stored in the object, and an operation on the value can put the object back into single-threaded mode: an operation that finds the object uniquely referenced updates it in place, which is sound only for an object no other thread reaches, and it records that by returning the object to single-threaded mode. Reading the value counts as such an operation, since asking whether a value is uniquely referenced is itself an operation on the object.
+
+The mode this sets is what every thread's reference counting reads, so a value already reachable from a second thread when the call runs is counted in one mode by one thread and in another by the other, and the counts each thread makes are lost to the other.
+
+# Sending on a value received from another thread
+
+A value that arrived from another thread is in multi-threaded mode when it arrives, and any operation this thread performs on it can return it to single-threaded mode by the rule above. **Call this function again on a value being sent on, however it was obtained.** The rule is the same one as above: what is handed to `Std::FFI::boxed_to_retained_ptr` is what this function has just returned.
 
 # Parameters
 

--- a/std_doc/Std.md
+++ b/std_doc/Std.md
@@ -118,7 +118,19 @@ Traverses all values reachable from the given value, and changes the reference c
 
 Building a program that calls this function requires multi-threading to be enabled by the `--threaded` compiler option or by the `threaded` field of the project file of the program being built. A library that calls this function is used by turning multi-threading on there.
 
-Call this before the value becomes reachable from another thread, and let the call finish before the pointer is handed over. The mode this sets is what every thread's reference counting reads, so a value already reachable from a second thread when the call runs is counted in one mode by one thread and in another by the other, and the counts each thread makes are lost to the other.
+##### How a value reaches another thread
+
+A value reaches another thread as a pointer: `Std::FFI::boxed_to_retained_ptr` turns a boxed value into a `Ptr`, and that pointer is what a threading library such as pthread is handed. A value of an unboxed type is wrapped in `Std::Box` first, so that there is a boxed value to take the pointer of. The whole sequence is therefore: wrap the value if its type is unboxed, call this function on it, call `Std::FFI::boxed_to_retained_ptr` on what this function returns, and hand the pointer over.
+
+##### Hand the result over immediately
+
+**Pass the value this function returns straight to `Std::FFI::boxed_to_retained_ptr`, and do nothing else with it in between.** The multi-threaded mode is a state stored in the object, and an operation on the value can put the object back into single-threaded mode: an operation that finds the object uniquely referenced updates it in place, which is sound only for an object no other thread reaches, and it records that by returning the object to single-threaded mode. Reading the value counts as such an operation, since asking whether a value is uniquely referenced is itself an operation on the object.
+
+The mode this sets is what every thread's reference counting reads, so a value already reachable from a second thread when the call runs is counted in one mode by one thread and in another by the other, and the counts each thread makes are lost to the other.
+
+##### Sending on a value received from another thread
+
+A value that arrived from another thread is in multi-threaded mode when it arrives, and any operation this thread performs on it can return it to single-threaded mode by the rule above. **Call this function again on a value being sent on, however it was obtained.** The rule is the same one as above: what is handed to `Std::FFI::boxed_to_retained_ptr` is what this function has just returned.
 
 ##### Parameters
 


### PR DESCRIPTION
Refs #430

`Std::mark_threaded` の文書が、その保証がいつまで続くかを述べていなかった。文書だけの変更で、
コンパイラには触れていない。

## 何が起きるか

`Std::mark_threaded` は、値から到達できるすべてのオブジェクトの参照カウントをマルチスレッドモード
(原子的に更新される) にする。他スレッドと値を共有するプログラムは、これを呼んでから
`Std::FFI::boxed_to_retained_ptr` でポインタを取り、そのポインタをスレッドライブラリへ渡す。

このモードは**オブジェクトに格納された状態**であって、値の性質ではない。一意性検査がそのオブジェクトを
1 参照だと見つけると、その場で書き換えてよいと判断して更新し、同時にシングルスレッドモードへ戻す。
したがって `mark_threaded` の保証が続くのは、次にその値へ操作が加わるまでである。

「操作」には読み取りも入る。値が一意かどうかを問うこと自体がオブジェクトへの操作だからである。

いままでの文書には、このどちらも書いていなかった。`Document.md` の Multithreading の手順は

> Call it on the value, and carry on with the value it returns.

と書いており、一度呼べば以後ずっと有効だと読める。そう書いたプログラムは、2 回目の受け渡しで
シングルスレッドのオブジェクトを別スレッドへ渡し、自分の参照カウントを壊す。診断は出ない。

## 実測

8 スレッドが 1 つの `Box (Array I64)` を叩くプログラムで、操作をどこに置くかだけを変えた
(`-O max`、5 回ずつ)。

| 操作の位置 | そのときの参照カウント | 失敗 |
| --- | --- | --- |
| `mark_threaded` の後、`boxed_to_retained_ptr` の前 | 1 | **5/5** |
| `boxed_to_retained_ptr` の後、送信の前 | 9 | 0/5 |

降格は一意性検査の一意側の枝でしか起きないので、他スレッド行きのポインタが 1 つでも生きていれば
カウントは 2 以上あり、以後の操作は共有側に落ちてコピーになる。**守るべき窓は
`mark_threaded` とポインタ取得の間だけ**である。書き込み (`mod_value` で `set`) でも読み取り
(`unsafe_is_unique`) でも同じ結果になる。

失敗は `free(): double free detected in tcache 2` と SIGSEGV で、ThreadSanitizer は参照カウントの
ワードを名指しする。`-O none` でも同じ形で落ちるので、どの最適化にも依存していない。

再現プログラムの全文は #430 にある。

## 直したもの

### `src/docs/std_mark_threaded.md`

節を 3 つ足した。

- **How a value reaches another thread** — 値が別スレッドへ届く道は 1 つで、`boxed_to_retained_ptr` が
  boxed な値を `Ptr` にし、そのポインタを pthread などのスレッドライブラリへ渡す。unbox な型の値は
  先に `Std::Box` で包む (ポインタを取る対象の boxed な値を作るため)。順序は「包む -> この関数 ->
  `boxed_to_retained_ptr` -> 渡す」。
- **Hand the result over immediately** — この関数が返した値は**そのまま**
  `boxed_to_retained_ptr` へ渡し、間に何もしない。理由 (モードはオブジェクトの状態であり、一意だと
  判明した操作がそれを戻す) と、読み取りも操作に入ることを述べた。既存の「呼ぶ時点で既に他スレッドから
  到達可能だと両者のカウントが食い違う」という段落はこの節に残した。
- **Sending on a value received from another thread** — 他スレッドから受け取った値も、こちらでの操作で
  モードが外れうるので、送り直すときは再度この関数を通す。

### `Document.md`

`Std::mark_threaded` を説明している 2 か所を、上と同じ内容に揃えた。

- Multithreading の手順: 「返ってきた値で続ければよい」を落とし、ポインタ化の項に「返ってきた値を
  そのまま渡し、間に何もしない」ことと理由を入れた。さらに「さらに別のスレッドへ送るときは、値の
  出どころによらず再度 `Std::mark_threaded` を通す」という項を足した。
- 外部言語へポインタを渡す節の注意書き: 「`boxed_to_retained_ptr` を呼ぶ前に」を「直前に、間に何も
  挟まずに」に改め、Multithreading 節への参照を付けた。

### `std_doc/Std.md`

`src/docs/std_mark_threaded.md` から生成される文書。スイートの `test_generate_documents` が
再生成したものをそのまま入れている。

## 検証

コードに触れていないのでテストの結果は変わらない (`cargo test --release` = 152 + 1516 passed / 0 failed)。

`CHANGELOG.md` への追記は無い。コンパイラの振る舞いは以前から今回書いたとおりで、誤っていたのは
文書の側である。
