### PR TITLE
main のコンパイルを直す (局所束縛の名前と読み手の食い違い)

### DIFF
--- a/src/metafiles/project_file.rs
+++ b/src/metafiles/project_file.rs
@@ -743,7 +743,7 @@ impl ProjectFile {
         config.project_sources.push(ProjectSources {
             name: self.general.name.clone(),
             version: self.general.version.clone(),
-            origin: source.clone(),
+            origin: project_origin.clone(),
             declared_dependencies: self.declared_dependency_names(BuildConfigType::Build),
             files: self.get_files(BuildConfigType::Build),
         });
@@ -751,7 +751,7 @@ impl ProjectFile {
             config.project_sources.push(ProjectSources {
                 name: self.general.name.clone(),
                 version: self.general.version.clone(),
-                origin: source.clone(),
+                origin: project_origin.clone(),
                 declared_dependencies: self.declared_dependency_names(BuildConfigType::Test),
                 files: self.get_test_only_files(),
             });


### PR DESCRIPTION
`main` がコンパイルできない状態なので、それを直す。

## 何が起きているか

`ProjectFile::set_config` (`src/metafiles/project_file.rs`) は、プロジェクトの取得元 (`ProjectOrigin`) を局所束縛に取り出し、`Configuration::project_sources` へ積む 2 つの記録がそれを読む。束縛の名前は `project_origin` で、読む側は `source` と書いている。

```
error[E0425]: cannot find value `source` in this scope
   --> src/metafiles/project_file.rs:746:21
    |
746 |             origin: source.clone(),
    |                     ^^^^^^ not found in this scope
```

読む側を束縛の名前に合わせる。2 行の変更で、振る舞いは変わらない。

## なぜ両方のスイートを素通りしたか

束縛の改名は PR #454 (レビュー清掃) に、記録を積む 2 行は PR #451 に在り、**どちらのブランチも単独ではコンパイルが通る**。#454 は #451 の途中の commit から切ってあり、その後 #451 に足したコミットが同じ関数の同じ領域を触ったため、2 つの変更は git から見ると別の行で、衝突せずにマージされた。

## 検証

- `cargo check --tests` が通る。
- `cargo test --release tests::test_dependencies` が 13 件すべて通る。
