### PR TITLE
catch-all の腕が scrutinee をちょうど 1 回処分することを留めるテスト

### DIFF
--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -400,4 +400,70 @@ main = (
         }
         test_source(UNION_DROPPED_WHOLE_SOURCE, Configuration::develop_mode());
     }
+
+    // A match whose catch-all arm has to dispose of the scrutinee. A sibling arm names the
+    // scrutinee a second time, so the scrutinee is live at every arm's head, and the arm that does
+    // not name it releases it there. In the catch-all arm that release meets a second one: the
+    // payload the arm binds is the scrutinee itself, bound without a retain, and an arm body that
+    // never reads the payload releases it too. The retain the match is entered with is what pays
+    // for the second. One release short leaves the union alive; one too many frees it while the
+    // caller still holds it.
+    const CATCH_ALL_REREAD_SOURCE: &str = r#"
+module Main;
+
+type Choice = box union { arr : Array I64, num : I64 };
+type Pair = unbox union { both : (Array I64, Array I64), none : I64 };
+
+// The tagged arm reads the scrutinee a second time; the catch-all arm reads neither the scrutinee
+// nor the payload it binds.
+reread : Choice -> I64;
+reread = |c| (
+    match c {
+        arr(a) => a.@(0) + (match c { arr(b) => b.@size, num(j) => j }),
+        other => 100
+    }
+);
+
+reread_unbox : Pair -> I64;
+reread_unbox = |p| (
+    match p {
+        none(i) => i + (match p { both(t) => t.@0.@(0), none(j) => j }),
+        other => 200
+    }
+);
+
+// The catch-all arm reads the payload it binds, so the scrutinee flows into that arm as well.
+reread_and_use : Choice -> I64;
+reread_and_use = |c| (
+    match c {
+        num(i) => i + (match c { arr(b) => b.@size, num(j) => j }),
+        other => (match other { arr(b) => b.@(0), num(j) => j * 3 })
+    }
+);
+
+main : IO ();
+main = (
+    assert_eq(|_|"boxed union, tagged arm", reread(Choice::arr([11, 12, 13])), 14);;
+    assert_eq(|_|"boxed union, catch-all arm", reread(Choice::num(7)), 100);;
+    assert_eq(|_|"unboxed union, tagged arm", reread_unbox(Pair::none(5)), 10);;
+    assert_eq(|_|"unboxed union, catch-all arm", reread_unbox(Pair::both(([1], [2]))), 200);;
+    assert_eq(|_|"catch-all arm reads its payload", reread_and_use(Choice::arr([9, 8])), 9);;
+    assert_eq(|_|"tagged arm rereads the scrutinee", reread_and_use(Choice::num(4)), 8);;
+    pure()
+);
+"#;
+
+    /// The unions are freed exactly once and none of them leaks, checked under Valgrind MemCheck,
+    /// which is what a release too few shows up as.
+    #[test]
+    pub fn test_catch_all_arm_over_a_reread_scrutinee_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        test_source(CATCH_ALL_REREAD_SOURCE, Configuration::develop_mode());
+    }
 }


### PR DESCRIPTION
バグハントが特定した、スイートが一度も踏まない経路を留めるテストを 1 本足す。動作の変更は無い。

## 何を留めるのか

RC 挿入 (`src/rc_ir/rc_insert.rs` の `insert_into_match`) は、`match` の各腕の先頭に release を置く。
置く理由は 2 つあり、1 つの腕でその両方が当たることがある。

- **dead-branch の規則**: ある変数が「別の腕では使われるが、この腕では使われず、match の後でも死んでいる」
  とき、この腕の先頭で release する。腕ごとに参照の行き先が違うので、使わない腕が自分で始末する。
- **未読の payload**: 腕が束縛した payload を本体が一度も読まないとき、その payload を先頭で release する。

**catch-all の腕では、この 2 つが同じオブジェクトを指す。** catch-all は scrutinee そのものを payload として、
retain 無しで束縛するからである。したがって腕の先頭に release が 2 つ並び、それを支えているのは
match に入る時点の retain 1 個だけになる。1 つ足りなければ union が生き残り (リーク)、1 つ多ければ
呼び出し側がまだ持っている union を解放する。

## なぜ足すのか

**この腕の先頭は、スイート全体で一度も実行されていない。** finder が計数したところ、
コンパイラの実行 939 回にわたって 0 回だった。参考までに、catch-all の腕そのものは 12 回、
boxed union 上の catch-all は 8 回出るので、形が無いのではなく、この組み合わせだけが無い。

軸に持ち主がいないことは、実装を壊して測って確かめた。

| 変異 | 意味 | フルスイートの結果 |
| --- | --- | --- |
| dead-branch の条件に `&& !(arm.tag.is_none() && *n == scrut.name)` を足す | catch-all で解放が 1 回足りない | **1516 passed / 1 failed** — 落ちたのはこのテストだけ |
| コンテナ release の条件から `arm.tag.is_some()` を落とす | catch-all で解放が 1 回多い | 1509 passed / 8 failed — 既存 5 本が落ちる |

## テストの中身

`src/tests/test_union_rc_shapes.rs` に定数 `CATCH_ALL_REREAD_SOURCE` と、それを走らせるテスト 1 本を足す。

Fix プログラムは 3 つの関数を定義し、すべて `main` から呼ぶ。どれも「タグ付きの腕が scrutinee を
**2 度目に読む**」形にしてあり、これが dead-branch の規則を効かせる条件である (scrutinee がどの腕の
先頭でも生きているため、使わない腕が自分で release する)。

- `reread : Choice -> I64` — boxed union。タグ付きの腕が scrutinee を読み直し、catch-all の腕は
  scrutinee も payload も読まない。**2 つの release が出会うのはここ。**
- `reread_unbox : Pair -> I64` — 同じ形の unbox union。
- `reread_and_use : Choice -> I64` — catch-all の腕が束縛した payload を読む形。scrutinee が腕の中へ
  流れ込むので、先頭の release は出ない。対照になる。

`main` は 6 つの表明で、各関数をタグ付きの腕と catch-all の腕の両方に落として、union が保持していた
値を読み返す。

## Valgrind の下だけで走る理由

上の表のとおり、この軸で持ち主がいないのは「解放が 1 回足りない」向きだけである。その向きの誤りは
リークであって、プログラムが計算する値はすべて正しいままなので、**値の表明では捕まらない**。
実際、その変異の下で赤くなったのは memory-safety 側だけだった。

逆向き (解放が 1 回多い) は `test_union_catchall_match` と `test_match_result_alias` が既に持っている。
したがって、このファイルの他のテストが取っている「正しさ版 + メモリ安全版」の 2 本組にはせず、
memory-safety の 1 本だけを足す。

## 検証

- 変異なしで緑。
- 上の 2 つの変異それぞれの下で赤 (「1 回足りない」では唯一の赤)。
- 変異を戻してフルスイート: `cargo test --release` が **152 + 1516 passed / 0 failed**。

`CHANGELOG.md` への追記は無い。利用者から見える振る舞いは変わらない。
