### PR TITLE
PR 本文の規約: 固定したリンクについて、後のコミットが壊すものと壊さないものを言う

### DIFF
--- a/.claude/skills/pr-message/SKILL.md
+++ b/.claude/skills/pr-message/SKILL.md
@@ -61,7 +61,7 @@ Those are the names the reader opens the source for, and each of them gets exact
 - **Pin every link to a commit hash.** Push the branch, take `git rev-parse HEAD`, and build all of them on that hash. A hash names the same lines forever and keeps resolving after the branch is deleted; a branch name in the path drifts with the next commit and resolves to nothing once the branch is gone.
 - **Span the definition**: `#L<signature>-L<closing>`, from the signature line to the line that closes the body. GitHub highlights that span, so the click lands on the whole function.
 - **A function the change deletes is linked at the commit the branch forked from** (`git merge-base HEAD main`), where it still stands.
-- **Re-pin when the body is revised after further commits are pushed**, so the lines the links point at are the ones the body describes.
+- **Re-pin a link whose file the branch has changed since.** A hash keeps a link resolving, so no link ever breaks; what a later commit breaks is the agreement between the body and what the link opens, and only for a file that commit touched. So when the body is revised on a branch that has moved, re-pin the links into the files the branch changed in between (`git diff <pinned hash> HEAD -- <file>`), and leave the rest as they are.
 
 The two line numbers are mechanical — the signature line, then the first line closing a block at the signature's own indentation:
 

