### PR TITLE
忙しい機械でもサイクル数を残す

### DIFF
--- a/benchmark/crosslang/perf.sh
+++ b/benchmark/crosslang/perf.sh
@@ -22,8 +22,7 @@ for name in $(comparable_cases); do
         binary="bin/${name}_${lang}"
         [ -x "$binary" ] || { echo "no $binary -- run build.sh first" >&2; exit 1; }
         out=$(python3 "$COUNTERS" "$binary") || { echo "  $name $lang: unavailable"; continue; }
-        # splits,cycles,contention
-        rest=${out#*,}
-        printf "  %-14s %-5s %14s %14s\n" "$name" "$lang" "${out%%,*}" "${rest%%,*}"
+        IFS=, read -r splits cycles _contention <<<"$out"
+        printf "  %-14s %-5s %14s %14s\n" "$name" "$lang" "$splits" "$cycles"
     done
 done

--- a/benchmark/crosslang/perf.sh
+++ b/benchmark/crosslang/perf.sh
@@ -22,6 +22,8 @@ for name in $(comparable_cases); do
         binary="bin/${name}_${lang}"
         [ -x "$binary" ] || { echo "no $binary -- run build.sh first" >&2; exit 1; }
         out=$(python3 "$COUNTERS" "$binary") || { echo "  $name $lang: unavailable"; continue; }
-        printf "  %-14s %-5s %14s %14s\n" "$name" "$lang" "${out%%,*}" "${out##*,}"
+        # splits,cycles,contention
+        rest=${out#*,}
+        printf "  %-14s %-5s %14s %14s\n" "$name" "$lang" "${out%%,*}" "${rest%%,*}"
     done
 done

--- a/benchmark/speedtest/cachegrind-benchmarking/cachegrind.py
+++ b/benchmark/speedtest/cachegrind-benchmarking/cachegrind.py
@@ -138,4 +138,7 @@ if __name__ == "__main__":
     counts = get_counts(run_with_cachegrind(sys.argv[1:]))
     instructions = counts["Ir"]
     memory_accesses = combined_instruction_estimate(counts)
-    print(f"{instructions},{memory_accesses}")
+    # The accesses that reached main memory are printed on their own beside the combined
+    # estimate that folds them in, because they decide something the estimate cannot express:
+    # whether another program running beside this one can change how long it takes.
+    print(f"{instructions},{memory_accesses},{counts['ram']}")

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -46,9 +46,9 @@ METRICS = [
      "several windows of runs. This is the only column here that is not deterministic. Other work "
      "reaches it two ways: over the core the run shares with the thread beside it, which the "
      "harness pins for and watches, and over the cache every core shares, which costs a program in "
-     "proportion to how much of its data comes from main memory. A window either could have moved "
-     "leaves the cell empty, so the series has gaps; the contention figure beside each commit says "
-     "how much of the machine the run had.",
+     "proportion to how much of its data comes from main memory. Where either of them could have "
+     "moved a reading, the cell is left empty, so the series has gaps; the contention figure beside "
+     "each commit says how much of the machine the run had.",
      "ratio", "perf"),
     ("splits", "perf splits",
      "Loads and stores that crossed a cache-line boundary, from the hardware counters. Cachegrind's "

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -37,12 +37,18 @@ METRICS = [
     ("mem", "Cachegrind memory",
      "Weighted memory-access estimate from cachegrind's cache model (l1 + 5*l3 + 35*ram).",
      "ratio", "cachegrind"),
+    ("ram", "Cachegrind main-memory accesses",
+     "Accesses that reached main memory, from cachegrind's cache model. The same program and input "
+     "give the same number on any machine, and it is what decides whether that program's cycle "
+     "count survives a machine with other work on it.", "ratio", "cachegrind"),
     ("cycles", "perf cycles",
      "Core cycles the program spent in user mode, from the hardware counters, as the lowest of "
-     "several runs. This is the only column here that is not deterministic: it rises with whatever "
-     "else the machine is doing, so it is read only on runs taken while the machine is free and the "
-     "series is sparse. Two points are comparable only when the machine had CPU to spare for "
-     "both, which is what the contention figure beside each commit says.",
+     "several windows of runs. This is the only column here that is not deterministic. Other work "
+     "reaches it two ways: over the core the run shares with the thread beside it, which the "
+     "harness pins for and watches, and over the cache every core shares, which costs a program in "
+     "proportion to how much of its data comes from main memory. A window either could have moved "
+     "leaves the cell empty, so the series has gaps; the contention figure beside each commit says "
+     "how much of the machine the run had.",
      "ratio", "perf"),
     ("splits", "perf splits",
      "Loads and stores that crossed a cache-line boundary, from the hardware counters. Cachegrind's "
@@ -161,9 +167,10 @@ def self_check():
     with tempfile.TemporaryDirectory() as tmp:
         log = Path(tmp) / "log.csv"
         log.write_text(
-            "commit,cpu,contention,a-inst,a-mem,a-splits,a-cycles,b-inst,a-inst-c,a-inst-rust\n"
-            "1111111111111111111111111111111111111111,Zen,0.10,100,200,4,7,50,90,\n"
-            "2222222222222222222222222222222222222222(dirty),Zen,,150,,0,,,90,120\n",
+            "commit,cpu,contention,a-inst,a-mem,a-ram,a-splits,a-cycles,b-inst,a-inst-c,"
+            "a-inst-rust\n"
+            "1111111111111111111111111111111111111111,Zen,0.10,100,200,3,4,7,50,90,\n"
+            "2222222222222222222222222222222222222222(dirty),Zen,,150,,5,0,,,90,120\n",
             encoding="utf-8",
         )
         history = Path(tmp) / "history.md"
@@ -179,7 +186,8 @@ def self_check():
     assert series["inst"] == {"a": [100, 150], "b": [50, None]}, series["inst"]
     assert series["mem"] == {"a": [200, None]}, series["mem"]
     assert series["splits"] == {"a": [4, 0]}, series["splits"]
-    # Cycles are read only on the runs taken while the machine was free, so the series has gaps.
+    assert series["ram"] == {"a": [3, 5]}, series["ram"]
+    # A cycle count other work could have moved leaves its cell empty, so the series has gaps.
     assert series["cycles"] == {"a": [7, None]}, series["cycles"]
     assert data["metrics"]["splits"]["kind"] == "absolute"
     assert data["metrics"]["inst"]["refs"] == {"a": {"c": 90, "rust": 120}}, data["metrics"]["inst"]["refs"]

--- a/benchmark/speedtest/history.md
+++ b/benchmark/speedtest/history.md
@@ -10,6 +10,14 @@ of instructions on every case. The measured command now runs with a fixed minima
 the `startup` case records what a program that does nothing costs, so a row says how much of each
 figure was there before any of the work.
 
+**A cycle count no longer waits for an idle machine, and the rows read the new way stay
+comparable with the rows below them.** The count is taken from the windows of runs that the other
+thread of the measurement's core stayed out of, and it is kept for a case whose data does not come
+from main memory often enough for another program to take the cache from it. The same C
+counterpart, byte for byte, read 203,745,780 cycles under 11 cores of other work and 203,299,270
+with the machine to itself, a difference of 0.22%. The `-ram` columns carry the main-memory
+accesses the second condition reads.
+
 **The split columns are comparable from `b2de6116d89ff9d43449c2a12fe5c29dd1304bb4` down, and not
 across it.** The counters were read with whatever environment the harness inherited until that row,
 and a split count moves with the environment for the reason given there.

--- a/benchmark/speedtest/history.md
+++ b/benchmark/speedtest/history.md
@@ -16,7 +16,7 @@ thread of the measurement's core stayed out of, and it is kept for a case whose 
 from main memory often enough for another program to take the cache from it. The same C
 counterpart, byte for byte, read 203,745,780 cycles under 11 cores of other work and 203,299,270
 with the machine to itself, a difference of 0.22%. The `-ram` columns carry the main-memory
-accesses the second condition reads.
+accesses the cache condition reads.
 
 **The split columns are comparable from `b2de6116d89ff9d43449c2a12fe5c29dd1304bb4` down, and not
 across it.** The counters were read with whatever environment the harness inherited until that row,

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -11,10 +11,10 @@ _LOG_FILE_PATH = "log.csv";
 _COMMIT_HASH : String;
 _COMMIT_HASH = "commit";
 
-// How many times each program is run for the hardware counters. The cycle count reported is
-// the lowest of them, and a run the machine disturbed only ever raises it.
-_REPEAT : String;
-_REPEAT = "5";
+// How many windows of runs the hardware counters are read over. The cycle count reported is the
+// lowest reading of them all, and a run the machine disturbed only ever raises it.
+_WINDOWS : String;
+_WINDOWS = "5";
 
 // The languages a case may carry a counterpart in, as a `ref.*` source beside its `main.fix`.
 _REFERENCE_LANGUAGES : Array String;
@@ -239,7 +239,7 @@ main = (
         // where it does not hold. The `contention` column says how much of the machine the run
         // that produced this row had.
         // On a machine without the counters both columns stay empty and the run carries on.
-        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--repeat", _REPEAT,
+        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--windows", _WINDOWS,
             "--dram-accesses", bench.@(2), "--instructions", bench.@(0),
             "./a.out"].ez_run_oec(config);
         let (log, case_contention) = if perf_code != 0_U8 { (log, 0.0) } else {
@@ -258,7 +258,7 @@ main = (
         // holds these out of the cost line printed at the end -- a reference does not move
         // with a pass sequence, so it has no business in what the pass search compares.
         let (log, max_contention) = *_REFERENCE_LANGUAGES.to_iter.fold_m((log, max_contention), |lang, (log, max_contention)|
-            let (ref_out, _, ref_code) = *["python3", "../../reference.py", "measure", lang, "--repeat", _REPEAT].ez_run_oec(config);
+            let (ref_out, _, ref_code) = *["python3", "../../reference.py", "measure", lang, "--windows", _WINDOWS].ez_run_oec(config);
             if ref_code != 0_U8 { (log, max_contention).pure };
             let ref_out = ref_out.strip_spaces.split(",").to_array;
             if ref_out.@size < 6 { (log, max_contention).pure };

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -11,6 +11,11 @@ _LOG_FILE_PATH = "log.csv";
 _COMMIT_HASH : String;
 _COMMIT_HASH = "commit";
 
+// How many times each program is run for the hardware counters. The cycle count reported is
+// the lowest of them, and a run the machine disturbed only ever raises it.
+_REPEAT : String;
+_REPEAT = "5";
+
 // The languages a case may carry a counterpart in, as a `ref.*` source beside its `main.fix`.
 _REFERENCE_LANGUAGES : Array String;
 _REFERENCE_LANGUAGES = ["c", "rust"];
@@ -98,10 +103,6 @@ namespace CSV {
 type Args = struct {
     no_save : Bool,
     llvm_passes_file: String,
-    // Whether to read the cycle counter as well. Off by default: a cycle count taken while the
-    // machine is busy is not comparable with one taken while it is idle, so the column is filled
-    // only on the runs whose operator knows the machine is free, and the series is sparse.
-    cycles : Bool,
 };
 
 namespace Args {
@@ -109,7 +110,6 @@ namespace Args {
     default = Args {
         no_save: false,
         llvm_passes_file: "",
-        cycles: false,
     };
 }
 
@@ -122,8 +122,6 @@ main = (
         if i >= raw_args.@size { break $ args };
         if raw_args.@(i) == "--no-save" {
             continue $ (i + 1, args.set_no_save(true))
-        } else if raw_args.@(i) == "--cycles" {
-            continue $ (i + 1, args.set_cycles(true))
         } else if raw_args.@(i) == "--llvm-passes-file" {
             if i + 1 >= raw_args.@size {
                 undefined("error: --llvm-passes-file requires a file path argument")
@@ -217,34 +215,38 @@ main = (
             exit(1)
         };
         let bench = bench.as_some;
-        // Split by comma to get "inst" and "mem".
+        // Split by comma to get "inst", "mem" and "ram".
         let bench = bench.split(",").to_array;
         let case_name = dir;
         let inst = case_name + "-inst";
         let mem = case_name + "-mem";
-        // Add to the log.
+        let ram = case_name + "-ram";
+        // Add to the log. `-ram` counts the accesses that reached main memory: it is what
+        // separates a case whose cycle count another program can move from one whose it
+        // cannot, and the program decides it, so it reads the same however busy the machine is.
         let log = log.set(inst, log.@size - 1, bench.@(0));
         let log = log.set(mem, log.@size - 1, bench.@(1));
+        let log = log.set(ram, log.@size - 1, bench.@(2));
         // Two things the instruction count cannot express. `-splits` counts loads and stores
         // that crossed a cache-line boundary, which cost real time and which cachegrind's
         // cache model has no notion of. `-cycles` counts what the machine actually took, so
         // that a change to code layout or branch density -- where the instruction count and
         // the time diverge -- shows up somewhere in this log.
         //
-        // The split count is deterministic like every cachegrind column here, so it is read on
-        // every run. **The cycle count is not**, so it is read only under `--cycles`, and it is
-        // left out where other work competed for the CPU; the `contention` column says how much
-        // of the machine the run that produced this row had.
+        // Both are read on every run. The cycle count survives a machine with other work on it
+        // as long as that work cannot reach the case through the cache, which the case's own
+        // `-ram` count decides; `perf_counters.py` applies the rule and leaves the field empty
+        // where it does not hold. The `contention` column says how much of the machine the run
+        // that produced this row had.
         // On a machine without the counters both columns stay empty and the run carries on.
-        let repeat = if args.@cycles { "5" } else { "1" };
-        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--repeat", repeat, "./a.out"].ez_run_oec(config);
+        let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--repeat", _REPEAT,
+            "--dram-accesses", bench.@(2), "--instructions", bench.@(0),
+            "./a.out"].ez_run_oec(config);
         let (log, case_contention) = if perf_code != 0_U8 { (log, 0.0) } else {
             let perf = perf.strip_spaces.split(",").to_array;
             if perf.@(0) == "" { (log, 0.0) };
             let log = log.set(case_name + "-splits", log.@size - 1, perf.@(0));
-            let log = if args.@cycles {
-                log.set(case_name + "-cycles", log.@size - 1, perf.@(1))
-            } else { log };
+            let log = log.set(case_name + "-cycles", log.@size - 1, perf.@(1));
             // A figure the harness cannot make out leaves the row's `contention` at whatever
             // the other cases reported, which is the honest reading: this case said nothing.
             (log, perf.@(2).read_number)
@@ -256,18 +258,17 @@ main = (
         // holds these out of the cost line printed at the end -- a reference does not move
         // with a pass sequence, so it has no business in what the pass search compares.
         let (log, max_contention) = *_REFERENCE_LANGUAGES.to_iter.fold_m((log, max_contention), |lang, (log, max_contention)|
-            let (ref_out, _, ref_code) = *["python3", "../../reference.py", "measure", lang, "--repeat", repeat].ez_run_oec(config);
+            let (ref_out, _, ref_code) = *["python3", "../../reference.py", "measure", lang, "--repeat", _REPEAT].ez_run_oec(config);
             if ref_code != 0_U8 { (log, max_contention).pure };
             let ref_out = ref_out.strip_spaces.split(",").to_array;
-            if ref_out.@size < 5 { (log, max_contention).pure };
+            if ref_out.@size < 6 { (log, max_contention).pure };
             let log = log.set(case_name + "-inst-" + lang, log.@size - 1, ref_out.@(0));
             let log = log.set(case_name + "-mem-" + lang, log.@size - 1, ref_out.@(1));
-            if ref_out.@(2) == "" { (log, max_contention).pure };
-            let log = log.set(case_name + "-splits-" + lang, log.@size - 1, ref_out.@(2));
-            let log = if args.@cycles {
-                log.set(case_name + "-cycles-" + lang, log.@size - 1, ref_out.@(3))
-            } else { log };
-            (log, max(max_contention, ref_out.@(4).read_number)).pure
+            let log = log.set(case_name + "-ram-" + lang, log.@size - 1, ref_out.@(2));
+            if ref_out.@(3) == "" { (log, max_contention).pure };
+            let log = log.set(case_name + "-splits-" + lang, log.@size - 1, ref_out.@(3));
+            let log = log.set(case_name + "-cycles-" + lang, log.@size - 1, ref_out.@(4));
+            (log, max(max_contention, ref_out.@(5).read_number)).pure
         );
         // Change back to the parent directory.
         ez_cd(config, "..");;
@@ -279,19 +280,20 @@ main = (
     let log = log.set("contention", log.@size - 1, max_contention.to_string_precision(2_U8));
 
     // Say which cases the run came away without a cycle count for. The field is left empty
-    // on a machine that was busy, and the row that results reads like every other one until
-    // someone opens the file.
+    // where other work could have moved the count, and the row that results reads like every
+    // other one until someone opens the file.
     let header = log.@(0);
     let latest = log.@(log.@size - 1);
     let uncounted = dirs.filter(|dir|
         let column = header.find_by(|name| name == dir + "-cycles");
         column.is_none || latest.@(column.as_some) == ""
     ).to_array;
-    when(args.@cycles && !uncounted.is_empty,
-        eprintln("warning: other work competed for the CPU, so " + uncounted.@size.to_string
-            + " of " + dirs.get_size.to_string + " cases came away without a cycle count"
-            + " (it reached " + max_contention.to_string_precision(2_U8) + " cores): "
-            + uncounted.to_iter.join(", "))
+    when(!uncounted.is_empty,
+        eprintln("warning: " + uncounted.@size.to_string + " of " + dirs.get_size.to_string
+            + " cases came away without a cycle count, with other work taking "
+            + max_contention.to_string_precision(2_U8) + " cores while they ran. A count is kept"
+            + " from a window the thread beside the measurement stayed out of, and from a case"
+            + " whose data does not come from main memory: " + uncounted.to_iter.join(", "))
     );;
 
     // Save the log to the log file.

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -216,7 +216,12 @@ main = (
         };
         let bench = bench.as_some;
         // Split by comma to get "inst", "mem" and "ram".
-        let bench = bench.split(",").to_array;
+        let fields = bench.split(",").to_array;
+        if fields.@size != 3 {
+            eprintln("error: cachegrind reported \"" + bench + "\" for " + dir);;
+            exit(1)
+        };
+        let bench = fields;
         let case_name = dir;
         let inst = case_name + "-inst";
         let mem = case_name + "-mem";
@@ -244,7 +249,10 @@ main = (
             "./a.out"].ez_run_oec(config);
         let (log, case_contention) = if perf_code != 0_U8 { (log, 0.0) } else {
             let perf = perf.strip_spaces.split(",").to_array;
-            if perf.@(0) == "" { (log, 0.0) };
+            if perf.@size != 3 {
+                undefined("error: perf_counters.py reported \"" + perf.to_iter.join(",")
+                    + "\" for " + dir)
+            };
             let log = log.set(case_name + "-splits", log.@size - 1, perf.@(0));
             let log = log.set(case_name + "-cycles", log.@size - 1, perf.@(1));
             // A figure the harness cannot make out leaves the row's `contention` at whatever

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -226,9 +226,9 @@ main = (
         let inst = case_name + "-inst";
         let mem = case_name + "-mem";
         let ram = case_name + "-ram";
-        // Add to the log. `-ram` counts the accesses that reached main memory: it is what
-        // separates a case whose cycle count another program can move from one whose it
-        // cannot, and the program decides it, so it reads the same however busy the machine is.
+        // Add to the log. `-ram` counts the accesses that reached main memory: it separates a
+        // case whose cycle count another program can move from a case where it cannot, and the
+        // program decides it, so it reads the same however busy the machine is.
         let log = log.set(inst, log.@size - 1, bench.@(0));
         let log = log.set(mem, log.@size - 1, bench.@(1));
         let log = log.set(ram, log.@size - 1, bench.@(2));
@@ -239,10 +239,11 @@ main = (
         // the time diverge -- shows up somewhere in this log.
         //
         // Both are read on every run. The cycle count survives a machine with other work on it
-        // as long as that work cannot reach the case through the cache, which the case's own
-        // `-ram` count decides; `perf_counters.py` applies the rule and leaves the field empty
-        // where it does not hold. The `contention` column says how much of the machine the run
-        // that produced this row had.
+        // when that work reached neither the core nor the cache: `perf_counters.py` runs on one
+        // thread of a core and keeps the windows the other thread stayed out of, and it reads
+        // the case's own `-ram` count to say whether the shared cache could have cost it. It
+        // leaves the field empty where either condition fails. The `contention` column says how
+        // much of the machine the run that produced this row had.
         // On a machine without the counters both columns stay empty and the run carries on.
         let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--windows", _WINDOWS,
             "--dram-accesses", bench.@(2), "--instructions", bench.@(0),
@@ -261,7 +262,7 @@ main = (
         };
         let max_contention = max(max_contention, case_contention);
         // A case may carry `ref.c` and `ref.rs`: the same program on the same input, read
-        // with the same four counters, so the chart can show how far the Fix line is from C
+        // with the same counters, so the chart can show how far the Fix line is from C
         // and Rust on each of them. The column name keeps the language last, which is what
         // holds these out of the cost line printed at the end -- a reference does not move
         // with a pass sequence, so it has no business in what the pass search compares.
@@ -301,7 +302,8 @@ main = (
             + " cases came away without a cycle count, with other work taking "
             + max_contention.to_string_precision(2_U8) + " cores while they ran. A count is kept"
             + " from a window the thread beside the measurement stayed out of, and from a case"
-            + " whose data does not come from main memory: " + uncounted.to_iter.join(", "))
+            + " that reaches main memory seldom enough for the shared cache not to cost it: "
+            + uncounted.to_iter.join(", "))
     );;
 
     // Save the log to the log file.

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -216,12 +216,11 @@ main = (
         };
         let bench = bench.as_some;
         // Split by comma to get "inst", "mem" and "ram".
-        let fields = bench.split(",").to_array;
-        if fields.@size != 3 {
+        let cachegrind_counts = bench.split(",").to_array;
+        if cachegrind_counts.@size != 3 {
             eprintln("error: cachegrind reported \"" + bench + "\" for " + dir);;
             exit(1)
         };
-        let bench = fields;
         let case_name = dir;
         let inst = case_name + "-inst";
         let mem = case_name + "-mem";
@@ -229,9 +228,9 @@ main = (
         // Add to the log. `-ram` counts the accesses that reached main memory: it separates a
         // case whose cycle count another program can move from a case where it cannot, and the
         // program decides it, so it reads the same however busy the machine is.
-        let log = log.set(inst, log.@size - 1, bench.@(0));
-        let log = log.set(mem, log.@size - 1, bench.@(1));
-        let log = log.set(ram, log.@size - 1, bench.@(2));
+        let log = log.set(inst, log.@size - 1, cachegrind_counts.@(0));
+        let log = log.set(mem, log.@size - 1, cachegrind_counts.@(1));
+        let log = log.set(ram, log.@size - 1, cachegrind_counts.@(2));
         // Two things the instruction count cannot express. `-splits` counts loads and stores
         // that crossed a cache-line boundary, which cost real time and which cachegrind's
         // cache model has no notion of. `-cycles` counts what the machine actually took, so
@@ -246,7 +245,7 @@ main = (
         // much of the machine the run that produced this row had.
         // On a machine without the counters both columns stay empty and the run carries on.
         let (perf, _, perf_code) = *["python3", "../../perf_counters.py", "--windows", _WINDOWS,
-            "--dram-accesses", bench.@(2), "--instructions", bench.@(0),
+            "--ram-accesses", cachegrind_counts.@(2), "--instructions", cachegrind_counts.@(0),
             "./a.out"].ez_run_oec(config);
         let (log, case_contention) = if perf_code != 0_U8 { (log, 0.0) } else {
             let perf = perf.strip_spaces.split(",").to_array;

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -9,7 +9,7 @@ nothing about how fast the machine gets through those instructions, which is whe
 code layout or branch density shows up.
 
 The split count is decided by the program and the environment it is given; the cycle count is
-not, so it is the minimum over `--repeat` windows, and it is reported when nothing else could
+not, so it is the minimum over `--windows` windows, and it is reported when nothing else could
 have moved it. Other work reaches it two ways: over the core it shares with the thread beside it,
 which the run is pinned and the sibling watched for, and over the cache every core shares, which
 the caller answers for by passing what cachegrind counted for this program. A run either could
@@ -20,7 +20,7 @@ Exits non-zero when the counters are unavailable (no hardware PMU, or
 `kernel.perf_event_paranoid` above 2) or when the PMU had to time-slice them, so a caller
 can leave the columns empty instead of logging an estimate.
 
-    python3 perf_counters.py [--repeat N] [--dram-accesses N --instructions N] ./a.out [args...]
+    python3 perf_counters.py [--windows N] [--dram-accesses N --instructions N] ./a.out [args...]
     python3 perf_counters.py --cpu
 """
 
@@ -122,23 +122,27 @@ CPU, SIBLING = measurement_core()
 os.sched_setaffinity(0, {CPU})
 
 
-def sibling_cpu_seconds():
-    """CPU seconds the other thread of the measurement's core has spent off idle since boot."""
-    if SIBLING is None:
-        return 0.0
+def cpu_seconds(name):
+    """CPU seconds spent off idle since boot, from the `/proc/stat` line of that name.
+
+    # Arguments
+    * `name` - what the line begins with: `cpu` for the machine as a whole, `cpu5` for one
+      logical CPU.
+    """
     with open("/proc/stat", encoding="utf-8") as stat:
         for line in stat:
-            if line.startswith(f"cpu{SIBLING} "):
+            if line.startswith(name + " "):
+                # user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice
                 fields = [int(f) for f in line.split()[1:]]
                 return (sum(fields) - fields[3] - fields[4]) / CLOCK_TICK
-    return 0.0
+    # Reading a busy CPU as an idle one would let every window through, so say so instead.
+    sys.exit(f"/proc/stat carries no {name} line")
 
 
-def machine_cpu_seconds():
-    """CPU seconds every process on this machine has spent off idle since boot."""
-    # user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice
-    fields = [int(f) for f in open("/proc/stat", encoding="utf-8").readline().split()[1:]]
-    return (sum(fields) - fields[3] - fields[4]) / CLOCK_TICK
+def sibling_cpu_seconds():
+    """CPU seconds the other thread of the measurement's core has spent off idle since boot, or
+    zero where that core has one thread and so nothing shares it."""
+    return cpu_seconds(f"cpu{SIBLING}") if SIBLING is not None else 0.0
 
 
 def own_cpu_seconds():
@@ -220,7 +224,7 @@ def read_window(argv, splits):
     return cycles, sibling_busy, splits
 
 
-def measure(argv, repeat):
+def measure(argv, windows):
     """The split count, the lowest cycle count over the windows the sibling thread left alone,
     and the CPU other work took over the whole of it, in cores.
 
@@ -228,17 +232,17 @@ def measure(argv, repeat):
     a core the program had only half of gives a figure about the sharing rather than about the
     program.
     """
-    machine_before = machine_cpu_seconds()
+    machine_before = cpu_seconds("cpu")
     own_before = own_cpu_seconds()
     started = time.monotonic()
     splits = None
     cycles = None
-    for _ in range(repeat):
+    for _ in range(windows):
         window_cycles, sibling_busy, splits = read_window(argv, splits)
         if sibling_busy <= SIBLING_BUSY_LIMIT:
             cycles = window_cycles if cycles is None else min(cycles, window_cycles)
     elapsed = time.monotonic() - started
-    others = (machine_cpu_seconds() - machine_before) - (own_cpu_seconds() - own_before)
+    others = (cpu_seconds("cpu") - machine_before) - (own_cpu_seconds() - own_before)
     # `/proc/stat` counts in whole ticks and the rusage clocks round, so a short measurement
     # can put the difference slightly below zero.
     contention = max(0.0, others) / elapsed if elapsed > 0 else 0.0
@@ -286,26 +290,84 @@ def cycles_are_comparable(contention, dram_accesses, instructions):
 
 def take_options(argv):
     """The options standing in front of the program, and the command left after them."""
-    options = {"--repeat": 5, "--dram-accesses": None, "--instructions": None}
+    options = {"--windows": 5, "--dram-accesses": None, "--instructions": None}
     while argv and argv[0] in options:
         if len(argv) < 2:
             sys.exit(f"{argv[0]} takes a value")
         options[argv[0]] = int(argv[1])
         argv = argv[2:]
-    return options["--repeat"], options["--dram-accesses"], options["--instructions"], argv
+    return options["--windows"], options["--dram-accesses"], options["--instructions"], argv
+
+
+def self_check():
+    """Answer what needs no machine to read, so a rule that stopped holding is seen here rather
+    than in a column of the log.
+
+    The counters themselves need a PMU and a program to run; these are the parts that decide what
+    is done with them, and they cost microseconds.
+    """
+    # A sysfs CPU list names single CPUs, ranges, and both together, and ends in a newline.
+    assert cpu_list("5\n") == [5], cpu_list("5\n")
+    assert cpu_list("5,11\n") == [5, 11], cpu_list("5,11\n")
+    assert cpu_list("2-5\n") == [2, 3, 4, 5], cpu_list("2-5\n")
+    assert cpu_list("2-5,8\n") == [2, 3, 4, 5, 8], cpu_list("2-5,8\n")
+
+    # A quiet machine's count is kept whatever the program asks of main memory, and with no figure
+    # to go on it is kept from a quiet machine alone.
+    busy = QUIET_CONTENTION * 2
+    assert cycles_are_comparable(QUIET_CONTENTION / 2, None, None)
+    assert not cycles_are_comparable(busy, None, 10 ** 9)
+    assert not cycles_are_comparable(busy, 10 ** 3, None)
+    assert not cycles_are_comparable(busy, 10 ** 3, 0)
+    # Above the rate another process reaches the count through the cache; below it it cannot.
+    below = int(CONTENDED_DRAM_RATE * 10 ** 9 / 2)
+    above = int(CONTENDED_DRAM_RATE * 10 ** 9 * 2)
+    assert cycles_are_comparable(busy, below, 10 ** 9)
+    assert not cycles_are_comparable(busy, above, 10 ** 9)
+
+    # The options are the ones standing in front of the program; what follows the program is the
+    # program's own, however it is spelled.
+    assert take_options(["./a.out"]) == (5, None, None, ["./a.out"])
+    assert take_options(["--windows", "3", "./a.out", "--windows", "9"]) == (
+        3, None, None, ["./a.out", "--windows", "9"])
+    assert take_options(["--dram-accesses", "7", "--instructions", "11", "--windows", "3",
+                         "./a.out"]) == (3, 7, 11, ["./a.out"])
+    try:
+        take_options(["--windows"])
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("--windows without a value was taken as an option")
+
+    # Only the windows the sibling stayed out of reach the cycle count, and where none did there is
+    # no count to report. The window left out below carries the lowest count of the three, so a gate
+    # that stopped rejecting it would be answered with that count.
+    global read_window
+    canned = []
+    real, read_window = read_window, lambda argv, splits: canned.pop(0)
+    try:
+        canned[:] = [(90, 0.0, 4), (70, 1.0, 4), (80, SIBLING_BUSY_LIMIT / 2, 4)]
+        splits, cycles, _contention = measure(None, 3)
+        assert (splits, cycles) == (4, 80), (splits, cycles)
+        canned[:] = [(90, 1.0, 4), (70, 1.0, 4)]
+        _splits, cycles, _contention = measure(None, 2)
+        assert cycles is None, cycles
+    finally:
+        read_window = real
 
 
 def main():
+    self_check()
     argv = sys.argv[1:]
     if argv == ["--cpu"]:
         print(cpu_model())
         return
-    repeat, dram_accesses, instructions, argv = take_options(argv)
+    windows, dram_accesses, instructions, argv = take_options(argv)
     if not argv:
-        sys.exit("usage: perf_counters.py [--repeat N] [--dram-accesses N --instructions N]"
+        sys.exit("usage: perf_counters.py [--windows N] [--dram-accesses N --instructions N]"
                  " <program> [args...]\n"
                  "       perf_counters.py --cpu")
-    splits, cycles, contention = measure(argv, repeat)
+    splits, cycles, contention = measure(argv, windows)
     # The split count is deterministic, so it is reported whatever the machine was doing.
     reported_cycles = (str(cycles) if cycles is not None
                        and cycles_are_comparable(contention, dram_accesses, instructions) else "")

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -114,6 +114,13 @@ def measurement_core():
 
 CPU, SIBLING = measurement_core()
 
+# The programs inherit this, so they run where the sibling is watched. Setting it here rather
+# than putting `taskset` in front of the command keeps the chain of programs that leads to the
+# measured one exactly as long as it was: the initial stack is laid out above that chain's
+# arguments, and moving it moves which accesses straddle a cache line, which is the `-splits`
+# column.
+os.sched_setaffinity(0, {CPU})
+
 
 def sibling_cpu_seconds():
     """CPU seconds the other thread of the measurement's core has spent off idle since boot."""
@@ -146,7 +153,7 @@ def read_counters(argv):
     proc = subprocess.run(
         # ASLR off, as cachegrind.py runs it: the split count depends on where the
         # allocator puts the data, so a moving heap would move the number.
-        ["setarch", ARCH, "-R", "taskset", "-c", str(CPU), "perf", "stat", "-x,",
+        ["setarch", ARCH, "-R", "perf", "stat", "-x,",
          "-e", ",".join(SPLIT_EVENTS + [CYCLE_EVENT]), "--"] + argv,
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
         env=MEASUREMENT_ENV,

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -10,11 +10,11 @@ code layout or branch density shows up.
 
 The split count is decided by the program and the environment it is given; the cycle count is
 not, so it is the minimum over `--windows` windows, and it is reported when nothing else could
-have moved it. Other work reaches it two ways: over the core it shares with the thread beside it,
-which the run is pinned and the sibling watched for, and over the cache every core shares, which
-the caller answers for by passing what cachegrind counted for this program. A run either could
-have moved leaves the cycle field empty rather than logging a figure that says more about that
-competition than about the program.
+have moved it. Other work reaches it two ways. It runs on the other thread of the same core: the
+measurement is pinned to one CPU, and how busy that thread was is read for every window. And it
+takes the cache every core shares: the caller answers for that by passing what cachegrind counted
+for this program. Where either of them could have moved a run, the cycle field comes back empty,
+since a figure logged there would say more about that competition than about the program.
 
 Exits non-zero when the counters are unavailable (no hardware PMU, or
 `kernel.perf_event_paranoid` above 2) or when the PMU had to time-slice them, so a caller
@@ -47,9 +47,9 @@ CYCLE_EVENT = "cycles:u"
 QUIET_CONTENTION = 0.5
 
 # How often a program's data comes from main memory, per instruction, before another process can
-# change its cycle count by taking the cache from it. A program above this rate loses between 1.5
-# and 2.1 times its cycles when four processes walk twice the last level cache beside it; one
-# below it stays within the spread of an undisturbed reading.
+# change its cycle count by taking the cache from it. A program above this rate takes between 1.5
+# and 2.1 times the cycles when four processes walk twice the last level cache beside it; one
+# below it takes the same cycles it takes undisturbed.
 CONTENDED_DRAM_RATE = 0.002
 
 # How much of a run the other thread of the measurement's core may be busy for. The two threads
@@ -60,9 +60,9 @@ CONTENDED_DRAM_RATE = 0.002
 SIBLING_BUSY_LIMIT = 0.5
 
 # The shortest run the sibling reading can speak for. `/proc/stat` counts in ticks of a
-# hundredth of a second, so a run of a few of them puts the reading's own quantisation above the
-# limit it is compared with. A program that returns sooner is run again until the window holds
-# enough of them, and the cycle count taken is the lowest of those runs.
+# hundredth of a second, so over a run of a few ticks the reading rounds by more than
+# `SIBLING_BUSY_LIMIT` itself. A program that returns sooner is run again until the window is this
+# long, and the cycle count taken is the lowest of those runs.
 MINIMUM_WINDOW = 0.2
 
 # The environment the measured command gets, fixed the way `cachegrind.py` fixes it. The
@@ -109,11 +109,10 @@ def measurement_core():
 
 CPU, SIBLING = measurement_core()
 
-# The programs inherit this, so they run where the sibling is watched. Setting it here rather
-# than putting `taskset` in front of the command keeps the chain of programs that leads to the
-# measured one exactly as long as it was: the initial stack is laid out above that chain's
-# arguments, and moving it moves which accesses straddle a cache line, which is the `-splits`
-# column.
+# The programs inherit this, so they run where the sibling is watched. Setting it in this process
+# leaves the chain of programs that leads to the measured one as short as it can be: the initial
+# stack is laid out above that chain's arguments, so a `taskset` in front of the command would move
+# which accesses straddle a cache line, which is the `-splits` column.
 os.sched_setaffinity(0, {CPU})
 
 
@@ -261,12 +260,12 @@ def cycles_are_comparable(contention, dram_accesses, instructions):
     """Whether a cycle count read under this much competition says more about the program than
     about the competition.
 
-    Two channels carry other work into a cycle count, and this answers for the second of them.
-    The core the program runs on is shared with the thread beside it, which `measure` answers
-    for by keeping only the windows that thread stayed out of. What is left is the cache, which
-    every core on the machine shares: another process takes a line the program was going to
-    find there, and the program that loses time to it is the one that goes to main memory often
-    enough for the loss to add up.
+    Other work reaches a cycle count two ways, and this answers for one of them. The core the
+    program runs on is shared with the thread beside it, which `measure` answers for by keeping
+    only the windows that thread stayed out of. What is left is the cache, which every core on
+    the machine shares: another process takes a line the program was going to find there, and the
+    program that loses time to it is the one that goes to main memory often enough for the loss to
+    add up.
 
     A program the scheduler takes the CPU from resumes with the same count of cycles ahead of
     it, and one the machine clocks down spends the same count getting there, so neither of those
@@ -297,8 +296,8 @@ def take_options(argv):
 
 
 def self_check():
-    """Answer what needs no machine to read, so a rule that stopped holding is seen here rather
-    than in a column of the log.
+    """Check the rules that need no machine to read, so one that stopped holding shows up here
+    rather than in a column of the log.
 
     The counters themselves need a PMU and a program to run; these are the parts that decide what
     is done with them, and they cost microseconds.
@@ -315,7 +314,7 @@ def self_check():
     assert cycles_are_comparable(QUIET_CONTENTION / 2, None, None)
     assert not cycles_are_comparable(busy, None, 10 ** 9)
     assert not cycles_are_comparable(busy, 10 ** 3, None)
-    # Above the rate another process reaches the count through the cache; below it it cannot.
+    # Above the rate another process reaches the count through the cache; below the rate it cannot.
     below = int(CONTENDED_DRAM_RATE * 10 ** 9 / 2)
     above = int(CONTENDED_DRAM_RATE * 10 ** 9 * 2)
     assert cycles_are_comparable(busy, below, 10 ** 9)
@@ -336,8 +335,8 @@ def self_check():
         raise AssertionError("--windows without a value was taken as an option")
 
     # Only the windows the sibling stayed out of reach the cycle count, and where none did there is
-    # no count to report. The window left out below carries the lowest count of the three, so a gate
-    # that stopped rejecting it would be answered with that count.
+    # no count to report. The window left out below carries the lowest count of the three, so
+    # `measure` letting it through would show up here as that count.
     global read_window
     canned = []
     real, read_window = read_window, lambda argv, splits: canned.pop(0)

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -81,8 +81,6 @@ def cpu_list(text):
     """The CPU numbers a sysfs list like `5,11` or `2-5,8` names."""
     numbers = []
     for part in text.strip().split(","):
-        if not part:
-            continue
         ends = part.split("-")
         numbers.extend(range(int(ends[0]), int(ends[-1]) + 1))
     return numbers
@@ -101,14 +99,11 @@ def measurement_core():
     first, so the thread watched here is the one the rest of the machine reaches for last, and a
     measurement finds its core to itself that much more often.
     """
-    present = sorted(int(name[3:]) for name in os.listdir("/sys/devices/system/cpu")
-                     if re.fullmatch(r"cpu\d+", name))
-    topology = f"/sys/devices/system/cpu/cpu{present[-1]}/topology/thread_siblings_list"
-    try:
-        with open(topology, encoding="utf-8") as siblings:
-            threads = sorted(cpu_list(siblings.read()))
-    except OSError:
-        threads = [present[-1]]
+    highest = max(int(name[3:]) for name in os.listdir("/sys/devices/system/cpu")
+                  if re.fullmatch(r"cpu\d+", name))
+    topology = f"/sys/devices/system/cpu/cpu{highest}/topology/thread_siblings_list"
+    with open(topology, encoding="utf-8") as siblings:
+        threads = sorted(cpu_list(siblings.read()))
     return threads[0], threads[-1] if len(threads) > 1 else None
 
 
@@ -232,6 +227,7 @@ def measure(argv, windows):
     a core the program had only half of gives a figure about the sharing rather than about the
     program.
     """
+    assert windows >= 1, windows
     machine_before = cpu_seconds("cpu")
     own_before = own_cpu_seconds()
     started = time.monotonic()
@@ -283,8 +279,9 @@ def cycles_are_comparable(contention, dram_accesses, instructions):
     """
     if contention <= QUIET_CONTENTION:
         return True
-    if dram_accesses is None or not instructions:
+    if dram_accesses is None or instructions is None:
         return False
+    assert instructions > 0, instructions
     return dram_accesses / instructions <= CONTENDED_DRAM_RATE
 
 
@@ -318,7 +315,6 @@ def self_check():
     assert cycles_are_comparable(QUIET_CONTENTION / 2, None, None)
     assert not cycles_are_comparable(busy, None, 10 ** 9)
     assert not cycles_are_comparable(busy, 10 ** 3, None)
-    assert not cycles_are_comparable(busy, 10 ** 3, 0)
     # Above the rate another process reaches the count through the cache; below it it cannot.
     below = int(CONTENDED_DRAM_RATE * 10 ** 9 / 2)
     above = int(CONTENDED_DRAM_RATE * 10 ** 9 * 2)
@@ -369,8 +365,8 @@ def main():
                  "       perf_counters.py --cpu")
     splits, cycles, contention = measure(argv, windows)
     # The split count is deterministic, so it is reported whatever the machine was doing.
-    reported_cycles = (str(cycles) if cycles is not None
-                       and cycles_are_comparable(contention, dram_accesses, instructions) else "")
+    comparable = cycles_are_comparable(contention, dram_accesses, instructions)
+    reported_cycles = str(cycles) if cycles is not None and comparable else ""
     print(f"{splits},{reported_cycles},{contention:.2f}")
 
 

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -20,7 +20,7 @@ Exits non-zero when the counters are unavailable (no hardware PMU, or
 `kernel.perf_event_paranoid` above 2) or when the PMU had to time-slice them, so a caller
 can leave the columns empty instead of logging an estimate.
 
-    python3 perf_counters.py [--windows N] [--dram-accesses N --instructions N] ./a.out [args...]
+    python3 perf_counters.py [--windows N] [--ram-accesses N --instructions N] ./a.out [args...]
     python3 perf_counters.py --cpu
 """
 
@@ -50,7 +50,7 @@ QUIET_CONTENTION = 0.5
 # change its cycle count by taking the cache from it. A program above this rate takes between 1.5
 # and 2.1 times the cycles when four processes walk twice the last level cache beside it; one
 # below it takes the same cycles it takes undisturbed.
-CONTENDED_DRAM_RATE = 0.002
+RAM_RATE_LIMIT = 0.002
 
 # How much of a run the other thread of the measurement's core may be busy for. The two threads
 # share the core's front end and execution units, and the cycle counter runs while the program's
@@ -63,7 +63,7 @@ SIBLING_BUSY_LIMIT = 0.5
 # hundredth of a second, so over a run of a few ticks the reading rounds by more than
 # `SIBLING_BUSY_LIMIT` itself. A program that returns sooner is run again until the window is this
 # long, and the cycle count taken is the lowest of those runs.
-MINIMUM_WINDOW = 0.2
+MINIMUM_WINDOW_SECONDS = 0.2
 
 # The environment the measured command gets, fixed the way `cachegrind.py` fixes it. The
 # initial stack is laid out above the environment block, so every address on the stack moves
@@ -101,42 +101,42 @@ def measurement_core():
     """
     highest = max(int(name[3:]) for name in os.listdir("/sys/devices/system/cpu")
                   if re.fullmatch(r"cpu\d+", name))
-    topology = f"/sys/devices/system/cpu/cpu{highest}/topology/thread_siblings_list"
-    with open(topology, encoding="utf-8") as siblings:
+    siblings_path = f"/sys/devices/system/cpu/cpu{highest}/topology/thread_siblings_list"
+    with open(siblings_path, encoding="utf-8") as siblings:
         threads = sorted(cpu_list(siblings.read()))
     return threads[0], threads[-1] if len(threads) > 1 else None
 
 
-CPU, SIBLING = measurement_core()
+MEASUREMENT_CPU, SIBLING_CPU = measurement_core()
 
 # The programs inherit this, so they run where the sibling is watched. Setting it in this process
 # leaves the chain of programs that leads to the measured one as short as it can be: the initial
 # stack is laid out above that chain's arguments, so a `taskset` in front of the command would move
 # which accesses straddle a cache line, which is the `-splits` column.
-os.sched_setaffinity(0, {CPU})
+os.sched_setaffinity(0, {MEASUREMENT_CPU})
 
 
-def cpu_seconds(name):
+def cpu_seconds(cpu_name):
     """CPU seconds spent off idle since boot, from the `/proc/stat` line of that name.
 
     # Arguments
-    * `name` - what the line begins with: `cpu` for the machine as a whole, `cpu5` for one
+    * `cpu_name` - what the line begins with: `cpu` for the machine as a whole, `cpu5` for one
       logical CPU.
     """
     with open("/proc/stat", encoding="utf-8") as stat:
         for line in stat:
-            if line.startswith(name + " "):
+            if line.startswith(cpu_name + " "):
                 # user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice
                 fields = [int(f) for f in line.split()[1:]]
                 return (sum(fields) - fields[3] - fields[4]) / CLOCK_TICK
     # Reading a busy CPU as an idle one would let every window through, so say so instead.
-    sys.exit(f"/proc/stat carries no {name} line")
+    sys.exit(f"/proc/stat carries no {cpu_name} line")
 
 
 def sibling_cpu_seconds():
     """CPU seconds the other thread of the measurement's core has spent off idle since boot, or
     zero where that core has one thread and so nothing shares it."""
-    return cpu_seconds(f"cpu{SIBLING}") if SIBLING is not None else 0.0
+    return cpu_seconds(f"cpu{SIBLING_CPU}") if SIBLING_CPU is not None else 0.0
 
 
 def own_cpu_seconds():
@@ -186,7 +186,7 @@ def read_window(argv, splits):
     """The lowest cycle count over a window of runs, how busy the sibling thread was through
     it, and the split count the runs agreed on.
 
-    A window holds as many runs as `MINIMUM_WINDOW` needs, so that the sibling reading covers
+    A window holds as many runs as `MINIMUM_WINDOW_SECONDS` needs, so that the sibling reading covers
     enough ticks of `/proc/stat` to mean something. The split count comes from the same runs
     and has to agree across them: the runs are given one environment, and from there nothing
     about the machine's state reaches the addresses the program touches.
@@ -212,7 +212,7 @@ def read_window(argv, splits):
         run_cycles = found[CYCLE_EVENT.removesuffix(":u")]
         cycles = run_cycles if cycles is None else min(cycles, run_cycles)
         elapsed = time.monotonic() - started
-        if elapsed >= MINIMUM_WINDOW:
+        if elapsed >= MINIMUM_WINDOW_SECONDS:
             break
     sibling_busy = (sibling_cpu_seconds() - sibling_before) / elapsed
     return cycles, sibling_busy, splits
@@ -256,43 +256,44 @@ def cpu_model():
     return "unknown"
 
 
-def cycles_are_comparable(contention, dram_accesses, instructions):
+def cycles_are_comparable(cycles, contention, ram_accesses, instructions):
     """Whether a cycle count read under this much competition says more about the program than
     about the competition.
 
-    Other work reaches a cycle count two ways, and this answers for one of them. The core the
-    program runs on is shared with the thread beside it, which `measure` answers for by keeping
-    only the windows that thread stayed out of. What is left is the cache, which every core on
-    the machine shares: another process takes a line the program was going to find there, and the
-    program that loses time to it is the one that goes to main memory often enough for the loss to
-    add up.
+    Other work reaches a cycle count two ways. It shares the core through the thread beside the
+    measurement: `measure` keeps only the windows that thread stayed out of, and hands back `None`
+    where it stayed out of none. And it takes the cache that every core shares, which costs the
+    program that goes to main memory often enough for the loss to add up.
 
     A program the scheduler takes the CPU from resumes with the same count of cycles ahead of
     it, and one the machine clocks down spends the same count getting there, so neither of those
     reaches the count at all.
 
     # Arguments
-    * `dram_accesses`, `instructions` - what cachegrind counted for this program, or `None`
+    * `cycles` - what `measure` returned, `None` where no window was the measurement's own.
+    * `ram_accesses`, `instructions` - what cachegrind counted for this program, or `None`
       where the caller has no figure for it. Both are decided by the program rather than by the
       machine it ran on, so the rate they give is the same on a busy machine as on an idle one.
     """
+    if cycles is None:
+        return False
     if contention <= QUIET_CONTENTION:
         return True
-    if dram_accesses is None or instructions is None:
+    if ram_accesses is None or instructions is None:
         return False
     assert instructions > 0, instructions
-    return dram_accesses / instructions <= CONTENDED_DRAM_RATE
+    return ram_accesses / instructions <= RAM_RATE_LIMIT
 
 
 def take_options(argv):
     """The options standing in front of the program, and the command left after them."""
-    options = {"--windows": 5, "--dram-accesses": None, "--instructions": None}
+    options = {"--windows": 5, "--ram-accesses": None, "--instructions": None}
     while argv and argv[0] in options:
         if len(argv) < 2:
             sys.exit(f"{argv[0]} takes a value")
         options[argv[0]] = int(argv[1])
         argv = argv[2:]
-    return options["--windows"], options["--dram-accesses"], options["--instructions"], argv
+    return options["--windows"], options["--ram-accesses"], options["--instructions"], argv
 
 
 def self_check():
@@ -311,21 +312,23 @@ def self_check():
     # A quiet machine's count is kept whatever the program asks of main memory, and with no figure
     # to go on it is kept from a quiet machine alone.
     busy = QUIET_CONTENTION * 2
-    assert cycles_are_comparable(QUIET_CONTENTION / 2, None, None)
-    assert not cycles_are_comparable(busy, None, 10 ** 9)
-    assert not cycles_are_comparable(busy, 10 ** 3, None)
+    assert cycles_are_comparable(1, QUIET_CONTENTION / 2, None, None)
+    assert not cycles_are_comparable(1, busy, None, 10 ** 9)
+    assert not cycles_are_comparable(1, busy, 10 ** 3, None)
     # Above the rate another process reaches the count through the cache; below the rate it cannot.
-    below = int(CONTENDED_DRAM_RATE * 10 ** 9 / 2)
-    above = int(CONTENDED_DRAM_RATE * 10 ** 9 * 2)
-    assert cycles_are_comparable(busy, below, 10 ** 9)
-    assert not cycles_are_comparable(busy, above, 10 ** 9)
+    below = int(RAM_RATE_LIMIT * 10 ** 9 / 2)
+    above = int(RAM_RATE_LIMIT * 10 ** 9 * 2)
+    assert cycles_are_comparable(1, busy, below, 10 ** 9)
+    # A count no window gave is no count, however little the program asks of main memory.
+    assert not cycles_are_comparable(None, QUIET_CONTENTION / 2, below, 10 ** 9)
+    assert not cycles_are_comparable(1, busy, above, 10 ** 9)
 
     # The options are the ones standing in front of the program; what follows the program is the
     # program's own, however it is spelled.
     assert take_options(["./a.out"]) == (5, None, None, ["./a.out"])
     assert take_options(["--windows", "3", "./a.out", "--windows", "9"]) == (
         3, None, None, ["./a.out", "--windows", "9"])
-    assert take_options(["--dram-accesses", "7", "--instructions", "11", "--windows", "3",
+    assert take_options(["--ram-accesses", "7", "--instructions", "11", "--windows", "3",
                          "./a.out"]) == (3, 7, 11, ["./a.out"])
     try:
         take_options(["--windows"])
@@ -357,15 +360,15 @@ def main():
     if argv == ["--cpu"]:
         print(cpu_model())
         return
-    windows, dram_accesses, instructions, argv = take_options(argv)
+    windows, ram_accesses, instructions, argv = take_options(argv)
     if not argv:
-        sys.exit("usage: perf_counters.py [--windows N] [--dram-accesses N --instructions N]"
+        sys.exit("usage: perf_counters.py [--windows N] [--ram-accesses N --instructions N]"
                  " <program> [args...]\n"
                  "       perf_counters.py --cpu")
     splits, cycles, contention = measure(argv, windows)
     # The split count is deterministic, so it is reported whatever the machine was doing.
-    comparable = cycles_are_comparable(contention, dram_accesses, instructions)
-    reported_cycles = str(cycles) if cycles is not None and comparable else ""
+    comparable = cycles_are_comparable(cycles, contention, ram_accesses, instructions)
+    reported_cycles = str(cycles) if comparable else ""
     print(f"{splits},{reported_cycles},{contention:.2f}")
 
 

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -9,20 +9,23 @@ nothing about how fast the machine gets through those instructions, which is whe
 code layout or branch density shows up.
 
 The split count is decided by the program and the environment it is given; the cycle count is
-not, so it is the minimum over `--repeat` runs, and it is reported only when the machine had
-CPU to spare for the program throughout. A run the rest of the machine competed with leaves the
-cycle field empty rather than logging a figure that says more about that competition than about
-the program.
+not, so it is the minimum over `--repeat` windows, and it is reported when nothing else could
+have moved it. Other work reaches it two ways: over the core it shares with the thread beside it,
+which the run is pinned and the sibling watched for, and over the cache every core shares, which
+the caller answers for by passing what cachegrind counted for this program. A run either could
+have moved leaves the cycle field empty rather than logging a figure that says more about that
+competition than about the program.
 
 Exits non-zero when the counters are unavailable (no hardware PMU, or
 `kernel.perf_event_paranoid` above 2) or when the PMU had to time-slice them, so a caller
 can leave the columns empty instead of logging an estimate.
 
-    python3 perf_counters.py [--repeat N] ./a.out [args...]
+    python3 perf_counters.py [--repeat N] [--dram-accesses N --instructions N] ./a.out [args...]
     python3 perf_counters.py --cpu
 """
 
 import os
+import re
 import resource
 import subprocess
 import sys
@@ -43,6 +46,25 @@ CYCLE_EVENT = "cycles:u"
 # a threshold on it rejects measurements that were never disturbed.
 QUIET_CONTENTION = 0.5
 
+# How often a program's data comes from main memory, per instruction, before another process can
+# change its cycle count by taking the cache from it. A program above this rate loses between 1.5
+# and 2.1 times its cycles when four processes walk twice the last level cache beside it; one
+# below it stays within the spread of an undisturbed reading.
+CONTENDED_DRAM_RATE = 0.002
+
+# How much of a run the other thread of the measurement's core may be busy for. The two threads
+# share the core's front end and execution units, and the cycle counter runs while the program's
+# instructions wait for a slot: a case read with the sibling busy for most of the run came out
+# 6.6% above its idle-machine figure, and 9.2% above with the sibling saturated, while the same
+# case read below this limit came within 0.22% of it.
+SIBLING_BUSY_LIMIT = 0.5
+
+# The shortest run the sibling reading can speak for. `/proc/stat` counts in ticks of a
+# hundredth of a second, so a run of a few of them puts the reading's own quantisation above the
+# limit it is compared with. A program that returns sooner is run again until the window holds
+# enough of them, and the cycle count taken is the lowest of those runs.
+MINIMUM_WINDOW = 0.2
+
 # The environment the measured command gets, fixed the way `cachegrind.py` fixes it. The
 # initial stack is laid out above the environment block, so every address on the stack moves
 # with how much the caller happened to export, and a stack object that lands 8 bytes below a
@@ -53,6 +75,56 @@ MEASUREMENT_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C"}
 CLOCK_TICK = os.sysconf("SC_CLK_TCK")
 
 ARCH = subprocess.check_output(["uname", "-m"], text=True).strip()
+
+
+def cpu_list(text):
+    """The CPU numbers a sysfs list like `5,11` or `2-5,8` names."""
+    numbers = []
+    for part in text.strip().split(","):
+        if not part:
+            continue
+        ends = part.split("-")
+        numbers.extend(range(int(ends[0]), int(ends[-1]) + 1))
+    return numbers
+
+
+def measurement_core():
+    """The CPU the programs are run on, and the other thread of its core where that core has
+    two.
+
+    Pinning is what makes the sibling knowable: a program the scheduler is free to move shares
+    its core with a different thread from one moment to the next, and which one it was is gone
+    by the time the run ends.
+
+    Of the core's two threads the run takes the lower, leaving the higher to be watched. Linux
+    numbers a core's second thread into the upper half of the CPUs and fills the lower half
+    first, so the thread watched here is the one the rest of the machine reaches for last, and a
+    measurement finds its core to itself that much more often.
+    """
+    present = sorted(int(name[3:]) for name in os.listdir("/sys/devices/system/cpu")
+                     if re.fullmatch(r"cpu\d+", name))
+    topology = f"/sys/devices/system/cpu/cpu{present[-1]}/topology/thread_siblings_list"
+    try:
+        with open(topology, encoding="utf-8") as siblings:
+            threads = sorted(cpu_list(siblings.read()))
+    except OSError:
+        threads = [present[-1]]
+    return threads[0], threads[-1] if len(threads) > 1 else None
+
+
+CPU, SIBLING = measurement_core()
+
+
+def sibling_cpu_seconds():
+    """CPU seconds the other thread of the measurement's core has spent off idle since boot."""
+    if SIBLING is None:
+        return 0.0
+    with open("/proc/stat", encoding="utf-8") as stat:
+        for line in stat:
+            if line.startswith(f"cpu{SIBLING} "):
+                fields = [int(f) for f in line.split()[1:]]
+                return (sum(fields) - fields[3] - fields[4]) / CLOCK_TICK
+    return 0.0
 
 
 def machine_cpu_seconds():
@@ -74,7 +146,7 @@ def read_counters(argv):
     proc = subprocess.run(
         # ASLR off, as cachegrind.py runs it: the split count depends on where the
         # allocator puts the data, so a moving heap would move the number.
-        ["setarch", ARCH, "-R", "perf", "stat", "-x,",
+        ["setarch", ARCH, "-R", "taskset", "-c", str(CPU), "perf", "stat", "-x,",
          "-e", ",".join(SPLIT_EVENTS + [CYCLE_EVENT]), "--"] + argv,
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
         env=MEASUREMENT_ENV,
@@ -105,21 +177,19 @@ def read_counters(argv):
     return found, proc.stderr
 
 
-def measure(argv, repeat):
-    """The split count, the lowest cycle count over `repeat` runs, and the CPU other work
-    took over the whole of it, in cores.
+def read_window(argv, splits):
+    """The lowest cycle count over a window of runs, how busy the sibling thread was through
+    it, and the split count the runs agreed on.
 
-    The run with the fewest cycles is the one the rest of the machine disturbed least. The
-    split count comes from the same runs and has to agree across them: the runs are given one
-    environment, and from there nothing about the machine's state reaches the addresses the
-    program touches.
+    A window holds as many runs as `MINIMUM_WINDOW` needs, so that the sibling reading covers
+    enough ticks of `/proc/stat` to mean something. The split count comes from the same runs
+    and has to agree across them: the runs are given one environment, and from there nothing
+    about the machine's state reaches the addresses the program touches.
     """
-    machine_before = machine_cpu_seconds()
-    own_before = own_cpu_seconds()
+    sibling_before = sibling_cpu_seconds()
     started = time.monotonic()
-    splits = None
     cycles = None
-    for _ in range(repeat):
+    while True:
         found, report = read_counters(argv)
         missing = [e for e in SPLIT_EVENTS + [CYCLE_EVENT.removesuffix(":u")]
                    if e not in found]
@@ -136,6 +206,30 @@ def measure(argv, repeat):
                      f"({splits} then {run_splits}), so one of them is not a measurement")
         run_cycles = found[CYCLE_EVENT.removesuffix(":u")]
         cycles = run_cycles if cycles is None else min(cycles, run_cycles)
+        elapsed = time.monotonic() - started
+        if elapsed >= MINIMUM_WINDOW:
+            break
+    sibling_busy = (sibling_cpu_seconds() - sibling_before) / elapsed
+    return cycles, sibling_busy, splits
+
+
+def measure(argv, repeat):
+    """The split count, the lowest cycle count over the windows the sibling thread left alone,
+    and the CPU other work took over the whole of it, in cores.
+
+    The cycle count comes back as `None` where the sibling was busy through every window, since
+    a core the program had only half of gives a figure about the sharing rather than about the
+    program.
+    """
+    machine_before = machine_cpu_seconds()
+    own_before = own_cpu_seconds()
+    started = time.monotonic()
+    splits = None
+    cycles = None
+    for _ in range(repeat):
+        window_cycles, sibling_busy, splits = read_window(argv, splits)
+        if sibling_busy <= SIBLING_BUSY_LIMIT:
+            cycles = window_cycles if cycles is None else min(cycles, window_cycles)
     elapsed = time.monotonic() - started
     others = (machine_cpu_seconds() - machine_before) - (own_cpu_seconds() - own_before)
     # `/proc/stat` counts in whole ticks and the rusage clocks round, so a short measurement
@@ -156,21 +250,58 @@ def cpu_model():
     return "unknown"
 
 
+def cycles_are_comparable(contention, dram_accesses, instructions):
+    """Whether a cycle count read under this much competition says more about the program than
+    about the competition.
+
+    Two channels carry other work into a cycle count, and this answers for the second of them.
+    The core the program runs on is shared with the thread beside it, which `measure` answers
+    for by keeping only the windows that thread stayed out of. What is left is the cache, which
+    every core on the machine shares: another process takes a line the program was going to
+    find there, and the program that loses time to it is the one that goes to main memory often
+    enough for the loss to add up.
+
+    A program the scheduler takes the CPU from resumes with the same count of cycles ahead of
+    it, and one the machine clocks down spends the same count getting there, so neither of those
+    reaches the count at all.
+
+    # Arguments
+    * `dram_accesses`, `instructions` - what cachegrind counted for this program, or `None`
+      where the caller has no figure for it. Both are decided by the program rather than by the
+      machine it ran on, so the rate they give is the same on a busy machine as on an idle one.
+    """
+    if contention <= QUIET_CONTENTION:
+        return True
+    if dram_accesses is None or not instructions:
+        return False
+    return dram_accesses / instructions <= CONTENDED_DRAM_RATE
+
+
+def take_options(argv):
+    """The options standing in front of the program, and the command left after them."""
+    options = {"--repeat": 5, "--dram-accesses": None, "--instructions": None}
+    while argv and argv[0] in options:
+        if len(argv) < 2:
+            sys.exit(f"{argv[0]} takes a value")
+        options[argv[0]] = int(argv[1])
+        argv = argv[2:]
+    return options["--repeat"], options["--dram-accesses"], options["--instructions"], argv
+
+
 def main():
     argv = sys.argv[1:]
     if argv == ["--cpu"]:
         print(cpu_model())
         return
-    repeat = 5
-    if len(argv) >= 2 and argv[0] == "--repeat":
-        repeat = int(argv[1])
-        argv = argv[2:]
+    repeat, dram_accesses, instructions, argv = take_options(argv)
     if not argv:
-        sys.exit("usage: perf_counters.py [--repeat N] <program> [args...]\n"
+        sys.exit("usage: perf_counters.py [--repeat N] [--dram-accesses N --instructions N]"
+                 " <program> [args...]\n"
                  "       perf_counters.py --cpu")
     splits, cycles, contention = measure(argv, repeat)
     # The split count is deterministic, so it is reported whatever the machine was doing.
-    reported_cycles = "" if contention > QUIET_CONTENTION else str(cycles)
+    reported_cycles = (str(cycles) if cycles is not None
+                       and cycles_are_comparable(contention, dram_accesses, instructions) else "")
     print(f"{splits},{reported_cycles},{contention:.2f}")
 
 

--- a/benchmark/speedtest/reference.py
+++ b/benchmark/speedtest/reference.py
@@ -13,7 +13,7 @@ Run from inside a case directory. Exits 2 when the case carries no counterpart f
 language asked for.
 
     python3 reference.py build <c|rust>
-    python3 reference.py measure <c|rust> [--repeat N]
+    python3 reference.py measure <c|rust> [--windows N]
 
 `measure` prints `<inst>,<mem>,<ram>,<splits>,<cycles>,<contention>`. The last three come back
 empty, empty and `0.00` where the hardware counters are out of reach, as they do for the case
@@ -56,13 +56,13 @@ def build(language):
         sys.exit(f"building {source} failed:\n{built.stderr.strip()}")
 
 
-def measure(language, repeat):
+def measure(language, windows):
     """The counters for the counterpart of `language`, as one
     `<inst>,<mem>,<ram>,<splits>,<cycles>,<contention>` line.
 
     # Arguments
-    * `repeat` - how many times the hardware counters are read; the cycle count reported is
-      the lowest of them.
+    * `windows` - how many windows of runs the hardware counters are read over; the cycle
+      count reported is the lowest of them.
     """
     _source, binary = source_and_binary(language)
     # The counterpart checks its own answer, so a reference that drifted away from the case
@@ -79,7 +79,7 @@ def measure(language, repeat):
     # A machine without the counters leaves these three fields the way the case's own
     # measurement leaves them, so a row is short of the same columns on both lines.
     counted = subprocess.run(
-        ["python3", str(PERF_COUNTERS), "--repeat", str(repeat),
+        ["python3", str(PERF_COUNTERS), "--windows", str(windows),
          # What the counterpart asks of main memory decides whether its cycle count survives
          # a busy machine, the same way it does for the case.
          "--dram-accesses", dram_accesses, "--instructions", instructions,
@@ -91,17 +91,17 @@ def measure(language, repeat):
 
 def main():
     argv = sys.argv[1:]
-    repeat = 1
-    if len(argv) >= 2 and argv[-2] == "--repeat":
-        repeat = int(argv[-1])
+    windows = 1
+    if len(argv) >= 2 and argv[-2] == "--windows":
+        windows = int(argv[-1])
         argv = argv[:-2]
     if len(argv) != 2 or argv[0] not in ("build", "measure") or argv[1] not in BUILD:
         sys.exit("usage: reference.py build <c|rust>\n"
-                 "       reference.py measure <c|rust> [--repeat N]")
+                 "       reference.py measure <c|rust> [--windows N]")
     if argv[0] == "build":
         build(argv[1])
     else:
-        print(measure(argv[1], repeat))
+        print(measure(argv[1], windows))
 
 
 main()

--- a/benchmark/speedtest/reference.py
+++ b/benchmark/speedtest/reference.py
@@ -15,7 +15,7 @@ language asked for.
     python3 reference.py build <c|rust>
     python3 reference.py measure <c|rust> [--repeat N]
 
-`measure` prints `<inst>,<mem>,<splits>,<cycles>,<contention>`. The last three come back
+`measure` prints `<inst>,<mem>,<ram>,<splits>,<cycles>,<contention>`. The last three come back
 empty, empty and `0.00` where the hardware counters are out of reach, as they do for the case
 itself.
 """
@@ -58,7 +58,7 @@ def build(language):
 
 def measure(language, repeat):
     """The counters for the counterpart of `language`, as one
-    `<inst>,<mem>,<splits>,<cycles>,<contention>` line.
+    `<inst>,<mem>,<ram>,<splits>,<cycles>,<contention>` line.
 
     # Arguments
     * `repeat` - how many times the hardware counters are read; the cycle count reported is
@@ -72,12 +72,18 @@ def measure(language, repeat):
     if simulated.returncode != 0:
         sys.exit(f"measuring {binary} failed:\n{simulated.stderr.strip()}")
     cachegrind = simulated.stdout.strip().splitlines()[-1]
-    if len(cachegrind.split(",")) != 2:
+    simulated_counts = cachegrind.split(",")
+    if len(simulated_counts) != 3:
         sys.exit(f"measuring {binary} produced \"{cachegrind}\"")
+    instructions, _memory_accesses, dram_accesses = simulated_counts
     # A machine without the counters leaves these three fields the way the case's own
     # measurement leaves them, so a row is short of the same columns on both lines.
     counted = subprocess.run(
-        ["python3", str(PERF_COUNTERS), "--repeat", str(repeat), f"./{binary}"],
+        ["python3", str(PERF_COUNTERS), "--repeat", str(repeat),
+         # What the counterpart asks of main memory decides whether its cycle count survives
+         # a busy machine, the same way it does for the case.
+         "--dram-accesses", dram_accesses, "--instructions", instructions,
+         f"./{binary}"],
         capture_output=True, text=True)
     hardware = counted.stdout.strip() if counted.returncode == 0 else ",,0.00"
     return f"{cachegrind},{hardware}"

--- a/benchmark/speedtest/reference.py
+++ b/benchmark/speedtest/reference.py
@@ -6,8 +6,8 @@ the Fix line a reference to be read against -- how far the language is from C on
 program, tracked over time rather than sampled once.
 
 Building and measuring are separate commands so that the harness can get every build out
-of the way before it reads a counter: the cycle count is dropped on a machine that is busy,
-and a compiler running between two measurements is what makes it busy.
+of the way before it reads a counter: a cycle count other work could have moved is dropped,
+and a compiler running between two measurements is that other work.
 
 Run from inside a case directory. Exits 2 when the case carries no counterpart for the
 language asked for.

--- a/benchmark/speedtest/reference.py
+++ b/benchmark/speedtest/reference.py
@@ -75,14 +75,14 @@ def measure(language, windows):
     simulated_counts = cachegrind.split(",")
     if len(simulated_counts) != 3:
         sys.exit(f"measuring {binary} produced \"{cachegrind}\"")
-    instructions, _memory_accesses, dram_accesses = simulated_counts
+    instructions, _memory_accesses, ram_accesses = simulated_counts
     # A machine without the counters leaves these three fields the way the case's own
     # measurement leaves them, so a row is short of the same columns on both lines.
     counted = subprocess.run(
         ["python3", str(PERF_COUNTERS), "--windows", str(windows),
          # What the counterpart asks of main memory decides whether its cycle count survives
          # a busy machine, the same way it does for the case.
-         "--dram-accesses", dram_accesses, "--instructions", instructions,
+         "--ram-accesses", ram_accesses, "--instructions", instructions,
          f"./{binary}"],
         capture_output=True, text=True)
     hardware = counted.stdout.strip() if counted.returncode == 0 else ",,0.00"


### PR DESCRIPTION
`benchmark/speedtest` が、忙しい機械でもサイクル数を記録するようにする。コンパイラは変えない。

## いまの状態

`benchmark/speedtest` は case ごとに 4 つの数を `log.csv` の 1 行に書く。うち 3 つ（cachegrind の命令数 `-inst`、キャッシュ模型の重み付きコスト `-mem`、キャッシュ行をまたいだアクセス数 `-splits`）はプログラムと与えた環境だけで決まるので、機械が何をしていても同じ数が出る。4 つめの `-cycles` は違う。これはプログラムが実際に消費したコアのサイクル数で、他の仕事の影響を受ける。

そこで `perf_counters.py` は、測定中に他の仕事が奪った CPU をコア数で見積もり（`contention` 列）、それが 0.5 コアを超えたら `-cycles` を空にしていた。機械全体が暇なときしか記録しない、という規則である。

結果として `log.csv` の **115 行のうち 110 行にサイクル列が 1 つも無い**。この機械では常に複数のエージェントがビルドとテストを回しているので、条件が満たされる瞬間がほとんど無い。

## 他の仕事がサイクル数に届く経路

サイクル数を動かせるものと動かせないものを実測で切り分けた。プローブは 3 本（作業集合 8 KiB の総和、64 MiB の逐次走査、8 MiB のポインタ追跡）と、コーパスの case を使った。

**届かないもの 2 つ。**

- **CPU を奪われること。** `cycles:u` はプロセスがユーザ空間で回したサイクルだけを数える。走っていない間は数えないので、他プロセスに CPU を明け渡した分は入らない。
- **周波数。** サイクルはサイクルなので、コアが 4.4 GHz で回ろうと 3.1 GHz で回ろうと同じ数になる。壁時間はここで動く。負荷 24.9 の機械で同じ 10 回の実行を両方の指標で読むと、壁時間は最大/最小が 1.55 倍、`cycles:u` は 1.04 倍だった。

**届くもの 2 つ。**

- **同一コアのもう 1 つのスレッド。** SMT の 2 スレッドはコアのフロントエンドと実行ユニットを共有する。相手が命令を出している間、こちらの命令は発行枠を待ち、その待ち時間はサイクルとして数えられる。
- **共有キャッシュ。** 他プロセスがこちらの行を追い出すと、ヒットするはずのアクセスがミスになり、その待ち時間もサイクルとして数えられる。

2 つは性質が違う。キャッシュを奪われる程度はプログラムが主記憶をどれだけ叩くかで決まるので、cachegrind が数える主記憶アクセス数から**事前に**分かる。一方、隣のスレッドが忙しいかどうかはプログラムの性質ではなく、そのときの機械の状態なので、**測定のたびに読む**しかない。

## この変更が入れる 2 つの条件

サイクル数は、次の 2 つがともに成り立つときだけ記録する。

1. **測定を 1 つのコアに固定し、その相方のスレッドが空いていた窓の読みだけを採る。**
2. **case の主記憶アクセスが命令あたり `RAM_RATE_LIMIT`（0.002）以下である**か、機械が `QUIET_CONTENTION`（0.5 コア）以下しか使われていない。

条件 1 が兄弟スレッド経路を、条件 2 が共有キャッシュ経路を塞ぐ。

### 条件 1 の根拠

測定を CPU 5 に固定し、相方の CPU 11 が窓の間どれだけ忙しかったかを `/proc/stat` から読んで、サイクル数と並べた（負荷 29、コーパスの `mandelbrot`）。

| 兄弟の稼働率 | cycles:u |
|---|---|
| 0% | 192,793,202 |
| 14% | 192,016,345 |
| 25-29% | 192,897,192 - 199,008,214 |
| 50-67% | 195,505,983 - 200,109,686 |
| 75-92% | 201,152,542 - 204,780,601 |

単調に増える。閾値を半分に置くと、そこから下の読みは上の読みより 5% 低い。

受け入れ試験は、歴史的に静穏な機械で測られた値との突き合わせで行った。`mandelbrot` の C 参照実装は `-inst-c` が 4 行とも 249,599,203 で一致する同一バイナリで、その `-cycles-c` は 203,247,187 / 203,296,498 / 203,299,270 と 0.03% の幅に収まっている。負荷 29 の機械で読むと：

| 条件 | cycles-c | 歴史との差 |
|---|---|---|
| 絞らない | 221,914,600 | +9.2% |
| 兄弟が半分以上稼働 | 216,673,237 | +6.6% |
| **兄弟が半分未満稼働** | **203,745,780** | **+0.22%** |

別の機会に、contention 2.55 コアの下で 203,376,204（+0.03%）も得ている。

### 条件 2 の根拠

`RAM_RATE_LIMIT` は、last level cache の 2 倍を歩き続けるプロセスを 4 本、別のコアで走らせた状態と、走らせない状態でサイクル数を比べて決めた（3 標本）。

| プログラム | 主記憶アクセス / 命令 | 攻撃下の膨張 |
|---|---|---|
| 作業集合 8 KiB の総和 | 0.0000017 | 0.98 / 0.93 / 1.02 |
| `mandelbrot` | 0.000011 | 1.02 / 0.96 / 0.93 |
| `fill` | 0.00041 | 0.94 / 0.63 / 1.05 |
| `sort` | 0.00080 | 1.05 / 0.95 / 0.90 |
| 8 MiB のポインタ追跡 | 0.00568 | 1.90 / 1.36 / 2.00 |
| `binary_trees` | 0.00594 | 1.90 / 1.65 / 1.97 |
| 64 MiB の逐次走査 | 0.0314 | -- / 1.53 / 2.12 |

0.00080 と 0.00568 のあいだに 7 倍の間隙があり、閾値をその中に置いた。

### 残る経路と、その大きさ

スケジューラによる中断は残る。`cycles:u` に入るのは、中断から復帰した実行がキャッシュ・TLB・分岐予測器を詰め直す分である。プロセスの資源使用状況が数える強制的なコンテキストスイッチ回数と、そのときのサイクル数を並べると、回数が 545 から 811 まで 1.5 倍動くあいだにサイクル数は 2.1% しか動かなかった。中断は加算的な妨害なので、**窓ごとの最小値を採る**推定量がこれを吸収する。兄弟スレッドが全窓で忙しいときは最小値でも逃げられないので、そちらだけ判定を置いている、という非対称になっている。

## 差分が触れる関数

### `benchmark/speedtest/perf_counters.py`

- **`cpu_list`（新規）** — `5,11` や `2-5,8` のような sysfs の CPU 一覧文字列を CPU 番号の配列にする。
- **`measurement_core`（新規）** — プログラムを走らせる CPU と、そのコアのもう 1 つのスレッドを返す。最大番号の CPU が属する対を取り、番号の小さい側で走らせて大きい側を見る。Linux はコアの第 2 スレッドを CPU 番号の上半分に置き、下半分から埋めるので、監視する側が他の仕事に最後に手を出される側になる。
- **`os.sched_setaffinity`（新規の 1 行）** — 測定を起動するプロセス自身に affinity を設定し、子がそれを継承する。
- **`cpu_seconds`（`machine_cpu_seconds` を一般化）** — `/proc/stat` の指定した名前の行から、起動以来アイドルでなかった CPU 秒を返す。行が見つからなければ実行を止める。
- **`sibling_cpu_seconds`（新規）** — 相方のスレッドについて同じ数を返す。SMT の無いコアでは 0 を返す。
- **`read_counters`（既存）** — プログラムを `perf stat` の下で走らせ、イベント名からカウントへの対応を返す。変更なし。
- **`read_window`（`measure` から分割）** — 1 つの窓を読む。`MINIMUM_WINDOW_SECONDS` に達するまでプログラムを繰り返し走らせ、そのあいだの最小サイクル数と、相方のスレッドの稼働率と、全実行が一致した split 数を返す。窓に下限を置くのは、`/proc/stat` が 100 分の 1 秒刻みで数えるためで、数刻みしかない窓では読み自身の量子化が比較する閾値を上回る。
- **`measure`（既存、書き換え）** — 窓を `windows` 個読み、相方が `SIBLING_BUSY_LIMIT` 以下だった窓の最小値を返す。1 つも無ければサイクル数として `None` を返す。
- **`cycles_are_comparable`（新規）** — 読んだサイクル数が、競合よりもプログラムについて多くを語るかを答える。`measure` が `None` を返していれば偽。機械が静穏なら真。そうでなければ、cachegrind が数えた主記憶アクセスが命令あたり `RAM_RATE_LIMIT` 以下かで決める。
- **`take_options`（新規）** — プログラムの手前に立つオプションと、その後ろに残るコマンドを分ける。
- **`self_check`（新規）** — 機械を要さずに読める規則を検査する。`main` の先頭で走る。
- **`main`（既存）** — 上記を繋ぐ。

### `benchmark/speedtest/cachegrind-benchmarking/cachegrind.py`

- **`__main__` ブロック** — 出力に 3 つめのフィールドとして、主記憶に到達したアクセス数を印字する。この数は `get_counts` が既に計算して `combined_instruction_estimate` の重み付き和に畳んでいたもので、畳んだ後は捨てられていた。

### `benchmark/speedtest/reference.py`

- **`measure`（既存）** — case の C / Rust 版を同じ道具で測る。cachegrind の 3 フィールドを受け取り、主記憶アクセス数と命令数を `perf_counters.py` に渡し、`<inst>,<mem>,<ram>,<splits>,<cycles>,<contention>` の 6 フィールドを印字する。
- **`main`（既存）** — オプション名の変更に追随する。

### `benchmark/speedtest/main.fix`

- **`_WINDOWS`（新規、旧 `Args::cycles` の置き換え）** — ハードウェアカウンタを何個の窓で読むか。
- **`main`（既存）** — case ごとに `-ram` 列を書き、主記憶アクセス数と命令数を `perf_counters.py` に渡し、サイクル列を毎回書く。`--cycles` フラグは無くなった。cachegrind とカウンタスクリプトが読めない行を返したときは、どちらが返したかを言って止まる。参照実装の列も `-ram-c` / `-ram-rust` が増えた分だけ添字がずれる。

### `benchmark/speedtest/graph_html.py`

- **`METRICS`（既存の表）** — `ram` の項目が増え、`cycles` の説明文が新しい規則を述べる。
- **`self_check`（既存）** — 固定データに `a-ram` 列と、その系列に対する表明が増えた。

### `benchmark/crosslang/perf.sh`

- 出力の 3 フィールドを名前で読む。`cycles` の見出しの下に 3 つめのフィールド、すなわち contention を印字していた。`${out##*,}` は最後のフィールドを取るので、`perf_counters.py` の出力が 2 列から 3 列になったときに見出しと中身がずれた。

## 利用者が読む文

### チャートの `cycles` の説明（`graph_html.py`）

いままで:

> Core cycles the program spent in user mode, from the hardware counters, as the lowest of several runs. This is the only column here that is not deterministic: it rises with whatever else the machine is doing, so it is read only on runs taken while the machine is free and the series is sparse. Two points are comparable only when the machine had CPU to spare for both, which is what the contention figure beside each commit says.

これから:

> Core cycles the program spent in user mode, from the hardware counters, as the lowest of several windows of runs. This is the only column here that is not deterministic. Other work reaches it two ways: over the core the run shares with the thread beside it, which the harness pins for and watches, and over the cache every core shares, which costs a program in proportion to how much of its data comes from main memory. Where either of them could have moved a reading, the cell is left empty, so the series has gaps; the contention figure beside each commit says how much of the machine the run had.

### チャートの新しい `ram` の説明（`graph_html.py`）

> Accesses that reached main memory, from cachegrind's cache model. The same program and input give the same number on any machine, and it is what decides whether that program's cycle count survives a machine with other work on it.

### ハーネスの警告（`main.fix`）

いままで:

> warning: other work competed for the CPU, so 12 of 46 cases came away without a cycle count (it reached 11.57 cores): nbody, sort, ...

これから:

> warning: 12 of 46 cases came away without a cycle count, with other work taking 11.57 cores while they ran. A count is kept from a window the thread beside the measurement stayed out of, and from a case that reaches main memory seldom enough for the shared cache not to cost it: nbody, sort, ...

### 方法論の記録（`history.md`）

既存の 2 つの境界注記に倣って 1 つ足す。

> **A cycle count no longer waits for an idle machine, and the rows read the new way stay comparable with the rows below them.** The count is taken from the windows of runs that the other thread of the measurement's core stayed out of, and it is kept for a case whose data does not come from main memory often enough for another program to take the cache from it. The same C counterpart, byte for byte, read 203,745,780 cycles under 11 cores of other work and 203,299,270 with the machine to itself, a difference of 0.22%. The `-ram` columns carry the main-memory accesses the cache condition reads.

### `perf_counters.py` の使い方

```
python3 perf_counters.py [--windows N] [--ram-accesses N --instructions N] ./a.out [args...]
python3 perf_counters.py --cpu
```

`--repeat` は実行回数を数えていたが、いまは窓の数を数えるので `--windows` になった。`reference.py measure` も同じ。

## 検証

- **既存列の継続性。** ハーネスを 2 case で通しで走らせ、`-splits` が歴史の値と一致することを確認した（`mandelbrot` 23、その C 参照 17、`fill` 24）。この列は測定されるプログラムに至る exec の連鎖の長さで動くので、当初 `taskset` を前置した版では 1 ずれていた。affinity を起動側のプロセスに設定する形にして戻っている。
- **`self_check`。** `perf_counters.py` の 4 つの規則それぞれについて、それを壊す 1 行の変異を入れると赤くなることを確認した（sysfs の範囲形、兄弟スレッドの判定、オプションの繰り返し、主記憶の率の判定）。`graph_html.py` の `self_check` も新しい列を含めて通る。
- **通し実行。** cachegrind と perf の両方を含む経路を、`mandelbrot`（C と Rust の参照実装つき）と `fill` で通した。`-ram` / `-ram-c` / `-ram-rust` 列が入り、条件を満たした case はサイクル数を得る。

## 変更履歴

利用者から見える振る舞いは変わらないので、`CHANGELOG.md` のエントリは無い。
