### PR TITLE
借用のルーティングを越えて末尾呼び出しが末尾のままであることを留めるテスト

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod test_assert;
 mod test_associated_type;
 mod test_basic;
 mod test_bool_union;
+mod test_borrow_tail_call;
 mod test_borrow_unit_ownership;
 mod test_borrowed_union_field;
 mod test_build_exit_status;

--- a/src/tests/test_borrow_tail_call.rs
+++ b/src/tests/test_borrow_tail_call.rs
@@ -1,0 +1,67 @@
+//! Tail recursion across the versions borrow-ification routes between: a tail call must stay a
+//! tail call whichever version it is routed to, so these loops must run in constant stack.
+
+#[cfg(test)]
+mod borrow_tail_call_tests {
+    use crate::{
+        configuration::{Configuration, ValgrindTool},
+        tests::test_util::test_source,
+    };
+
+    /// Deep tail recursion with a read-only parameter, and with a read-only parameter beside an
+    /// owned one. The first loop is routed to its borrow version, which must add no release after
+    /// the call; the second passes an owned argument in tail position, which must keep the call on
+    /// the owning version rather than un-tail it with an after-call release. Either mistake turns
+    /// the loop into real recursion, and the depth here overflows the stack.
+    ///
+    /// The depth makes this a stack test, not a memcheck one, so Valgrind is switched off to keep
+    /// it fast.
+    #[test]
+    pub fn test_tail_recursion_survives_borrow_routing() {
+        let source = r#"
+            module Main;
+
+            // Only reads `a`: its tail call is routed to the borrow version.
+            loop_sum : I64 -> I64 -> Array I64 -> I64;
+            loop_sum = |n, acc, a| (
+                if n == 0 { acc };
+                loop_sum(n - 1, acc + a.@(n % 3), a)
+            );
+
+            // Reads `ro` and updates `rw`: the tail call passes an owned argument, so it stays on
+            // the owning version.
+            loop_mix : I64 -> Array I64 -> Array I64 -> I64;
+            loop_mix = |n, ro, rw| (
+                if n == 0 { ro.@(0) + rw.@(0) };
+                let rw = rw.set(n % 3, ro.@(n % 3));
+                loop_mix(n - 1, ro, rw)
+            );
+
+            // Borrows both parameters, and its tail call passes a borrowed value at one and a
+            // freshly built (owned) array at the other. Routing that call to the borrow version
+            // would put the fresh array's release after the call; it must stay on the owning
+            // version, which consumes the array in the call itself.
+            churn : I64 -> Array I64 -> Array I64 -> I64;
+            churn = |n, ro, b| (
+                if n == 0 { ro.@(0) + b.@(0) };
+                let v = ro.@(n % 3) + b.@(0);
+                churn(n - 1, ro, [v % 1000, v % 999, v % 998])
+            );
+
+            main : IO ();
+            main = (
+                let a = Array::from_map(3, |i| i + 1);
+                let b = Array::from_map(3, |i| 10 * (i + 1));
+                let n = 30000000;
+                assert_eq(|_|"read-only loop", loop_sum(n, 0, a), 60000000);;
+                assert_eq(|_|"mixed loop", loop_mix(n, a, b), 2);;
+                assert_eq(|_|"fresh-array loop", churn(n, a, b), 11);;
+                assert_eq(|_|"the borrowed arrays survive", a.@(0) + b.@(0), 11);;
+                pure()
+            );
+        "#;
+        let mut config = Configuration::develop_mode();
+        config.set_valgrind(ValgrindTool::None);
+        test_source(source, config);
+    }
+}


### PR DESCRIPTION
バグハントが特定した、持ち主のいないガードを留めるテストを 1 本足す。動作の変更は無い。

## 何を留めるのか

借用化 (`src/rc_ir/borrow.rs` の `borrow_ify`) は、読むだけのパラメータを借用に変えた版を作り、呼び出しごとに
どちらの版を呼ぶかを決める。借用版を呼ぶときは、呼び出し先が解放しなくなった分を呼び出し側が引き受けるので、
**所有していた引数には呼び出しの後に release が付く**。

呼び出しが末尾位置にあると、これが問題になる。後置の release は呼び出しの後に実行されるので、その呼び出しは
末尾ではなくなり、末尾呼び出し最適化が効かなくなる。ループとして書かれた再帰が本物の再帰になり、深いループが
スタックを溢れさせる。

`RewriteCtx::routing_is_safe` がこれを防いでいる。末尾位置の呼び出しは、所有している引数を 1 つも渡さない
ときに限って借用版へ回す。

## なぜ足すのか

このガードを外して (常に「安全」と答えさせて) フルスイートを回すと、**赤くなるのはこのテストだけ**である。

| | 結果 |
| --- | --- |
| `routing_is_safe` を常に `true` にする | **1516 passed / 1 failed** — 落ちたのはこのテスト |

つまりこのガードには持ち主がいなかった。

## ガードが実際に負っているもの

トレースして分かったことを書いておく。ガードは見た目より狭い範囲しか負っていない。

**末尾呼び出しの引数は、どれも最終使用である** (呼び出しの後には何も無い)。したがって
`routing_saves_retain` の利得判定 — 「呼び出し先が借りる unit のうち、`所有 かつ 最終使用` ではないものが
あるか」 — は、引数が所有のものだけなら偽になり、その呼び出しはガードを見るまでもなく借用版へ回らない。

ガードだけが弾いているのは、**借用した値と、その場で作った所有の値を、同じ末尾呼び出しで渡す形**である。
借用値の側が利得を生むので `routing_saves_retain` は真を返し、所有値の側が後置 release を要求する。
このテストの 3 つ目のループ `churn` がその形になっている。

## テストの中身

`src/tests/test_borrow_tail_call.rs` を新設し、`src/tests/mod.rs` に登録する。テストは 1 本。

Fix プログラムは 3 000 万段の末尾再帰を 3 通り書き、すべて `main` から呼ぶ。どれも再帰なので
インライン化を生き延び、借用化に届く。

- `loop_sum` — 読むだけのパラメータ 1 つ。借用版へ回る側で、後置 release が付いてはならない。
- `loop_mix` — 読むパラメータと、更新して渡し直すパラメータ。所有引数を末尾で渡すので、所有版に留まる。
- `churn` — 借用値と、その場で作った配列を同時に末尾で渡す。**ガードだけが弾いている形。**

深さが判定装置なので、Valgrind は切ってある (メモリ検査ではなくスタック検査であり、3 000 万段を
Valgrind の下で回す意味が無い)。ルーティングが壊れると "terminated by signal" で落ちる。

## 検証

- 変異なしで緑 (1.38 秒)。
- `routing_is_safe` を常に `true` にする変異の下で赤 (スタックオーバーフロー)。
- 変異を戻してフルスイート: `cargo test --release` が **152 + 1516 passed / 0 failed**。

`CHANGELOG.md` への追記は無い。利用者から見える振る舞いは変わらない。
