### PR TITLE
レビュー清掃 (#448): まわりの名前・import・コメント

### DIFF
--- a/src/rc_ir/simplify.rs
+++ b/src/rc_ir/simplify.rs
@@ -164,7 +164,9 @@ fn node_count(node: &RcExprNode) -> u64 {
         let cont = match node.expr.as_ref() {
             RcExpr::Ret(_) => return 1,
             RcExpr::Let(_, RcRhs::Match(_, arms), k) => {
-                return 1 + arms.iter().map(|a| node_count(&a.body)).sum::<u64>() + node_count(k);
+                return 1
+                    + arms.iter().map(|arm| node_count(&arm.body)).sum::<u64>()
+                    + node_count(k);
             }
             RcExpr::Let(_, _, k)
             | RcExpr::Destructure(_, _, _, k)
@@ -181,7 +183,7 @@ fn union_construction(rhs: &RcRhs) -> Option<(usize, &RcVar)> {
     let RcRhs::Llvm(gen, args) = rhs else {
         return None;
     };
-    let make = gen.as_any().downcast_ref::<InlineLLVMMakeUnionBody>()?;
+    let construction = gen.as_any().downcast_ref::<InlineLLVMMakeUnionBody>()?;
     // An operation's operands are its free variables, of which a union construction has the payload
     // alone.
     assert_eq!(
@@ -189,7 +191,7 @@ fn union_construction(rhs: &RcRhs) -> Option<(usize, &RcVar)> {
         1,
         "a union construction takes its payload alone"
     );
-    Some((make.variant_index(), &args[0]))
+    Some((construction.variant_index(), &args[0]))
 }
 
 /// case-of-known-constructor on a union: `let x = union_tag(payload); let m = match x { .. }; k`,
@@ -199,7 +201,7 @@ fn case_of_known_union(node: &RcExprNode) -> Option<RcExprNode> {
     let RcExpr::Let(x, rhs, k) = node.expr.as_ref() else {
         return None;
     };
-    let (variant, payload) = union_construction(rhs)?;
+    let (variant, operand) = union_construction(rhs)?;
     // The continuation must be exactly a match on `x`, and `x` must be used nowhere else.
     let RcExpr::Let(m, RcRhs::Match(scrut, arms), k2) = k.expr.as_ref() else {
         return None;
@@ -209,10 +211,10 @@ fn case_of_known_union(node: &RcExprNode) -> Option<RcExprNode> {
     }
     // Pick the arm for the known tag. A catch-all arm binds the whole union (not the payload), so it
     // would not remove the construction; skip when only a catch-all matches.
-    let arm = arms.iter().find(|a| a.tag == Some(variant))?;
-    let body = substitute_expr(&arm.body, &single(&arm.payload.name, &payload.name));
-    Some(replace_tail(&body, &mut |result| {
-        substitute_expr(k2, &single(&m.name, &result.name))
+    let arm = arms.iter().find(|arm| arm.tag == Some(variant))?;
+    let body = substitute_expr(&arm.body, &single(&arm.payload.name, &operand.name));
+    Some(replace_tail(&body, &mut |arm_result| {
+        substitute_expr(k2, &single(&m.name, &arm_result.name))
     }))
 }
 
@@ -409,23 +411,23 @@ fn replace_tail_union(
                 }
                 RcExpr::Let(r.clone(), rhs.clone(), replace_tail_union(k, result_ty, f))
             }
-            RcExpr::Destructure(c, fields, state, k) => RcExpr::Destructure(
-                c.clone(),
+            RcExpr::Destructure(container, fields, state, k) => RcExpr::Destructure(
+                container.clone(),
                 fields.clone(),
                 *state,
                 replace_tail_union(k, result_ty, f),
             ),
             RcExpr::Eval(v, k) => RcExpr::Eval(v.clone(), replace_tail_union(k, result_ty, f)),
-            RcExpr::Retain(v, p, st, k) => RcExpr::Retain(
+            RcExpr::Retain(v, path, state, k) => RcExpr::Retain(
                 v.clone(),
-                p.clone(),
-                *st,
+                path.clone(),
+                *state,
                 replace_tail_union(k, result_ty, f),
             ),
-            RcExpr::Release(v, p, st, k) => RcExpr::Release(
+            RcExpr::Release(v, path, state, k) => RcExpr::Release(
                 v.clone(),
-                p.clone(),
-                *st,
+                path.clone(),
+                *state,
                 replace_tail_union(k, result_ty, f),
             ),
         };
@@ -477,15 +479,18 @@ fn replace_tail(node: &RcExprNode, f: &mut dyn FnMut(&RcVar) -> RcExprNode) -> R
         let expr = match node.expr.as_ref() {
             RcExpr::Ret(r) => return f(r),
             RcExpr::Let(x, rhs, k) => RcExpr::Let(x.clone(), rhs.clone(), replace_tail(k, f)),
-            RcExpr::Destructure(c, fields, state, k) => {
-                RcExpr::Destructure(c.clone(), fields.clone(), *state, replace_tail(k, f))
-            }
+            RcExpr::Destructure(container, fields, state, k) => RcExpr::Destructure(
+                container.clone(),
+                fields.clone(),
+                *state,
+                replace_tail(k, f),
+            ),
             RcExpr::Eval(v, k) => RcExpr::Eval(v.clone(), replace_tail(k, f)),
-            RcExpr::Retain(v, p, st, k) => {
-                RcExpr::Retain(v.clone(), p.clone(), *st, replace_tail(k, f))
+            RcExpr::Retain(v, path, state, k) => {
+                RcExpr::Retain(v.clone(), path.clone(), *state, replace_tail(k, f))
             }
-            RcExpr::Release(v, p, st, k) => {
-                RcExpr::Release(v.clone(), p.clone(), *st, replace_tail(k, f))
+            RcExpr::Release(v, path, state, k) => {
+                RcExpr::Release(v.clone(), path.clone(), *state, replace_tail(k, f))
             }
         };
         node_of(expr, &node.source)
@@ -503,7 +508,9 @@ fn count_value_uses(name: &FullName, node: &RcExprNode) -> usize {
         match node.expr.as_ref() {
             RcExpr::Ret(v) => hit(v),
             RcExpr::Let(_, rhs, k) => rhs_value_uses(name, rhs) + count_value_uses(name, k),
-            RcExpr::Destructure(c, _, _state, k) => hit(c) + count_value_uses(name, k),
+            RcExpr::Destructure(container, _, _state, k) => {
+                hit(container) + count_value_uses(name, k)
+            }
             RcExpr::Eval(v, k) => hit(v) + count_value_uses(name, k),
             RcExpr::Retain(_, _, _, k) | RcExpr::Release(_, _, _, k) => count_value_uses(name, k),
         }
@@ -531,9 +538,9 @@ fn rhs_value_uses(name: &FullName, rhs: &RcRhs) -> usize {
 
 /// A one-entry substitution map.
 fn single(from: &FullName, to: &FullName) -> Map<FullName, FullName> {
-    let mut m: Map<FullName, FullName> = Map::default();
-    m.insert(from.clone(), to.clone());
-    m
+    let mut subst: Map<FullName, FullName> = Map::default();
+    subst.insert(from.clone(), to.clone());
+    subst
 }
 
 /// A node holding `expr` and reporting `source` as the place it comes from. A rewritten node carries

--- a/src/rc_ir/simplify.rs
+++ b/src/rc_ir/simplify.rs
@@ -209,8 +209,8 @@ fn case_of_known_union(node: &RcExprNode) -> Option<RcExprNode> {
     if scrut.name != x.name || count_value_uses(&x.name, k) != 1 {
         return None;
     }
-    // Pick the arm for the known tag. A catch-all arm binds the whole union (not the payload), so it
-    // would not remove the construction; skip when only a catch-all matches.
+    // Pick the arm for the known tag. A catch-all arm binds the whole union, so the construction
+    // stays to build it; skip when only a catch-all matches.
     let arm = arms.iter().find(|arm| arm.tag == Some(variant))?;
     let body = substitute_expr(&arm.body, &single(&arm.payload.name, &operand.name));
     Some(replace_tail(&body, &mut |arm_result| {
@@ -500,7 +500,7 @@ fn replace_tail(node: &RcExprNode, f: &mut dyn FnMut(&RcVar) -> RcExprNode) -> R
 /// The number of times `name` occurs as a value in `node`: a move, a call callee or argument, an
 /// inline-LLVM operand, a closure capture, a match scrutinee, a destructured container, an `eval`, or
 /// the returned variable. Binders do not count. `Retain`/`Release` name a variable only for reference
-/// counting, so they are transparent (and do not occur before `insert_rc` anyway).
+/// counting, so they are transparent.
 fn count_value_uses(name: &FullName, node: &RcExprNode) -> usize {
     // A deep continuation chain recurses to its full depth here; grow the stack on demand.
     grow_stack(|| {

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -60,22 +60,22 @@ mod integration_tests {
     /// itself and every line up to the next `fn` header.
     fn fn_bodies_matching<'a>(dump: &'a str, needles: &[&str]) -> Vec<String> {
         let mut bodies = Vec::new();
-        let mut current: Option<String> = None;
+        let mut current_body: Option<String> = None;
         for line in dump.lines() {
             if line.starts_with("fn ") {
-                if let Some(body) = current.take() {
+                if let Some(body) = current_body.take() {
                     bodies.push(body);
                 }
                 if needles.iter().all(|n| line.contains(n)) {
-                    current = Some(String::new());
+                    current_body = Some(String::new());
                 }
             }
-            if let Some(body) = current.as_mut() {
+            if let Some(body) = current_body.as_mut() {
                 body.push_str(line);
                 body.push('\n');
             }
         }
-        if let Some(body) = current.take() {
+        if let Some(body) = current_body.take() {
             bodies.push(body);
         }
         bodies
@@ -126,14 +126,14 @@ mod integration_tests {
             }
         }
 
-        let run = Command::new(project_dir.join("a.out"))
+        let output = Command::new(project_dir.join("a.out"))
             .output()
             .expect("failed to run the built executable");
         assert!(
-            run.status.success(),
+            output.status.success(),
             "the built executable did not run cleanly"
         );
-        assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), expected);
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), expected);
     }
 
     /// The `range.fold` driver the simplifier leaves behind builds no union: the `Option` that

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -1,14 +1,12 @@
-// Tests for the RC IR term simplifier: what it removes, read from the `--emit-rc-ir` dump, and what
-// the simplified program computes.
-//
-// A read loop over `range(0, size).fold` lowers to a specialized fold driver whose loop-carried state
-// is the `Option` that `range`'s `advance` builds and `fold` immediately matches. The simplifier
-// cancels that union (case-of-case + case-of-known-constructor), so the driver keeps only the plain
-// `RangeIterator` two-scalar state and no union construction — the property the integration tests
-// assert. The value tests compile and run Fix programs written to drive the same rewrite, and check
-// what each one computes. The build-time tests bound how long a program shaped to drive it may take
-// to compile.
+//! Tests for the RC IR term simplifier: what it removes, read from the `--emit-rc-ir` dump, and what
+//! the simplified program computes.
 
+/// Case projects built with `--emit-rc-ir`, read for what the simplifier removed and run for what
+/// they print. A read loop over `range(0, size).fold` lowers to a specialized fold driver whose
+/// loop-carried state is the `Option` that `range`'s `advance` builds and `fold` immediately
+/// matches. The simplifier cancels that union (case-of-case + case-of-known-constructor), so the
+/// driver keeps only the plain `RangeIterator` two-scalar state and no union construction — the
+/// property these tests assert.
 #[cfg(test)]
 mod integration_tests {
     use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
@@ -202,6 +200,7 @@ mod integration_tests {
     }
 }
 
+/// Fix programs written to drive the rewrites, compiled and run for the values each one computes.
 #[cfg(test)]
 mod value_tests {
     use crate::{configuration::Configuration, tests::test_util::test_source};
@@ -283,9 +282,8 @@ mod value_tests {
     }
 
     /// The outer match answers the `none` an inner arm builds with a catch-all arm, which binds the
-    /// whole union rather than that constructor's payload. Moving such an arm into the inner arm
-    /// would bind it to the payload instead, so the rewrite declines and the values stay what the
-    /// source computes.
+    /// whole union. Moving such an arm into the inner arm would bind it to the construction's
+    /// payload instead, so the rewrite declines and the values stay what the source computes.
     #[test]
     pub fn test_catch_all_outer_arm() {
         let source = r#"
@@ -312,6 +310,7 @@ mod value_tests {
     }
 }
 
+/// A program shaped to drive case-of-case, bounded in how long it may take to compile.
 #[cfg(test)]
 mod build_time_tests {
     use crate::tests::test_util::build_within_and_run;

--- a/src/tests/test_simplify.rs
+++ b/src/tests/test_simplify.rs
@@ -12,6 +12,7 @@
 #[cfg(test)]
 mod integration_tests {
     use crate::tests::test_util::{copy_dir_recursive, fix_command_at_opt_level};
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use tempfile::TempDir;
@@ -52,7 +53,7 @@ mod integration_tests {
         }
 
         let dump_path = project_dir.join(".fixlang/rc_ir.post.txt");
-        std::fs::read_to_string(&dump_path)
+        fs::read_to_string(&dump_path)
             .unwrap_or_else(|e| panic!("failed to read {}: {}", dump_path.display(), e))
     }
 


### PR DESCRIPTION
Refs #427

`simplify-tail-match` (#448) のコードレビューで、変更のまわり (ring 2 — 触れた 2 ファイルのうち差分の外) に出た指摘をまとめたもの。中身はローカル束縛の改名、import 1 つ、コメントの書き直しだけで、**動作は構成上変わらない**。#448 の差分を読むときにこれらが混ざらないよう、別の pull request にしてある。

対象ファイルは `src/rc_ir/simplify.rs` と `src/tests/test_simplify.rs` の 2 つ。

## ローカル束縛の改名 (`code-review: name the locals the way rc_ir names them`)

規約は「読み手が名前から中身を予測できるか」と「プロジェクトの語が勝つ」。改名はどれも 1 つの関数の中で閉じている。

`src/rc_ir/simplify.rs`:

- `union_construction` の `make` -> `construction`。動詞が値に付いていた。このファイルが名詞として使う語は "union construction"。
- `case_of_known_union` の `payload` -> `operand`。`substitute_expr(&arm.body, &single(&arm.payload.name, &payload.name))` の 1 行に、アームの束縛子 (`arm.payload`) と構築の被演算子という別物が同じ語で 2 つ並んでいた。`case_of_case` と `replace_tail_union` は後者を `operand` と呼ぶ。
- `case_of_known_union` のクロージャ引数 `result` -> `arm_result`。どの結果かを言っていなかった。
- `node_count` と `case_of_known_union` のクロージャ引数 `a` -> `arm`。`rc_ir` の他のファイルはアームを `arm` と綴り、`a` は引数 (args) に使われている。
- `replace_tail_union` / `replace_tail` / `count_value_uses` の `c` -> `container`、`p` -> `path`、`st` -> `state`。`st` は同じ `match` の 2 行上で `state` と綴られていて、1 つの関数の中で 1 つの物に 2 語あった。3 語とも `rc_ir` 全体の語で、`rename.rs` の同型の再構築も同じ綴りを使う。
- `single` の `m` -> `subst`。`m` はこのファイルでは外側 `match` の変数を指す。同じ型の値を `destructure_of_struct` は `subst` と呼ぶ。

`src/tests/test_simplify.rs`:

- `assert_union_cancelled` の `run` -> `output`。型は `std::process::Output` で、同じファイルの `emit_all_rc_ir` が同じ物を `output` と呼ぶ。
- `fn_bodies_matching` の `current` -> `current_body`。何が現在なのかを言っていなかった。

## import (`code-review: import fs rather than qualifying its call`)

`emit_all_rc_ir` の `std::fs::read_to_string(&dump_path)` を、`use std::fs;` を足して `fs::read_to_string(&dump_path)` にした。規約は「意味を運ぶ修飾子だけ残す」で、`read_to_string` 単独では `io::Read::read_to_string` と読めるため `fs` の 1 節は残す。

## コメント (`code-review: say the catch-all and the module docs plainly`)

- `case_of_known_union` の「A catch-all arm binds the whole union (not the payload), so it would not remove the construction」を「A catch-all arm binds the whole union, so the construction stays to build it」に。規約は肯定形で書くこと。
- `count_value_uses` の doc 末尾「so they are transparent (and do not occur before `insert_rc` anyway)」から括弧の付言を落とした。同じく肯定形。
- `src/tests/test_simplify.rs` の冒頭コメントを `//!` の module doc にし、3 つの `mod` それぞれに doc を付けた。冒頭に集めてあった各群の説明はそれぞれの `mod` へ移したので、同じことが 2 か所に書かれてはいない。`//!` はテストファイル 25 本が採る形。

## 検証

`cargo test --release` 全通過。`cargo fmt` は差分なし。

## 作者に残した指摘 (この pull request では直していない)

いずれも ring 2 では編集できない種類 (署名の変更・実行時メッセージ) なので、報告のみ。

- `simplify_to_fixpoint` の develop-mode の panic 文言 `"a simplifier pass left a body of {} nodes at {}, so a rewrite it fired did not make it smaller"` は、2 つ目の数がどちらの計数か読み取りにくい。`"a simplifier pass grew a body of {} nodes to {}"` の形が読みやすい。この文字列リテラルは 117 桁で、ほぼ 100 桁に収まっているファイルの中で最も長い行でもある。
- `fn_bodies_matching<'a>(dump: &'a str, needles: &[&str]) -> Vec<String>` の `'a` は使われていない (返り値は所有型)。消せるが署名の変更にあたる。
- `src/rc_ir/simplify.rs` の `fn single` は「何が 1 つなのか」を言っていない。`single_subst` が候補。アイテム名なので作者の判断。
- `src/rc_ir/rename.rs` の `clone_fresh` の引数 `marker` は、同じファイルの `fresh_rename_function` などが同じ値を `pass_tag` と呼んでいる中でここだけ別語 (ring 3)。直すなら `simplify.rs` の `const MARKER` も併せて。
