### PR TITLE
レビュー清掃 (#451): まわりの doc コメントと局所名

### DIFF
--- a/src/elaboration/mod.rs
+++ b/src/elaboration/mod.rs
@@ -73,7 +73,8 @@ fn elaborate(mut program: Program, config: &Configuration) -> Result<Program, Er
     program.validate_import_statements()?;
 
     // Set and check kinds that appear in type signatures.
-    // NOTE: kinds of type variables appearing in type annotations in expressions are set not at this stage but at the type inference stage.
+    // NOTE: kinds of type variables appearing in type annotations in expressions are set at the
+    // type inference stage.
     program.set_kinds()?;
 
     // Check that no two implementations of one trait can apply to the same type.
@@ -210,11 +211,11 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
         errors.eat_err_or(res, |mod_| modules.push(mod_));
     }
 
-    // If an error occurres in parsing,
     if let SubCommand::Diagnostics(diag_config) = &config.subcommand {
-        // In eny parsing error occurres in diagnostics mode, delay the error and remove the root project from modules.
-        // In other words, in the following diagnostic process, only the dependent projects are targeted.
-        // This allows us to give the language server the information it needs for code completion, even if there is a parse error in the root project.
+        // If a parsing error occurs in diagnostics mode, delay the error and remove the root
+        // project from modules, so that the diagnostic process that follows targets the dependent
+        // projects alone. This gives the language server the information it needs for code
+        // completion even when the root project has a parse error.
         if errors.has_error() {
             let mut dependency_modules = vec![];
             for mod_ in modules {
@@ -233,7 +234,7 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
 
     // Link all modules.
     for mod_ in modules {
-        program.link(mod_, false)?; // If an error occurres in linking, return the error.
+        program.link(mod_, false)?; // If an error occurs in linking, return the error.
     }
 
     // Resolve imports.

--- a/src/elaboration/mod.rs
+++ b/src/elaboration/mod.rs
@@ -96,11 +96,11 @@ fn elaborate(mut program: Program, config: &Configuration) -> Result<Program, Er
     // When running diagnostics, perform type checking of target modules and return here.
     if let SubCommand::Diagnostics(diag_config) = &config.subcommand {
         let _sw = StopWatch::new("typecheck", config.show_build_times);
-        let modules = program.modules_from_files(&diag_config.files)?;
+        let target_module_names = program.modules_from_files(&diag_config.files)?;
         let mut errors = Errors::empty();
         errors.eat_err(program.resolve_namespace_and_check_type_in_modules(
             &typechecker,
-            &modules,
+            &target_module_names,
             diag_config.target_symbols.as_deref(),
             config,
         ));
@@ -115,10 +115,10 @@ fn elaborate(mut program: Program, config: &Configuration) -> Result<Program, Er
     // This ensures opaque type resolutions are available before instantiation.
     {
         let _sw = StopWatch::new("typecheck", config.show_build_times);
-        let all_modules: Vec<_> = program.modules.iter().map(|m| m.name.clone()).collect();
+        let all_module_names: Vec<_> = program.modules.iter().map(|m| m.name.clone()).collect();
         program.resolve_namespace_and_check_type_in_modules(
             &typechecker,
-            &all_modules,
+            &all_module_names,
             None,
             config,
         )?;
@@ -204,11 +204,13 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
     let mut program = make_std_mod(config)?;
 
     // Parse all source files.
-    let mut modules = vec![];
+    let mut parsed_programs = vec![];
     let mut errors = Errors::empty();
     for file_path in &config.source_files {
-        let res = parse_file_path(file_path.clone(), config);
-        errors.eat_err_or(res, |mod_| modules.push(mod_));
+        let parse_result = parse_file_path(file_path.clone(), config);
+        errors.eat_err_or(parse_result, |parsed_program| {
+            parsed_programs.push(parsed_program)
+        });
     }
 
     if let SubCommand::Diagnostics(diag_config) = &config.subcommand {
@@ -217,14 +219,14 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
         // projects alone. This gives the language server the information it needs for code
         // completion even when the root project has a parse error.
         if errors.has_error() {
-            let mut dependency_modules = vec![];
-            for mod_ in modules {
-                let mods = mod_.modules_from_files(&diag_config.files)?;
-                if mods.is_empty() {
-                    dependency_modules.push(mod_);
+            let mut dependency_programs = vec![];
+            for parsed_program in parsed_programs {
+                let target_module_names = parsed_program.modules_from_files(&diag_config.files)?;
+                if target_module_names.is_empty() {
+                    dependency_programs.push(parsed_program);
                 }
             }
-            modules = dependency_modules;
+            parsed_programs = dependency_programs;
         }
         program.deferred_errors.append(errors);
     } else {
@@ -233,8 +235,8 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
     }
 
     // Link all modules.
-    for mod_ in modules {
-        program.link(mod_, false)?; // If an error occurs in linking, return the error.
+    for parsed_program in parsed_programs {
+        program.link(parsed_program, false)?; // If an error occurs in linking, return the error.
     }
 
     // Resolve imports.

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,8 +71,7 @@ impl Errors {
     }
 
     /// Takes every diagnostic out of `self` as an error, leaving `self` empty, once one of them
-    /// has error severity. A collection of warnings alone is a success and stays where it is, for
-    /// a later `take_warnings` to print.
+    /// has error severity. A collection of warnings alone is a success and stays where it is.
     pub fn to_result(&mut self) -> Result<(), Errors> {
         if self.has_error() {
             Err(mem::replace(self, Errors::empty()))
@@ -81,9 +80,8 @@ impl Errors {
         }
     }
 
-    /// Drain all warning-severity items into a fresh `Errors`, leaving only
-    /// error-severity items in `self`. Useful for printing warnings before
-    /// checking `to_result()`.
+    /// Takes the warning-severity diagnostics out of this collection, keeping their order and
+    /// leaving the error-severity ones where they are.
     pub fn take_warnings(&mut self) -> Errors {
         let (warnings, errors) = mem::take(&mut self.errs)
             .into_iter()
@@ -207,9 +205,8 @@ pub struct Error {
     /// Data about this diagnostic beyond its text, such as the name a fix has to insert. Its
     /// shape is decided by `code`.
     pub data: Option<Value>,
-    /// Severity of this diagnostic. Construct warnings via
-    /// `Error::warning_from_msg_srcs`; the other constructors produce
-    /// `Severity::Error`.
+    /// Severity of this diagnostic: an error fails the compilation, a warning accompanies a
+    /// compilation that still succeeds.
     pub severity: Severity,
 }
 
@@ -289,8 +286,6 @@ impl Error {
 /// Panics with `msg`, having installed a panic hook that prints the message alone, so that the
 /// thread name, the panic location and the backtrace note stay out of the compiler's output.
 fn panic_notrace(msg: &str) -> ! {
-    // Default panic hook shows message such as "thread 'main' panicked at " or "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace".
-    // We replace it to empty.
     panic::set_hook(Box::new(move |info| {
         let msg = any_to_string(info.payload());
         eprintln!("{}", msg);

--- a/src/error.rs
+++ b/src/error.rs
@@ -150,17 +150,17 @@ impl Errors {
     /// whose rendering repeats one already written is left out.
     pub fn to_string(&self) -> String {
         let mut msg_set = Set::default();
-        let mut str = String::default();
+        let mut rendered = String::default();
         for err in &self.errs {
             let msg = err.to_string();
             if msg_set.contains(&msg) {
                 continue;
             }
             msg_set.insert(msg.clone());
-            str += &msg;
-            str += "\n";
+            rendered += &msg;
+            rendered += "\n";
         }
-        str
+        rendered
     }
 
     /// Groups the diagnostics by the file of their first source location, ordered by path.
@@ -171,22 +171,22 @@ impl Errors {
     ///   point at one.
     pub fn organize_by_path(&self, spanless_fallback: &Path) -> Vec<(PathBuf, Vec<Error>)> {
         // Organize errors into a hashmap.
-        let mut map: Map<PathBuf, Vec<Error>> = Map::default();
+        let mut errs_by_path: Map<PathBuf, Vec<Error>> = Map::default();
         for err in &self.errs {
             let path = match err.srcs.first() {
                 None => spanless_fallback.to_path_buf(),
                 Some((_, span)) => span.input.file_path.clone(),
             };
-            insert_to_map_vec(&mut map, &path, err.clone());
+            insert_to_map_vec(&mut errs_by_path, &path, err.clone());
         }
 
         // Convert the hashmap into a vector.
-        let mut res = map.into_iter().collect::<Vec<_>>();
+        let mut errs_by_path = errs_by_path.into_iter().collect::<Vec<_>>();
 
         // Sort the vector by the path.
-        res.sort_by(|a, b| a.0.cmp(&b.0));
+        errs_by_path.sort_by(|a, b| a.0.cmp(&b.0));
 
-        res
+        errs_by_path
     }
 }
 
@@ -229,7 +229,11 @@ impl Error {
             msg,
             srcs: srcs
                 .iter()
-                .filter_map(|x| x.as_ref().map(|x| (String::default(), (*x).clone())))
+                .filter_map(|span_opt| {
+                    span_opt
+                        .as_ref()
+                        .map(|span| (String::default(), span.clone()))
+                })
                 .collect(),
             code: None,
             data: None,
@@ -264,22 +268,22 @@ impl Error {
     /// then each attached location as its description followed by the quoted source with the
     /// span underlined in the severity's color.
     pub fn to_string(&self) -> String {
-        let mut str = String::default();
+        let mut rendered = String::default();
         let (label, underline_color) = self.severity.label_and_underline_color();
-        str += &label;
-        str += ": ";
-        str += &self.msg;
-        str += "\n";
+        rendered += &label;
+        rendered += ": ";
+        rendered += &self.msg;
+        rendered += "\n";
         for (src_desc, src) in &self.srcs {
             if src_desc.len() > 0 {
-                str += "\n";
-                str += src_desc;
-                str += "\n";
+                rendered += "\n";
+                rendered += src_desc;
+                rendered += "\n";
             }
-            str += "\n";
-            str += &src.to_string(underline_color);
+            rendered += "\n";
+            rendered += &src.to_string(underline_color);
         }
-        str
+        rendered
     }
 }
 

--- a/src/metafiles/project_file.rs
+++ b/src/metafiles/project_file.rs
@@ -29,63 +29,91 @@ use std::{
 };
 use toml::Spanned;
 
-// The name of a project.
+/// The name of a project, as the `[general]` section of its project file gives it and the
+/// dependency entries of other projects refer to it.
 pub type ProjectName = String;
 
-// The `general` section of the project file.
+/// The `general` section of the project file, holding the project's identity: its name, its
+/// version, and the compiler versions it builds with.
 #[derive(Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFileGeneral {
-    // The name of the project.
+    /// The name of the project, which the dependency entries of other projects refer to it by.
     pub name: ProjectName,
-    // The version of the project.
-    // Use `version` method to get the value validated as semver.
+    /// The version of the project, written as semver. `ProjectFile::validate` rejects a string that
+    /// is not one.
     pub version: String,
-    // The Fix compiler version.
-    // Defaults to "*".
+    /// The compiler versions this project builds with, written as a semver requirement. Left out,
+    /// the project builds with every version.
     pub fix_version: Option<String>,
-    // The description of the project.
+    /// A sentence describing the project, shown to whoever reads the project file.
     #[allow(unused)]
     pub description: Option<String>,
-    // The authors of the project.
+    /// The people credited with the project.
     #[allow(unused)]
     pub authors: Option<Vec<String>>,
-    // The license of the project.
+    /// The name of the license the project is distributed under.
     #[allow(unused)]
     pub license: Option<String>,
 }
 
 impl ProjectFileGeneral {
-    // Get the version.
+    /// The `version` field parsed as semver. Panics unless `ProjectFile::validate` has accepted
+    /// the field.
     pub fn version(&self) -> Version {
         Version::parse(&self.version).unwrap()
     }
 }
 
-// The `build` section of the project file.
+/// The `build` section of the project file, holding the settings a build of the project reads.
 #[derive(Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFileBuild {
+    /// The Fix source files the build compiles, each resolved against the project directory and
+    /// paired with its byte range in the project file.
     files: Vec<Spanned<PathBuf>>,
+    /// The object files the build links, each resolved against the project directory.
     #[serde(default)]
     objects: Vec<PathBuf>,
+    /// The libraries the build links statically, each named as the linker's `-l` names it: `"abc"`
+    /// links `libabc.a`.
     static_links: Option<Vec<String>>,
+    /// The libraries the build links dynamically, each named as the linker's `-l` names it: `"xyz"`
+    /// links `libxyz.so`.
     dynamic_links: Option<Vec<String>>,
+    /// The directories the linker searches for libraries, each resolved against the project
+    /// directory.
     library_paths: Option<Vec<PathBuf>>,
+    /// Further flags handed to the linker as they are written.
     #[serde(default)]
     ld_flags: Vec<String>,
+    /// The commands run in the project directory before the Fix program is compiled, each written
+    /// as a program followed by its arguments. They run once the user has approved them.
     #[serde(default)]
     preliminary_commands: Vec<Vec<String>>,
 
+    /// Whether to build the program with thread-safe reference counting, which lets a value cross
+    /// threads. Unset builds it with single-threaded reference counting.
     threaded: Option<bool>,
     /// Name of the sanitizer to instrument the built program with, from the set
     /// `Sanitizer::from_str` accepts.
     sanitize: Option<String>,
+    /// Whether to put debugging information into the built program. Unset leaves it out.
     debug: Option<bool>,
+    /// Name of the optimization level to build at, from the set `FixOptimizationLevel::from_str`
+    /// accepts.
     opt_level: Option<String>,
+    /// The path `fix build` writes its output file to. `fix run` and `fix test` build into a
+    /// temporary place of their own.
     output: Option<PathBuf>,
+    /// Name of the kind of file `fix build` produces, from the set `OutputFileType::from_str`
+    /// accepts.
     output_type: Option<String>,
+    /// Whether the program prints a backtrace when a run-time error ends it. Unset ends it with the
+    /// error message alone.
     backtrace: Option<bool>,
+    /// Regex patterns of the CPU features to turn off, so that `"avx512.*"` keeps the program off
+    /// every feature whose name that pattern matches.
     #[serde(default)]
     disable_cpu_features: Vec<String>,
     /// Whether to leave the run-time checks, such as the array bounds check, out of the program.
@@ -95,32 +123,53 @@ pub struct ProjectFileBuild {
     /// the program. Unset evaluates `{side}`.
     skip_eval: Option<bool>,
 
-    /// The `build.test` sub-section, which supplies the settings a `fix test` build uses in place of
+    /// The `build.test` sub-section, which supplies the settings a `fix test` build reads beside
     /// the ones this `build` section gives.
     test: Option<ProjectFileBuildTest>,
 }
 
-// The `build.test` section of the project file.
+/// The `build.test` section of the project file, holding the settings a `fix test` build reads.
+/// The doc of each field states how its value combines with the one the `build` section gives.
 #[derive(Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFileBuildTest {
+    /// The Fix source files a test build compiles, added to the ones the `build` section gives.
+    /// Each is resolved against the project directory and paired with its byte range in the project
+    /// file.
     files: Vec<Spanned<PathBuf>>,
+    /// The object files a test build links, added to the ones the `build` section gives.
     #[serde(default)]
     objects: Vec<PathBuf>,
+    /// The libraries a test build links statically, added to the ones the `build` section gives.
     static_links: Option<Vec<String>>,
+    /// The libraries a test build links dynamically, added to the ones the `build` section gives.
     dynamic_links: Option<Vec<String>>,
+    /// The directories the linker searches for libraries in a test build, added to the ones the
+    /// `build` section gives.
     library_paths: Option<Vec<PathBuf>>,
+    /// Further flags handed to the linker in a test build, added to the ones the `build` section
+    /// gives.
     #[serde(default)]
     ld_flags: Vec<String>,
+    /// The commands run before a test build compiles, added to the ones the `build` section gives.
     #[serde(default)]
     preliminary_commands: Vec<Vec<String>>,
 
+    /// Whether to build a test with thread-safe reference counting. Unset leaves the value the
+    /// `build` section gives in force.
     threaded: Option<bool>,
     /// Name of the sanitizer to instrument the built test program with, from the set
     /// `Sanitizer::from_str` accepts.
     sanitize: Option<String>,
+    /// Whether to put debugging information into a test build. Unset leaves the value the `build`
+    /// section gives in force.
     debug: Option<bool>,
+    /// Name of the optimization level to build a test at, from the set
+    /// `FixOptimizationLevel::from_str` accepts. Unset leaves the value the `build` section gives in
+    /// force.
     opt_level: Option<String>,
+    /// Whether a test prints a backtrace when a run-time error ends it. Unset leaves the value the
+    /// `build` section gives in force.
     backtrace: Option<bool>,
     /// Regex patterns of the CPU features to turn off in a test build, added to the ones the
     /// `build` section gives.
@@ -138,23 +187,26 @@ pub struct ProjectFileBuildTest {
     memcheck: Option<bool>,
 }
 
-// The entry of `dependencies` section of the project file.
+/// One entry of the `dependencies` or `test_dependencies` section: a project this project builds
+/// against, and where that project is fetched from.
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFileDependency {
-    // Name of the project.
+    /// The name of the project depended on, as that project's own `[general]` section gives it.
     pub name: ProjectName,
-    // Path to directory.
+    /// The directory the project sits in, resolved against the directory of the project file that
+    /// declares it. Exactly one of `path` and `git` is written.
     pub path: Option<PathBuf>,
-    // Git repository.
+    /// The git repository the project is cloned from. Exactly one of `path` and `git` is written.
     pub git: Option<ProjectFileDependencyGit>,
-    // Version requirement for the dependent project.
-    // If None, the latest version is used.
+    /// The versions of the project this entry accepts, written as a semver requirement in Cargo's
+    /// syntax. Left out, the latest version is taken.
     pub version: Option<String>,
 }
 
 impl ProjectFileDependency {
-    // Get the version requirement.
+    /// The `version` field parsed as a semver requirement. A field left out accepts every version.
+    /// Panics unless `ProjectFile::validate` has accepted the field.
     pub fn version(&self) -> VersionReq {
         match &self.version {
             Some(v) => VersionReq::parse(v).unwrap(),
@@ -163,16 +215,19 @@ impl ProjectFileDependency {
     }
 }
 
-// The `git` field of the dependency.
+/// The `git` field of a dependency entry: the repository the project is cloned from, and the ref
+/// the clone is pinned to.
 #[derive(Deserialize, Serialize, Default, Clone, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFileDependencyGit {
-    // The URL of the git repository.
+    /// The URL of the git repository.
     pub url: String,
-    // The commit hash to pin to.
+    /// The commit hash the dependency is pinned to. At most one of `rev` and `tag` is written; with
+    /// neither, the version requirement of the entry picks a tag.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    // The tag name to pin to.
+    /// The tag name the dependency is pinned to. At most one of `rev` and `tag` is written; with
+    /// neither, the version requirement of the entry picks a tag.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
 }
@@ -195,27 +250,33 @@ impl ProjectFileDependencyGit {
     }
 }
 
-// Role of a loaded project file in the current build: the build's root, or a dependency
-// of another project. Populated by the loader (`read_root_file` /
-// `DependencyLockFileEntry::project_file`); not serialized into `fixproj.toml`.
+/// The place a loaded project file has in the current build, set by the loader that read the
+/// file.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub enum ProjectFileRole {
+    /// The project the build was started in, whose project file alone contributes the settings that
+    /// take one value across the whole build.
     #[default]
     Root,
+    /// A project another project of the build declares as a dependency.
     Dependent,
 }
 
-// Where a project comes from.
+/// Where a project comes from.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ProjectOrigin {
-    // Root project or a local-path dependency. Holds the absolute path of the project directory.
+    /// A project in the local file system, at the absolute path this variant holds: the root
+    /// project, or one a `path` dependency entry names.
     Local(PathBuf),
-    // Git dependency. Carries the repository URL and pinned commit hash from the lockfile.
+    /// A project cloned from a git repository, identified by the repository URL and the commit hash
+    /// the lock file pins the clone to.
     Git { url: String, commit: String },
 }
 
 impl ProjectOrigin {
-    // String form used as a stable key (e.g. for the trust store).
+    /// A string naming where the project comes from: the project directory for a local project, and
+    /// `git+` followed by the repository URL for a git one, so that every commit of one repository
+    /// shares a key.
     pub fn to_trust_key(&self) -> String {
         match self {
             ProjectOrigin::Local(p) => p.to_string_lossy().to_string(),
@@ -223,7 +284,7 @@ impl ProjectOrigin {
         }
     }
 
-    // Commit hash, if this project is pinned by one.
+    /// The commit hash a git project is pinned to.
     pub fn commit_hash(&self) -> Option<&str> {
         match self {
             ProjectOrigin::Local(_) => None,
@@ -232,40 +293,45 @@ impl ProjectOrigin {
     }
 }
 
-// The project file.
+/// A project file (`fixproj.toml`): what the project is, how it is built, what it depends on, and
+/// what the loader that read it knows about where it came from.
 #[derive(Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectFile {
-    // `general` section
+    /// The `general` section, holding the project's name and version.
     pub general: ProjectFileGeneral,
-    // `build` section
+    /// The `build` section, holding the settings a build reads.
     pub build: ProjectFileBuild,
-    // `dependencies` section
+    /// The `dependencies` entries: the projects every build of this one may use.
     #[serde(default)]
     pub dependencies: Vec<ProjectFileDependency>,
-    // `test_dependencies` section
+    /// The `test_dependencies` entries: the projects the test sources of this one may use, beside
+    /// the ones `dependencies` names.
     #[serde(default)]
     pub test_dependencies: Vec<ProjectFileDependency>,
-    // The path to the project file.
+    /// The path this file was read from. Every relative path the file writes is resolved against
+    /// the directory holding it.
     #[serde(skip)]
     pub path: PathBuf,
-    // Role of this project file in the current build.
+    /// The place this project has in the current build, set by the loader that read the file.
     #[serde(skip)]
     pub role: ProjectFileRole,
-    // Where this project came from. Used to tag `preliminary_commands` for trust-store lookup.
-    // `None` on a freshly deserialized `ProjectFile`; loaders must set this to `Some(...)` before the
-    // file is handed off for `set_config`.
+    /// Where this project came from. A freshly deserialized `ProjectFile` carries `None`, and the
+    /// loader that read the file fills it in before the file configures a build.
     #[serde(skip)]
     pub source: Option<ProjectOrigin>,
 }
 
 impl ProjectFile {
-    // Get dependencies based on mode.
+    /// The projects this project declares as dependencies for a build of the given mode. Their
+    /// names are distinct, since `validate` rejects a project file that declares one project twice.
+    ///
+    /// # Arguments
+    ///
+    /// * `mode` - `Test` also takes the entries of the `test_dependencies` section.
     pub fn get_dependencies(&self, mode: BuildConfigType) -> Vec<ProjectFileDependency> {
         match mode {
             BuildConfigType::Test => {
-                // Merge dependencies and test_dependencies
-                // Note: Duplicate check is already performed in validate()
                 let mut all_deps = self.dependencies.clone();
                 all_deps.extend(self.test_dependencies.clone());
                 all_deps
@@ -400,7 +466,13 @@ impl ProjectFile {
         Ok(())
     }
 
-    // Validate a single dependency entry.
+    /// Checks one dependency entry: its project name, that it names exactly one of `path` and
+    /// `git`, that its version requirement parses, and that a git entry pins at most one of `rev`
+    /// and `tag`.
+    ///
+    /// # Arguments
+    ///
+    /// * `span` - The place in the project file each error points at.
     fn validate_dependency_entry(dep: &ProjectFileDependency, span: Span) -> Result<(), Errors> {
         // Validate the project name.
         Self::validate_project_name(&dep.name, Some(span.clone()))?;
@@ -585,7 +657,9 @@ impl ProjectFile {
         errors.to_result()
     }
 
-    // Get the version requirement for the Fix compiler.
+    /// The compiler versions this project builds with, as its `fix_version` field requires. A
+    /// project file naming none builds with every version. Panics unless `validate` has accepted
+    /// the field.
     pub fn fix_version(&self) -> VersionReq {
         match &self.general.fix_version {
             Some(v) => VersionReq::parse(v).unwrap(),
@@ -593,7 +667,7 @@ impl ProjectFile {
         }
     }
 
-    // Check if the project file is compatible with the current version of Fix.
+    /// Checks that the running compiler's version satisfies what this project requires of it.
     pub fn is_fix_version_compatible(&self) -> Result<(), Errors> {
         if self
             .fix_version()
@@ -648,17 +722,14 @@ impl ProjectFile {
             .clone()
             .expect("ProjectFile::source must be set by the loader before set_config");
 
-        // Determine the build mode.
-        // If the project is a dependent project, we do not consider the `[build.test]` section.
+        // Determine the build mode. A dependent project contributes its `build` section alone.
         let mut mode = config.subcommand.build_mode();
         if is_dependent_proj {
             mode = BuildConfigType::Build;
         }
 
-        // Reject missing source files up front, pointing at the offending
-        // project-file entry. Otherwise the missing file surfaces later as a
-        // span-less "failed to canonicalize" error that editors cannot
-        // attach to any file.
+        // Reject missing source files up front, so that the error points at the project-file entry
+        // naming the file and an editor attaches it there.
         self.check_source_files_exist(mode)?;
 
         // Record what this project provides and what it declares, so that an import reaching past
@@ -678,12 +749,10 @@ impl ProjectFile {
             });
         }
 
-        // Append source files. Root-project files go through
-        // `add_user_source_file` so they also land in
-        // `root_source_files`, which scopes deprecation diagnostics to
-        // user code (mirroring rustc/swiftc: a deprecated use inside a
-        // dependency is the dependency's problem, not the user's).
-        // Dependent-project files are pushed to `source_files` only.
+        // Append source files. Root-project files go through `add_user_source_file` so they also
+        // land in `root_source_files`, which scopes deprecation diagnostics to the user's own code:
+        // a deprecated use inside a dependency is the dependency's problem. Dependent-project files
+        // are pushed to `source_files` only.
         let files = self.get_files(mode);
         if is_dependent_proj {
             config.source_files.extend(files);
@@ -994,7 +1063,7 @@ impl ProjectFile {
         Ok(lock_file)
     }
 
-    // Helper method to save lock file to disk.
+    /// Writes `lock_file` to the path a lock file of the given kind is read from.
     fn save_lock_file(lock_file: &DependecyLockFile, mode: LockFileType) -> Result<(), Errors> {
         let content = toml::to_string(lock_file)
             .map_err(|e| Errors::from_msg(format!("Failed to serialize lock file: {:?}", e)))?;
@@ -1004,7 +1073,8 @@ impl ProjectFile {
         Ok(())
     }
 
-    // Open the lock file or create a new one if it does not exist.
+    /// The lock file of the given kind. One that is missing or out of date is built afresh from
+    /// this project's dependency entries and written out.
     pub fn open_or_create_lock_file(
         &self,
         mode: LockFileType,
@@ -1019,9 +1089,9 @@ impl ProjectFile {
         })
     }
 
-    // Open the lock file, or automatically create/update it if it does not exist or is invalid, and install the dependencies.
-    // This method is designed for LSP to automatically manage lock files without user intervention.
-    // Returns error without panicking, allowing LSP to report diagnostics to the user.
+    /// The lock file of the given kind, with its dependencies installed. One that is missing or out
+    /// of date is built afresh and written out, creating the directory that holds it where that is
+    /// missing too, so that a project which has never been built reaches a lock file as well.
     pub fn open_or_auto_update_lock_file(
         &self,
         mode: LockFileType,
@@ -1054,13 +1124,17 @@ impl ProjectFile {
         }
     }
 
-    // Open the lock file, create a new one if it does not exist, and install the dependencies.
+    /// Installs the dependencies the lock file of the given kind pins, writing that lock file first
+    /// where the one on disk is missing or out of date.
     pub fn open_or_create_lock_file_and_install(&self, mode: LockFileType) -> Result<(), Errors> {
         self.open_or_create_lock_file(mode)
             .and_then(|lf| lf.install())
     }
 
-    // Update configuration by adding source files, linking libraries, ... as required by dependencies.
+    /// Adds what this project's dependencies contribute to `config`: their source files, the
+    /// libraries they link, and the rest of the settings their project files give. The dependencies
+    /// are installed first, and the lock file written where the one on disk is missing or out of
+    /// date.
     pub fn install_dependencies(
         self: &ProjectFile,
         config: &mut Configuration,
@@ -1079,13 +1153,19 @@ impl ProjectFile {
         Ok(())
     }
 
-    // Create span for a range in the project file.
+    /// The place in this project file a diagnostic points at.
+    ///
+    /// # Arguments
+    ///
+    /// * `start`, `end` - Byte offsets into the project file. `0, 0` points at its head, which is
+    ///   where a diagnostic with no finer place to point goes.
     fn project_file_span(&self, start: usize, end: usize) -> Span {
         let input = SourceFile::from_file_path(self.path.clone());
         Span { start, end, input }
     }
 
-    // Convert a relative path to an absolute path by joining it with the directory of the project file.
+    /// `path` resolved against the directory holding this project file. An absolute `path` is
+    /// returned as it is.
     fn join_to_project_dir(&self, path: &Path) -> PathBuf {
         if path.is_absolute() {
             return path.to_path_buf();
@@ -1098,9 +1178,10 @@ impl ProjectFile {
         }
     }
 
-    // Get the source of a dependent project.
+    /// Where the project named `name` is fetched from, as the `dependencies` and
+    /// `test_dependencies` entries of this project file say. Panics when no entry names the
+    /// project, or when the entry that does names no source.
     pub fn get_dependency_source(&self, name: &ProjectName) -> ProjectSource {
-        // Search in both dependencies and test_dependencies
         for dep in self
             .dependencies
             .iter()
@@ -1120,11 +1201,10 @@ impl ProjectFile {
         panic!("Project `{}` not found in dependencies.", name);
     }
 
-    // Creates an example project file in the current directory.
+    /// Creates a project file named after `proj_name`, a sample "main.fix" and a sample "test.fix"
+    /// in the current directory. An error is raised as soon as one of the three names is taken, and
+    /// the file that carries it is left as it is.
     pub fn create_example_file(proj_name: String) -> Result<(), Errors> {
-        // Create sample "fixproj.toml" file in the current directory.
-
-        // If the project file already exists, do not overwrite it.
         if Path::new(PROJECT_FILE_PATH).exists() {
             return Err(Errors::from_msg(format!(
                 "The file \"{}\" already exists.",
@@ -1134,10 +1214,10 @@ impl ProjectFile {
 
         let content = include_str!("../docs/project_template.toml");
 
-        // Replace `{PLACEHOLDER_PROJECT_NAME}` to `proj_name`.
+        // Replace `{PLACEHOLDER_PROJECT_NAME}` with `proj_name`.
         let content = content.replace("{PLACEHOLDER_PROJECT_NAME}", &proj_name);
 
-        // Replace `{PLACEHOLDER_FIX_VERSION}` to the current version of Fix.
+        // Replace `{PLACEHOLDER_FIX_VERSION}` with the current version of Fix.
         let content = content.replace("{PLACEHOLDER_FIX_VERSION}", env!("CARGO_PKG_VERSION"));
 
         fs::write(PROJECT_FILE_PATH, content).map_err(|e| {
@@ -1172,7 +1252,15 @@ impl ProjectFile {
         Ok(())
     }
 
-    // Add dependencies to Fix projects to the project file.
+    /// Appends a dependency entry for each project of `proj_vers` to this project file, taking the
+    /// repository of each from the registries `fix_config` names.
+    ///
+    /// # Arguments
+    ///
+    /// * `proj_vers` - Each is `proj-name` or `proj-name@ver_req`. A name written without a version
+    ///   requirement takes the latest tagged version of the project.
+    /// * `mode` - `Build` writes `[[dependencies]]` entries, `Test` writes `[[test_dependencies]]`
+    ///   ones.
     pub fn add_dependencies(
         &self,
         proj_vers: &Vec<String>,
@@ -1181,7 +1269,7 @@ impl ProjectFile {
     ) -> Result<(), Errors> {
         let mut added = "".to_string();
 
-        // Parse each element of `proj_vars` as the form `proj-name@ver_req`.
+        // Parse each element of `proj_vers` as the form `proj-name@ver_req`.
         let mut projs: Vec<(String, Option<String>)> = vec![]; // (proj_name, ver_str)
         for proj_ver in proj_vers {
             let proj_ver_split = proj_ver.split('@').collect::<Vec<&str>>();

--- a/src/metafiles/project_file.rs
+++ b/src/metafiles/project_file.rs
@@ -432,8 +432,8 @@ impl ProjectFile {
         // This ensures that when a local path dependency changes its own dependencies,
         // the lock file is invalidated and re-created.
         for dep in &deps {
-            if let Some(path) = &dep.path {
-                let proj_file_path = self.join_to_project_dir(path).join(PROJECT_FILE_PATH);
+            if let Some(dep_dir) = &dep.path {
+                let proj_file_path = self.join_to_project_dir(dep_dir).join(PROJECT_FILE_PATH);
                 if let Ok(content) = fs::read_to_string(&proj_file_path) {
                     hash_source += &content;
                 }
@@ -717,7 +717,7 @@ impl ProjectFile {
     /// before this is called.
     pub fn set_config(&self, config: &mut Configuration) -> Result<(), Errors> {
         let is_dependent_proj = self.role == ProjectFileRole::Dependent;
-        let source = self
+        let project_origin = self
             .source
             .clone()
             .expect("ProjectFile::source must be set by the loader before set_config");
@@ -862,7 +862,7 @@ impl ProjectFile {
                 command: command.clone(),
                 project_name: project_name.clone(),
                 mode: PreliminaryCommandMode::Build,
-                source: source.clone(),
+                source: project_origin.clone(),
             });
         }
         if mode == BuildConfigType::Test {
@@ -877,7 +877,7 @@ impl ProjectFile {
                     command: command.clone(),
                     project_name: project_name.clone(),
                     mode: PreliminaryCommandMode::Test,
-                    source: source.clone(),
+                    source: project_origin.clone(),
                 });
             }
         }
@@ -1190,8 +1190,8 @@ impl ProjectFile {
             if &dep.name != name {
                 continue;
             }
-            if let Some(path) = &dep.path {
-                return ProjectSource::Local(self.join_to_project_dir(path));
+            if let Some(dep_dir) = &dep.path {
+                return ProjectSource::Local(self.join_to_project_dir(dep_dir));
             }
             if let Some(git) = &dep.git {
                 return ProjectSource::Git(git.url.clone(), None);
@@ -1252,56 +1252,56 @@ impl ProjectFile {
         Ok(())
     }
 
-    /// Appends a dependency entry for each project of `proj_vers` to this project file, taking the
+    /// Appends a dependency entry for each project of `proj_specs` to this project file, taking the
     /// repository of each from the registries `fix_config` names.
     ///
     /// # Arguments
     ///
-    /// * `proj_vers` - Each is `proj-name` or `proj-name@ver_req`. A name written without a version
-    ///   requirement takes the latest tagged version of the project.
+    /// * `proj_specs` - Each is `proj-name` or `proj-name@ver_req`. A name written without a
+    ///   version requirement takes the latest tagged version of the project.
     /// * `mode` - `Build` writes `[[dependencies]]` entries, `Test` writes `[[test_dependencies]]`
     ///   ones.
     pub fn add_dependencies(
         &self,
-        proj_vers: &Vec<String>,
+        proj_specs: &Vec<String>,
         fix_config: &ConfigFile,
         mode: BuildConfigType,
     ) -> Result<(), Errors> {
-        let mut added = "".to_string();
+        let mut added_toml = "".to_string();
 
-        // Parse each element of `proj_vers` as the form `proj-name@ver_req`.
-        let mut projs: Vec<(String, Option<String>)> = vec![]; // (proj_name, ver_str)
-        for proj_ver in proj_vers {
-            let proj_ver_split = proj_ver.split('@').collect::<Vec<&str>>();
-            if proj_ver_split.len() == 0 || proj_ver_split.len() > 2 {
+        // Parse each element of `proj_specs` as the form `proj-name@ver_req`.
+        let mut proj_ver_reqs: Vec<(String, Option<String>)> = vec![]; // (proj_name, ver_req)
+        for proj_spec in proj_specs {
+            let proj_spec_parts = proj_spec.split('@').collect::<Vec<&str>>();
+            if proj_spec_parts.len() == 0 || proj_spec_parts.len() > 2 {
                 return Err(Errors::from_msg(format!(
                     "Invalid project specification: \"{}\". It should be in the form \"proj-name\" or \"proj-name@ver_req\"",
-                    proj_ver
+                    proj_spec
                 )));
             }
-            let proj_name = proj_ver_split[0];
+            let proj_name = proj_spec_parts[0];
             ProjectFile::validate_project_name(&proj_name.to_string(), None)?;
-            let version = if proj_ver_split.len() == 2 {
-                let _ = VersionReq::parse(proj_ver_split[1]).map_err(|e| {
+            let version = if proj_spec_parts.len() == 2 {
+                let _ = VersionReq::parse(proj_spec_parts[1]).map_err(|e| {
                     Errors::from_msg(format!(
                         "Failed to parse version requirement in \"{}\": {:?}",
-                        proj_ver, e
+                        proj_spec, e
                     ))
                 })?;
-                Some(proj_ver_split[1].to_string())
+                Some(proj_spec_parts[1].to_string())
             } else {
                 None
             };
-            projs.push((proj_name.to_string(), version));
+            proj_ver_reqs.push((proj_name.to_string(), version));
         }
 
         // Check if dependencies to the same project are specified multiple times.
-        for i in 0..projs.len() {
-            for j in i + 1..projs.len() {
-                if projs[i].0 == projs[j].0 {
+        for i in 0..proj_ver_reqs.len() {
+            for j in i + 1..proj_ver_reqs.len() {
+                if proj_ver_reqs[i].0 == proj_ver_reqs[j].0 {
                     return Err(Errors::from_msg(format!(
                         "The project \"{}\" is specified multiple times.",
-                        projs[i].0
+                        proj_ver_reqs[i].0
                     )));
                 }
             }
@@ -1309,8 +1309,8 @@ impl ProjectFile {
 
         // Check if the project file already has the dependencies.
         let existing_deps = self.get_dependencies(mode);
-        for proj in &projs {
-            let proj_name = &proj.0;
+        for proj_ver_req in &proj_ver_reqs {
+            let proj_name = &proj_ver_req.0;
             if existing_deps.iter().any(|dep| &dep.name == proj_name) {
                 return Err(Errors::from_msg(format!(
                     "The project file already has a dependency on \"{}\".",
@@ -1325,8 +1325,8 @@ impl ProjectFile {
 
             // For each project to be added, search it in the registry file.
             let mut added_indices = Set::default();
-            for (i, proj) in projs.iter().enumerate() {
-                let (proj_name, version) = proj;
+            for (proj_idx, proj_ver_req) in proj_ver_reqs.iter().enumerate() {
+                let (proj_name, version) = proj_ver_req;
                 if let Some(proj_info) = reg_file
                     .projects
                     .iter()
@@ -1343,19 +1343,19 @@ impl ProjectFile {
                         Some(v) => v.clone(),
                         None => {
                             let (_tmp_dir, repo) = clone_git_repo(&proj_info.git)?;
-                            let vers = get_versions_from_repo(&repo)?;
-                            let mut tagged_vers = vers
+                            let version_infos = get_versions_from_repo(&repo)?;
+                            let mut tagged_versions = version_infos
                                 .iter()
-                                .filter_map(|vi| {
-                                    if vi.tagged {
-                                        Some(vi.version.clone())
+                                .filter_map(|version_info| {
+                                    if version_info.tagged {
+                                        Some(version_info.version.clone())
                                     } else {
                                         None
                                     }
                                 })
                                 .collect::<Vec<_>>();
-                            tagged_vers.sort();
-                            if tagged_vers.is_empty() {
+                            tagged_versions.sort();
+                            if tagged_versions.is_empty() {
                                 warn_msg(&format!(
                                     "Adding version requirement \"*\" for \"{}\" since there are no tagged versions. \
                                     This means that updating the lock file (which is done by `fix deps add` or `fix deps update`) may introduce breaking changes.",
@@ -1363,7 +1363,7 @@ impl ProjectFile {
                                 ));
                                 "*".to_string()
                             } else {
-                                let latest = tagged_vers.pop().unwrap();
+                                let latest = tagged_versions.pop().unwrap();
                                 let latest =
                                     format!("{}.{}.{}", latest.major, latest.minor, latest.patch);
                                 info_msg(&format!(
@@ -1379,35 +1379,35 @@ impl ProjectFile {
                         BuildConfigType::Build => "[[dependencies]]",
                         BuildConfigType::Test => "[[test_dependencies]]",
                     };
-                    added += "\n\n";
-                    added += section_name;
-                    added += &format!("\nname = \"{}\"", proj_name);
-                    added += &format!("\nversion = \"{}\"", version);
-                    added += &format!("\ngit = {{ url = \"{}\" }}", proj_info.git);
+                    added_toml += "\n\n";
+                    added_toml += section_name;
+                    added_toml += &format!("\nname = \"{}\"", proj_name);
+                    added_toml += &format!("\nversion = \"{}\"", version);
+                    added_toml += &format!("\ngit = {{ url = \"{}\" }}", proj_info.git);
 
-                    added_indices.insert(i);
+                    added_indices.insert(proj_idx);
                 }
             }
 
             // Remove the projects that have been added.
-            projs = projs
+            proj_ver_reqs = proj_ver_reqs
                 .into_iter()
                 .enumerate()
-                .filter_map(|(i, v)| {
-                    if added_indices.contains(&i) {
+                .filter_map(|(proj_idx, proj_ver_req)| {
+                    if added_indices.contains(&proj_idx) {
                         None
                     } else {
-                        Some(v)
+                        Some(proj_ver_req)
                     }
                 })
                 .collect();
         }
 
         // Check if all the projects have been added.
-        for proj in projs {
+        for proj_ver_req in proj_ver_reqs {
             return Err(Errors::from_msg(format!(
                 "The project \"{}\" is not found in the registries.",
-                proj.0
+                proj_ver_req.0
             )));
         }
 
@@ -1422,7 +1422,7 @@ impl ProjectFile {
                     e
                 ))
             })?;
-        file.write_all(added.as_bytes()).map_err(|e| {
+        file.write_all(added_toml.as_bytes()).map_err(|e| {
             Errors::from_msg(format!(
                 "Failed to write to file \"{}\": {:?}",
                 self.path.to_string_lossy().to_string(),

--- a/src/tests/test_dependencies.rs
+++ b/src/tests/test_dependencies.rs
@@ -1,6 +1,5 @@
-// ==================== Integration Tests ====================
-// These tests use actual Fix projects in src/tests/test_dependencies/cases/
-
+/// Tests that run the `fix` command over the Fix projects kept in
+/// `src/tests/test_dependencies/cases`.
 #[cfg(test)]
 mod integration_tests {
     use crate::constants::{LOCK_FILE_PATH, LOCK_FILE_TEST_PATH};
@@ -8,7 +7,8 @@ mod integration_tests {
     use std::{fs, path::PathBuf, process::Output};
     use tempfile::TempDir;
 
-    // Get the path to the test cases directory
+    /// The directory holding the test-case projects in the repository. A test copies it out and
+    /// runs in the copy, so what it holds stays as it is.
     fn get_test_cases_dir() -> PathBuf {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("src/tests/test_dependencies/cases");
@@ -52,21 +52,19 @@ mod integration_tests {
         run_case(project_path, "build")
     }
 
-    // Clean up lock files and build artifacts before running test
+    /// Removes the lock files and the build artifacts of the project at `project_dir`, so that the
+    /// run that follows starts from a project that has never been built.
     fn cleanup_test_project(project_dir: &PathBuf) {
         let _ = fs::remove_file(project_dir.join(LOCK_FILE_PATH));
         let _ = fs::remove_file(project_dir.join(LOCK_FILE_TEST_PATH));
         let _ = fix_command().arg("clean").current_dir(project_dir).output();
     }
 
+    /// A build writes `fixdeps.lock` alone, and locks the ordinary dependencies alone: the test
+    /// dependencies of the project and the test dependencies of the projects it depends on both
+    /// stay out of the lock file.
     #[test]
     fn test_dependencies_build_mode() {
-        // This test verifies that in build mode:
-        // 1. Only fixdeps.lock is created
-        // 2. fixdeps.test.lock is NOT created
-        // 3. Only normal dependencies are included
-        // 4. Test dependencies of normal dependencies are NOT included
-
         let (_temp_dir, project_dir) = setup_case_env("dependencies_for_test/main_project");
         cleanup_test_project(&project_dir);
 
@@ -116,14 +114,12 @@ mod integration_tests {
         );
     }
 
+    /// `fix test` writes `fixdeps.test.lock` on its own when the project has none, and the test it
+    /// then runs reaches the test dependencies that lock file names. `test-dep` is locked because
+    /// the main project declares it as a test dependency; the test dependencies of `normal-dep`
+    /// stay out.
     #[test]
     fn test_dependencies_test_mode() {
-        // This test verifies that `fix test` automatically handles test dependencies:
-        // 1. fixdeps.test.lock is created if not present
-        // 2. Test dependencies are properly available during test execution
-        // Note: test-dep appears in fixdeps.test.lock because main-project directly depends on it,
-        // not because normal-dep has it as a test dependency (dependency's test dependencies don't propagate)
-
         let (_temp_dir, project_dir) = setup_case_env("dependencies_for_test/main_project");
         cleanup_test_project(&project_dir);
 
@@ -178,11 +174,11 @@ mod integration_tests {
         );
     }
 
+    /// Spelling the steps of a build out as `fix deps update`, `fix deps install` and `fix build`
+    /// locks the ordinary dependencies alone: `fix deps update` without `--test` writes
+    /// `fixdeps.lock` alone, and `test-dep` stays out of it.
     #[test]
     fn test_dependencies_build_workflow() {
-        // This test verifies the explicit build workflow:
-        // `fix deps update` → `fix deps install` → `fix build`
-
         let (_temp_dir, project_dir) = setup_case_env("dependencies_for_test/main_project");
         cleanup_test_project(&project_dir);
 
@@ -260,11 +256,11 @@ mod integration_tests {
         );
     }
 
+    /// Spelling the steps of a test run out as `fix deps update --test`, `fix deps install --test`
+    /// and `fix test` locks the ordinary and the test dependencies together: `--test` writes
+    /// `fixdeps.test.lock` alone, and the test the run then executes passes.
     #[test]
     fn test_dependencies_test_workflow() {
-        // This test verifies the explicit test workflow:
-        // `fix deps update --test` → `fix deps install --test` → `fix test`
-
         let (_temp_dir, project_dir) = setup_case_env("dependencies_for_test/main_project");
         cleanup_test_project(&project_dir);
 

--- a/src/tests/test_dependencies.rs
+++ b/src/tests/test_dependencies.rs
@@ -84,21 +84,21 @@ mod integration_tests {
         }
 
         // Verify fixdeps.lock exists
-        let lock_file = project_dir.join(LOCK_FILE_PATH);
+        let lock_file_path = project_dir.join(LOCK_FILE_PATH);
         assert!(
-            lock_file.exists(),
+            lock_file_path.exists(),
             "fixdeps.lock should be created in build mode"
         );
 
         // Verify fixdeps.test.lock does NOT exist
-        let test_lock_file = project_dir.join(LOCK_FILE_TEST_PATH);
+        let test_lock_file_path = project_dir.join(LOCK_FILE_TEST_PATH);
         assert!(
-            !test_lock_file.exists(),
+            !test_lock_file_path.exists(),
             "fixdeps.test.lock should NOT be created in build mode"
         );
 
         // Read and verify lock file contents
-        let lock_content = fs::read_to_string(&lock_file).expect("Failed to read lock file");
+        let lock_content = fs::read_to_string(&lock_file_path).expect("Failed to read lock file");
 
         // Check that normal-dep is included
         assert!(
@@ -139,22 +139,22 @@ mod integration_tests {
         }
 
         // Verify fixdeps.test.lock was created
-        let test_lock_file = project_dir.join(LOCK_FILE_TEST_PATH);
+        let test_lock_file_path = project_dir.join(LOCK_FILE_TEST_PATH);
         assert!(
-            test_lock_file.exists(),
+            test_lock_file_path.exists(),
             "fixdeps.test.lock should be created by `fix test`"
         );
 
         // Verify fixdeps.lock was NOT created
-        let lock_file = project_dir.join(LOCK_FILE_PATH);
+        let lock_file_path = project_dir.join(LOCK_FILE_PATH);
         assert!(
-            !lock_file.exists(),
+            !lock_file_path.exists(),
             "fixdeps.lock should NOT be created by `fix test`"
         );
 
         // Read and verify test lock file contents
         let test_lock_content =
-            fs::read_to_string(&test_lock_file).expect("Failed to read test lock file");
+            fs::read_to_string(&test_lock_file_path).expect("Failed to read test lock file");
 
         // Check that both dependencies are included in test lock file
         assert!(
@@ -197,16 +197,16 @@ mod integration_tests {
         }
 
         // Verify fixdeps.lock was created
-        let lock_file = project_dir.join(LOCK_FILE_PATH);
+        let lock_file_path = project_dir.join(LOCK_FILE_PATH);
         assert!(
-            lock_file.exists(),
+            lock_file_path.exists(),
             "fixdeps.lock should be created by `fix deps update`"
         );
 
         // Verify fixdeps.test.lock was NOT created
-        let test_lock_file = project_dir.join(LOCK_FILE_TEST_PATH);
+        let test_lock_file_path = project_dir.join(LOCK_FILE_TEST_PATH);
         assert!(
-            !test_lock_file.exists(),
+            !test_lock_file_path.exists(),
             "fixdeps.test.lock should NOT be created by `fix deps update` (without --test)"
         );
 
@@ -245,7 +245,7 @@ mod integration_tests {
         }
 
         // Verify lock file contents
-        let lock_content = fs::read_to_string(&lock_file).expect("Failed to read lock file");
+        let lock_content = fs::read_to_string(&lock_file_path).expect("Failed to read lock file");
         assert!(
             lock_content.contains("normal-dep"),
             "Lock file should contain normal-dep"
@@ -279,16 +279,16 @@ mod integration_tests {
         }
 
         // Verify fixdeps.test.lock was created
-        let test_lock_file = project_dir.join(LOCK_FILE_TEST_PATH);
+        let test_lock_file_path = project_dir.join(LOCK_FILE_TEST_PATH);
         assert!(
-            test_lock_file.exists(),
+            test_lock_file_path.exists(),
             "fixdeps.test.lock should be created by `fix deps update --test`"
         );
 
         // Verify fixdeps.lock was NOT created
-        let lock_file = project_dir.join(LOCK_FILE_PATH);
+        let lock_file_path = project_dir.join(LOCK_FILE_PATH);
         assert!(
-            !lock_file.exists(),
+            !lock_file_path.exists(),
             "fixdeps.lock should NOT be created by `fix deps update --test`"
         );
 
@@ -328,7 +328,7 @@ mod integration_tests {
 
         // Verify test lock file contents
         let test_lock_content =
-            fs::read_to_string(&test_lock_file).expect("Failed to read test lock file");
+            fs::read_to_string(&test_lock_file_path).expect("Failed to read test lock file");
         assert!(
             test_lock_content.contains("normal-dep"),
             "Test lock file should contain normal-dep"


### PR DESCRIPTION
レビューが、変更のまわり (触ったファイルの、差分の外) に見つけた分の掃除。振る舞いは変わらない。

対象は 4 ファイル: `src/metafiles/project_file.rs`、`src/elaboration/mod.rs`、`src/error.rs`、`src/tests/test_dependencies.rs`。`src/ast/program.rs` と `src/configuration.rs` は同じ種類の指摘が数十件あり、変更が触ったのはそのごく一部なので、掃除には入れず本文末尾に一覧として置く。

## コメントとドキュメント

### 書かれていなかった doc コメントを書いた

`src/metafiles/project_file.rs` は、プロジェクトファイルの各節を表す型 (`ProjectFileGeneral` / `ProjectFileBuild` / `ProjectFileBuildTest` / `ProjectFileDependency` / `ProjectFileDependencyGit`) とそのフィールド、`ProjectFileRole` / `ProjectOrigin` とその variant、そしてメソッド 15 個が、`///` を持っていなかった (多くは `//` の 1 行)。プロジェクトファイルは利用者が書く TOML であり、フィールド 1 つが利用者から見える設定 1 つなので、そこに意味が書かれていないと、読み手は `set_config` の本体を追って初めて設定の効き方を知ることになる。

各フィールドには、名前と型が言わないことを書いた。例:

- `static_links` / `dynamic_links` — リンカの `-l` と同じ綴りであること (`"abc"` が `libabc.a` を指す)。
- `library_paths` — プロジェクトディレクトリを基準に解決されること。
- `disable_cpu_features` — 正規表現であること (`"avx512.*"` が名前の一致する機能を全部落とす)。
- `[build.test]` の各フィールド — `build` 側との合成のしかた (ファイルは足される、`opt_level` は置き換える、など)。

### 呼び出し側の列挙・経緯・否定形を落とした

- `ProjectFileRole` / `ProjectOrigin::to_trust_key` / `ProjectFile::source` / `open_or_auto_update_lock_file` の doc が、誰がその値を書くか・誰が読むかを挙げていた。挙げた側が増えるたびに古くなる書き方なので、その値が何であるかに書き直した。
- `get_dependencies` の本文にあった「重複検査は `validate()` で済んでいる」という注記を、関数の契約の側へ移した。
- `set_config` の本文にあった「そうしないと後で別の形の誤りとして出る」「rustc/swiftc に倣って」という但し書きを落とした。
- `elaborate` の「型注釈の型変数の kind は、この段ではなく型推論の段で決まる」を、決まる場所を述べる形にした。
- `Errors::take_warnings` と `Error::severity` の doc が、使い道と兄弟のコンストラクタを指していたので、その値が何であるかに書き直した。
- `panic_notrace` の本文にあった、直上の doc と同じことを言うコメントを落とした。

### 綴りと途中で切れた文を直した

`load_source_files` の "occurres" (2 か所)、"eny"、および "If an error occurres in parsing," で終わっている文。

## 名前

局所束縛だけを改名した (項目名は本文末尾の一覧に置く)。

- `src/elaboration/mod.rs` — `parse_file_path` が返すのは `Program` なので、`modules` / `mod_` / `dependency_modules` を `parsed_programs` / `parsed_program` / `dependency_programs` に。モジュール名の列を持つ `mods` / `modules` / `all_modules` は `..._module_names` に。
- `src/error.rs` — 組み込み型名を覆っていた `str` を `rendered` に。`map` / `res` を `errs_by_path` に。`Error::from_msg_srcs` で 2 段に重なっていた `x` を `span_opt` / `span` に。
- `src/metafiles/project_file.rs` — `set_config` の `source` を `project_origin` に (このファイルの `source_file_entries` / `config.source_files` の「ソースファイル」と語が衝突していた)。`add_dependencies` の `proj_vers` / `proj_ver` は要素が `name` または `name@ver_req` なので `proj_specs` / `proj_spec` に (本文のエラーが既に "project specification" と呼んでいる)。ほか `added` -> `added_toml`、`i` -> `proj_idx`、`vers` -> `version_infos`、`path` -> `dep_dir`。
- `src/tests/test_dependencies.rs` — `PathBuf` を持つ `lock_file` / `test_lock_file` を `..._path` に。

## なぜ振る舞いが変わらないか

編集はコメント・doc コメントと、関数 1 つの中で閉じた局所束縛の改名だけである。公開する項目の名前、シグネチャ、制御の流れには触れていない。`cargo check --tests` と `cargo fmt --check` が通り、`cargo test --release tests::test_dependencies` が 10 件すべて通る。

## 付録: 作者に残した指摘

掃除に入れなかったもの。項目名の変更は利用者や呼び出し側に波及するので判断を仰ぐ。

### 名前 (項目名なので未変更)

- `Errors` / `errs` — doc 自身が "errors and warnings together" と述べ、`has_error()` と `has_diagnostics()` が並ぶ。この変更で警告も載るようになった。`Diagnostics` / `diagnostics` が候補。波及は crate 全体。
- `Errors::to_result` — `to_` は受け手を残す変換を約束するが、この関数は `mem::replace` で空にする。隣の同じ働きの関数は `take_warnings` と名乗る。
- `Errors::to_string` / `Error::to_string` — `ToString::to_string` を覆う inherent method で、`Display for Errors` はその inherent 側を呼ぶ。`render` が候補。
- `ProjectFileRole::Dependent` — doc は「他のプロジェクトが依存として宣言したプロジェクト」と述べており、辺の向きが名前と逆。`Dependency` が候補。
- `ProjectFile::source` / `PreliminaryCommand::source` — 型は `ProjectOrigin`。`origin` にすれば、このファイルの「ソースファイル」語彙との衝突が消える。
- `ProjectFileDependency::version() -> VersionReq` — 隣の `ProjectFileGeneral::version() -> Version` と同名で、片方は版、片方は版要求。`version_req` が候補。
- `set_config` — 実際には `Configuration` へ自分の分を足す関数 (複数のプロジェクトが順に呼ぶ)。
- `DependecyLockFile` — 綴り誤り。
- `no_runtime_check` — 否定形の bool。TOML のキー名でもあるので、変えるならプロジェクトファイルの形式変更になる。
- `get_` 接頭辞が、同じ impl の中で付くものと付かないものに割れている (`get_files` / `source_file_entries`)。

### `src/ast/program.rs` と `src/configuration.rs` に残る同種の指摘

どちらも変更が触ったのは一部で、同じ種類の指摘が数十件ある。掃除の範囲に入れると、この pull request が変更本体より大きくなるため外した。

- `program.rs`: doc の無い項目が約 25 (`Program` のメソッド群と `enum EndNode` とその variant)。呼び出し側の列挙、却下案の記録、否定形の説明、`HashSet` と書きながら `Set` を使う記述、`check_imports` の存在しないフィールドを指すコメント。
- `configuration.rs`: 却下した案と未解決の問いを書いた `ValgrindTool` の本文、消費者を名指しする定数の doc、`FixOptimizationLevel` の variant 4 つの `//`。

### 既存の不具合 (このレビューの外)

`ProjectFile::create_example_file` は `fixproj.toml` を書いてから `main.fix` / `test.fix` の不在を確かめるので、`main.fix` が既にあるディレクトリで `fix init` すると、書いたばかりの `fixproj.toml` を残したまま失敗する。
