### PR TITLE
ソースファイルの一覧を、それを持つ記録から導く

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -3,6 +3,7 @@ use crate::elaboration::elaborate_via_config;
 use crate::error::Errors;
 use crate::metafiles::project_file::ProjectFile;
 use crate::misc::info_msg;
+use std::path::PathBuf;
 
 pub fn check(mut config: Configuration) -> Result<(), Errors> {
     info_msg("Checking...");
@@ -16,9 +17,10 @@ pub fn check(mut config: Configuration) -> Result<(), Errors> {
     proj_file.install_dependencies(&mut config, BuildConfigType::Test)?;
 
     // Set all source files as diagnostics target files.
+    let source_files: Vec<PathBuf> = config.source_files().cloned().collect();
     match &mut config.subcommand {
         SubCommand::Diagnostics(diag_config) => {
-            diag_config.files = config.source_files.clone();
+            diag_config.files = source_files;
         }
         _ => unreachable!(),
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -413,18 +413,16 @@ impl ProjectSources {
 /// `Program::module_dependency_hash`, which decides when a cached type-check result may be reused.
 #[derive(Clone)]
 pub struct Configuration {
-    /// Every source file the program is compiled from, the root project's own files and those of
-    /// its dependencies alike.
-    pub source_files: Vec<PathBuf>,
-    /// The subset of `source_files` that is user-authored: the root
-    /// project's own files, files passed via `--file`, and files pushed
-    /// by unit-test entry points. Excludes files contributed by
-    /// dependencies. Used to scope deprecation warnings to user code,
-    /// mirroring how Rust/Swift/Kotlin/etc. only flag deprecated uses in
-    /// the crate or module currently being compiled.
+    /// The source files no project supplies: the ones a `--file` option names, and the ones a
+    /// unit-test entry point builds a configuration around. The files the projects supply are in
+    /// `project_sources`, and `source_files` answers with both.
+    pub extra_source_files: Vec<PathBuf>,
+    /// The source files that are user-authored: the root project's own files, files passed via
+    /// `--file`, and files pushed by unit-test entry points. Excludes files contributed by
+    /// dependencies. Used to scope diagnostics to user code, mirroring how Rust/Swift/Kotlin/etc.
+    /// only flag a deprecated use in the crate or module currently being compiled.
     ///
-    /// Maintain this in lockstep with `source_files` via
-    /// `add_user_source_file` whenever you're adding user code.
+    /// Every one of these is compiled, so `source_files` covers them.
     pub root_source_files: Vec<PathBuf>,
     /// The sources every project contributes to the build, beside what that project declares for
     /// them, the root project and every dependency alike. `ProjectFile::set_config` adds them as it
@@ -589,7 +587,7 @@ impl Configuration {
     fn new(subcommand: SubCommand) -> Result<Self, Errors> {
         Ok(Configuration {
             subcommand,
-            source_files: vec![],
+            extra_source_files: vec![],
             root_source_files: vec![],
             project_sources: vec![],
             object_files: vec![],
@@ -708,17 +706,24 @@ impl Configuration {
             .push((name.to_string(), LinkType::Dynamic));
     }
 
-    /// Register a user-authored source file: the root project's own files,
-    /// a path passed via `--file`, or a file pushed by a unit-test entry
-    /// point. The file lands in `source_files` (so it is parsed alongside
-    /// dependencies) and additionally in `root_source_files`, which scopes
-    /// deprecation diagnostics to user code.
+    /// Take on a user-authored source file that no project supplies: a path passed via `--file`,
+    /// or a file pushed by a unit-test entry point. It is compiled, and it is the user's own, so
+    /// it lands in `extra_source_files` and in `root_source_files` alike.
     ///
-    /// Files contributed by *dependencies* must NOT use this — push them
-    /// into `source_files` directly, leaving `root_source_files` alone.
+    /// A project's own files reach the build through `ProjectFile::set_config`, which records them
+    /// in `project_sources`.
     pub fn add_user_source_file(&mut self, path: PathBuf) {
-        self.source_files.push(path.clone());
+        self.extra_source_files.push(path.clone());
         self.root_source_files.push(path);
+    }
+
+    /// Every source file the program is compiled from: the ones each project supplies, in the
+    /// order the projects were configured, and then the ones no project supplies.
+    pub fn source_files(&self) -> impl Iterator<Item = &PathBuf> {
+        self.project_sources
+            .iter()
+            .flat_map(|sources| sources.files.iter())
+            .chain(self.extra_source_files.iter())
     }
 
     /// Where `--emit-llvm` writes one compilation unit's LLVM IR: a `.ll` file beside the output

--- a/src/elaboration/mod.rs
+++ b/src/elaboration/mod.rs
@@ -206,7 +206,7 @@ fn load_source_files(config: &Configuration) -> Result<Program, Errors> {
     // Parse all source files.
     let mut parsed_programs = vec![];
     let mut errors = Errors::empty();
-    for file_path in &config.source_files {
+    for file_path in config.source_files() {
         let parse_result = parse_file_path(file_path.clone(), config);
         errors.eat_err_or(parse_result, |parsed_program| {
             parsed_programs.push(parsed_program)

--- a/src/metafiles/project_file.rs
+++ b/src/metafiles/project_file.rs
@@ -757,17 +757,11 @@ impl ProjectFile {
             });
         }
 
-        // Append source files. Root-project files go through `add_user_source_file` so they also
-        // land in `root_source_files`, which scopes deprecation diagnostics to the user's own code:
-        // a deprecated use inside a dependency is the dependency's problem. Dependent-project files
-        // are pushed to `source_files` only.
-        let files = self.get_files(mode);
-        if is_dependent_proj {
-            config.source_files.extend(files);
-        } else {
-            for file in files {
-                config.add_user_source_file(file);
-            }
+        // The records above are what the build compiles. The root project's files are the user's
+        // own as well, which scopes diagnostics to the code they can edit: a deprecated use inside
+        // a dependency is the dependency's problem.
+        if !is_dependent_proj {
+            config.root_source_files.extend(self.get_files(mode));
         }
 
         // Append object files.


### PR DESCRIPTION
ビルドがコンパイルするソースファイルの一覧が、2 つの場所に同じものを持っていた。片方を導出にして、二重を消す。振る舞いは変わらない。

## 何が二重だったか

`Configuration` は、コンパイルするソースファイルを `source_files` に並べて持っていた。同時に、`project_sources` が各プロジェクトの出すファイルを、そのプロジェクトが宣言した依存と並べて持っている (宣言していない依存の import を報告するために足したもの)。プロジェクトの出すファイルは、この 2 つの両方に入っていた。

歩調を合わせる仕組みは無く、`root_source_files` の doc コメントが次の書き手に頼んでいるだけだった。

> Maintain this in lockstep with `source_files` via `add_user_source_file` whenever you're adding user code.

## 書き手と読み手は 2 つずつしかない

`source_files` に書くのは 2 か所だった。

- `ProjectFile::set_config` — プロジェクトが出すファイル。依存プロジェクトは `extend`、ルートプロジェクトは `add_user_source_file` 経由。
- `Configuration::add_user_source_file` — `--file` が名指すファイルと、プロジェクトファイル無しで `Configuration` を組む単体テストのファイル。

読むのも 2 か所である。`elaboration::load_source_files` が順に舐めてパースするのと、`fix check` が診断の対象ファイルとして複製するのと。

つまりこの一覧は「プロジェクトが出すファイル」と「どのプロジェクトも出さないファイル」で尽きている。

## 変更

- **`Configuration::source_files`** (フィールド) — **役目**: ビルドがコンパイルするソースファイルの一覧。**変更**: フィールドを消し、同名のメソッドにした。各プロジェクトの記録が持つファイルを、プロジェクトが設定された順に並べ、そのあとにどのプロジェクトも出さないファイルを繋ぐ。

- **`Configuration::extra_source_files`** (フィールド) — **役目**: 新設。どのプロジェクトも出さないソースファイル、すなわち `--file` が名指すものと、単体テストが `Configuration` を直に組んで足すもの。旧 `source_files` のフィールドがこの役目に絞られた形である。

- **`Configuration::add_user_source_file`** — **役目**: 利用者が書いた、どのプロジェクトも出さないソースファイルを受け取る。**変更**: `extra_source_files` と `root_source_files` に入れる (以前は `source_files` と `root_source_files`)。**目的**: プロジェクトが出すファイルはもう `project_sources` に在るので、この口はプロジェクト外のファイル専用になる。

- **`ProjectFile::set_config`** — **役目**: プロジェクトファイルの内容を `Configuration` に反映する。**変更**: ソースファイルを一覧へ積む節を落とした。ルートプロジェクトのときだけ、自分のファイルを `root_source_files` に足す。**目的**: 記録 (`project_sources`) がそのまま一覧になったので、積み直す必要がない。ルートかどうかで分ける理由は診断の範囲を利用者のコードに絞ることだけになり、`is_dependent_proj` の分岐がその 1 点を述べる形になった。

- **`check::check`** と **`elaboration::load_source_files`** — 読み手 2 か所を、フィールドからメソッドへ移した。`fix check` は `config.subcommand` を可変に借りている間に読めないので、一覧を先に集める。

## 並びは変わらない

パースの順が変われば、モジュールのリンク順も、位置を持たない診断の順も動きうる。今日の並びは `create_config` の呼ぶ順で決まっている — ルートプロジェクトの `set_config`、次に `install_dependencies` (依存プロジェクトの `set_config`)、最後に `set_config_from_args` (`--file`)。したがって `source_files` は [ルート, 依存…, `--file`] だった。

導出は [各プロジェクトの記録を順に, どのプロジェクトも出さないファイル] で、記録は同じ順に積まれるので同じ並びになる。テストモードのルートプロジェクトだけ、記録が「通常のソース」と「テストが足すソース」の 2 つに分かれるが、`get_files(Test)` も通常のファイルを先に並べるので、平らにすれば元と同じである。

## 一箇所だけ挙動が変わる (良い方向)

`[build.test] files` が `[build] files` のファイルを重ねて書いている場合、旧 `source_files` にはそのファイルが 2 度入り、2 度パースされていた。記録の側は重複を通常のソースに残して 1 つにしているので、導出では 1 度になる。リポジトリ自身の `src/tests/test_hole_cache/cases/test_and_build` がその形で、テストは通る。

## 検証

- フルスイート: `cargo test --release` が **152 + 1539 passed / 0 failed**。

テストは足していない。導出が壊れれば (プロジェクトの分を落とす、extras を繋がない、のどちらでも) コンパイルできるプログラムが無くなるので、スイートのほぼ全体が赤くなる。押さえる軸としては既に持ち主が居る。
