### PR TITLE
bug-hunt: メモ化の鍵と、スレッドの窓を測る検出器を 2 つ足す

### DIFF
--- a/.claude/skills/bug-hunt/SKILL.md
+++ b/.claude/skills/bug-hunt/SKILL.md
@@ -241,6 +241,20 @@ Two things make the reading honest. Measure the pre-change compiler on the same 
 
 Leaks, double frees, and use-after-free produce correct output on a good day, so comparing outputs finds none of them. Memcheck does. Interpret its report against a baseline: a glibc thread-local pattern or a third-party library's internal allocation shows up identically on unmodified code.
 
+#### Recompute a memoized answer at the hit, and diff it against what the cache serves
+
+A compiler memoizes almost everything expensive — a generated function keyed by a name, a type's layout keyed by the type, an elaborated module keyed by a hash of its sources. Every key is a claim: *this key names everything the value depends on.* Nothing checks the claim, and a key that omits an input serves a value computed for something else — a wrong answer with no diagnostic anywhere near it.
+
+Check it where the cache is read: on every hit, recompute the value from scratch under a fresh name (or into a scratch slot), diff it against the cached one, and count both the hits and the disagreements over a whole corpus. The count is what makes a silence worth something — "117,454 hits re-derived, one disagreement" is evidence where "no disagreements" alone is not. Prove it fires first by dropping one field from the key and watching the diff report the values that then collide.
+
+Both readings are useful. A disagreement names an input the key is missing. A clean sweep says the key covers everything this corpus reaches, and names its own gap: the value requested only once, since a hit is what the probe rides on.
+
+#### Put another thread's step inside the window, and read an oracle the race leaves alone
+
+Code that observes a shared state and then acts on the observation — "the count says shared, so clone", "the count says unique, so run the destructor" — is correct only while nothing changes between the two. In a threaded program something does, and the failure is invisible to the usual detectors: the counter itself is updated atomically, so a race detector sees no race, and a single-threaded memcheck run never opens the window at all.
+
+Build a harness with the window under your control: two workers, a barrier to start them together, and a delay in one of them that you sweep. Then read an oracle that does not depend on the race being detected — the allocator's in-use bytes before and after, a count of finalizer runs kept in C, the number of frees memcheck reports. What comes back is a number that appears at the delays landing the other thread inside the window and disappears at the delays that do not, and that shape is itself the evidence that the window is what you found.
+
 #### Run threaded programs under a data-race detector
 
 Output comparison and memcheck both run single-threaded and miss data races — two threads racing on a refcount or on shared state produce the right answer on a good day. A data-race detector (ThreadSanitizer, or valgrind's helgrind / DRD) is the one sanitizer routine runs skip, because its false-positive rate is high; that cost is why the concurrency class stays unhunted, and paying it is how a hunt reaches races nothing else does. Triage against a baseline exactly as with memcheck: a glibc or library-internal race pattern shows identically on unmodified code.


### PR DESCRIPTION
RC のコード生成を的にしたバグハント (wave 45) が使った検出器のうち、他のサブシステムでも効く 2 つを `Techniques That Found Bugs` に足す。どちらも今回の的から独立している。

## メモ化した答えを、ヒットのたびに作り直して差分する

コンパイラは高くつくものをほぼすべてメモ化する — 名前で引く生成関数、型で引くレイアウト、ソースのハッシュで引く型検査の結果。**鍵はどれも「この鍵は値が依存するものを全部名指している」という主張**であり、それを検査するものは無い。鍵が入力を 1 つ取りこぼすと、別物のために計算された値が配られ、診断はどこにも出ない。

読む側で検査する: ヒットのたびに値を新しい名前で作り直し、配られた値と差分し、コーパス全体で**ヒット数と不一致数の両方を数える**。数えることが沈黙に意味を与える — 「117,454 回のヒットを作り直して不一致 1 件」は証拠だが、「不一致なし」だけでは証拠にならない。鍵からフィールドを 1 つ落として、衝突する値を差分が報告することを先に確かめる。

## 別のスレッドの一歩を窓の中に置き、競走が触らないオラクルを読む

共有された状態を観測してから、その観測に基づいて行動するコード (「カウントが共有と言ったので複製する」「一意と言ったのでデストラクタを走らせる」) は、その間に何も変わらない限りでのみ正しい。マルチスレッドでは変わるが、**ふつうの検出器はどれも黙る** — カウンタ自体は原子的に更新されるので race detector は競走を見ず、単一スレッドの memcheck は窓を開けもしない。

窓を自分で握るハーネスを作る: ワーカ 2 本、揃えて始める barrier、片方に置いた掃引できる遅延。そして**競走が検出されることに依存しないオラクル**を読む — 前後の in-use バイト、C 側に置いたデストラクタの実行回数、memcheck の free の回数。窓に入る遅延では数が出て、入らない遅延では消える。その形自体が「見つけたのは窓である」ことの証拠になる。

## 出所

1 つ目は #462 (生成される RC ヘルパの名前が予約されていない) を掃いた probe から。**フルスイートで 117,454 回のメモ化ヒットを作り直し、意味的な不一致は仕込んだ衝突 1 件のみ**という否定的結果も同じ probe が出した。陽性対照は `RcState` の接尾辞を鍵から落とす変異。

2 つ目は #461 (配列の記憶域の要素が漏れ、`Destructor` のデストラクタが走らない) の再現から。どちらも memcheck と ThreadSanitizer が黙る形で、遅延を掃引して `mallinfo2` と C 側の計数を読むことで初めて数字になった。