--- a/src/tests/test_contended_release/cases/array_clone/driver.c
+++ b/src/tests/test_contended_release/cases/array_clone/driver.c
@@ -4,19 +4,34 @@
 void fix_worker_write(void *value);
 void fix_worker_drop(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
+// is built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
+static int arrived;
+
+// Holds a thread until both threads have reached this point, so that one is copying the storage
+// while the other lets go of the value. Without this the first thread finishes before the second is
+// created, and the release that ends up last is never the copying thread's.
+//
+// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
+// the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
+    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *write_thread(void *value) {
-    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
-    // of the value. Without this the first thread finishes before the second is created, and the
-    // release that ends up last is never the copying thread's.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_write(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_drop(value);
     return 0;
 }
@@ -24,10 +39,8 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t writer, dropper;
-    pthread_barrier_init(&start, 0, 2);
     pthread_create(&writer, 0, write_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(writer, 0);
     pthread_join(dropper, 0);
-    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_contended_release/cases/destructor/driver.c
+++ b/src/tests/test_contended_release/cases/destructor/driver.c
@@ -11,10 +11,20 @@ void fix_drop_one(void *value);
 
 static int worker_count;
 static pthread_t workers[MAX_THREADS];
-// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
-static pthread_barrier_t round_gate;
 static void *round_value;
 static int stopping;
+
+// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
+//
+// POSIX leaves barriers optional and Darwin omits them, so this is built out of a mutex and a
+// condition variable, which every platform provides. It is reached twice per round, so it counts
+// the rounds it has opened and a thread waits for that count to move: waiting for the arrivals to
+// reach a number would let a thread that reaches the next round first mistake the arrivals of the
+// round it just left for its own.
+static pthread_mutex_t round_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t round_opened = PTHREAD_COND_INITIALIZER;
+static int round_arrived;
+static unsigned rounds_opened;
 
 // Threads that have reached the gate, counted across every round. A round is `worker_count`
 // arrivals, so a thread waits until its own group of that many is complete.
@@ -25,6 +35,21 @@ static int destructor_runs;
 void note_destructor_ran(void) { __atomic_fetch_add(&destructor_runs, 1, __ATOMIC_SEQ_CST); }
 
 int destructor_run_count(void) { return __atomic_load_n(&destructor_runs, __ATOMIC_SEQ_CST); }
+
+// Holds a thread until every worker and the thread driving them has reached this point.
+static void rendezvous(void) {
+    pthread_mutex_lock(&round_lock);
+    unsigned opened = rounds_opened;
+    round_arrived++;
+    if (round_arrived == worker_count + 1) {
+        round_arrived = 0;
+        rounds_opened++;
+        pthread_cond_broadcast(&round_opened);
+    } else {
+        while (rounds_opened == opened) pthread_cond_wait(&round_opened, &round_lock);
+    }
+    pthread_mutex_unlock(&round_lock);
+}
 
 // Holds a thread until every thread of the round has reached this point. They leave within a few
 // hundred nanoseconds of each other, which is what puts more than one of them between reading the
@@ -44,33 +69,31 @@ void wait_at_gate(void) {
 static void *worker(void *unused) {
     (void)unused;
     for (;;) {
-        pthread_barrier_wait(&round_gate);
+        rendezvous();
         if (stopping) return 0;
         fix_drop_one(round_value);
-        pthread_barrier_wait(&round_gate);
+        rendezvous();
     }
 }
 
 // Starts the threads that take the rounds. They live across the rounds, so that a round costs the
-// two words of a barrier rather than the creation of a thread.
+// two words of a rendezvous rather than the creation of a thread.
 void start_workers(int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     worker_count = threads;
     stopping = 0;
-    pthread_barrier_init(&round_gate, 0, threads + 1);
     for (int i = 0; i < threads; i++) pthread_create(&workers[i], 0, worker, 0);
 }
 
 // Hands `value` to every worker, each holding one reference of its own, and waits for the round.
 void run_round(void *value) {
     round_value = value;
-    pthread_barrier_wait(&round_gate);
-    pthread_barrier_wait(&round_gate);
+    rendezvous();
+    rendezvous();
 }
 
 void stop_workers(void) {
     stopping = 1;
-    pthread_barrier_wait(&round_gate);
+    rendezvous();
     for (int i = 0; i < worker_count; i++) pthread_join(workers[i], 0);
-    pthread_barrier_destroy(&round_gate);
 }

--- a/src/tests/test_contended_release/cases/punched_clone/driver.c
+++ b/src/tests/test_contended_release/cases/punched_clone/driver.c
@@ -4,19 +4,34 @@
 void fix_worker_plug(void *value);
 void fix_worker_drop(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
+// is built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
+static int arrived;
+
+// Holds a thread until both threads have reached this point, so that one is copying the storage
+// while the other lets go of the value. Without this the first thread finishes before the second is
+// created, and the release that ends up last is never the copying thread's.
+//
+// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
+// the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
+    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *plug_thread(void *value) {
-    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
-    // of the value. Without this the first thread finishes before the second is created, and the
-    // release that ends up last is never the copying thread's.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_plug(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_drop(value);
     return 0;
 }
@@ -24,10 +39,8 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t plugger, dropper;
-    pthread_barrier_init(&start, 0, 2);
     pthread_create(&plugger, 0, plug_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(plugger, 0);
     pthread_join(dropper, 0);
-    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_thread_safety/cases/hammer/driver.c
+++ b/src/tests/test_thread_safety/cases/hammer/driver.c
@@ -8,12 +8,28 @@
 // and drops it.
 void fix_hammer_one(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the threads need is
+// built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t all_arrived = PTHREAD_COND_INITIALIZER;
+static int expected;
+static int arrived;
+
+// Holds a thread until every thread has reached this point, so that the reference counting they do
+// overlaps. Without this each thread finishes before the next is created and nothing contends.
+//
+// Every thread passes here once, so a thread waits for the arrivals to reach `expected` and nothing
+// resets the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == expected) pthread_cond_broadcast(&all_arrived);
+    while (arrived < expected) pthread_cond_wait(&all_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *worker(void *value) {
-    // Wait for every thread to arrive, so that the reference counting they do overlaps. Without
-    // this each thread finishes before the next is created and nothing contends.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_hammer_one(value);
     return 0;
 }
@@ -22,8 +38,7 @@ static void *worker(void *value) {
 void hammer_from_threads(void *value, int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     pthread_t ids[MAX_THREADS];
-    pthread_barrier_init(&start, 0, threads);
+    expected = threads;
     for (int i = 0; i < threads; i++) pthread_create(&ids[i], 0, worker, value);
     for (int i = 0; i < threads; i++) pthread_join(ids[i], 0);
-    pthread_barrier_destroy(&start);
 }


### PR DESCRIPTION
`pr-message` スキルは、プルリクエストの本文に載せるリンクをコミットハッシュに固定するよう求めており、その並びの最後に「本文を改訂するときは貼り直す」という条項があった。

```
- **Re-pin when the body is revised after further commits are pushed**, so the lines the
  links point at are the ones the body describes.
```

**この条項は、なぜ貼り直すのかを言っていない。**そしてハッシュに固定してある以上、後から何をコミットしてもリンクは壊れず、行がずれることもない。読み手はこの条項を「リンクが古くなる」と読み、実際には起きないことに備えることになる。

実際に後のコミットが壊すのは、**本文が語っている内容と、リンクが開く内容の一致**だけである。しかもそれは、そのコミットが当のファイルを触った場合に限られる。

この経験から書き直した。あるブランチで、リンクを `488fe3eb` に固定したあと `main` を取り込んだところ、取り込んだ変更は `object.rs` と `generator.rs` を触っており、リンク先の 13 ファイルはすべて `488fe3eb` と同一のままだった。貼り直す必要はなく、貼り直す判断は `git diff <固定したハッシュ> HEAD -- <ファイル>` で機械的に下せる。

## 変更した項目

### `Link every item the change adds or modifies` の最後の箇条

**役目**: リンクをいつ貼り直すかを定める。

**変更**: 「リンクは決して壊れない」ことを先に述べ、後のコミットが壊すのは本文とリンク先の一致だけであること、それも当のファイルを触ったコミットに限られることを述べ、判定を `git diff` の 1 行にした。

**目的**: 起きないこと (リンクが壊れる、行がずれる) への備えを読み手から取り除き、実際に確かめるべきことを 1 つ残す。

```diff
--- .claude/skills/pr-message/SKILL.md (before)
+++ .claude/skills/pr-message/SKILL.md (after)
@@ -1 +1 @@
-- **Re-pin when the body is revised after further commits are pushed**, so the lines the links point at are the ones the body describes.
+- **Re-pin a link whose file the branch has changed since.** A hash keeps a link resolving, so no link ever breaks; what a later commit breaks is the agreement between the body and what the link opens, and only for a file that commit touched. So when the body is revised on a branch that has moved, re-pin the links into the files the branch changed in between (`git diff <pinned hash> HEAD -- <file>`), and leave the rest as they are.
```
