### PR TITLE
PR #482 が巻き込んだテストドライバを、PR #479 が残した状態へ戻す

### DIFF
--- a/src/tests/test_contended_release/cases/array_clone/driver.c
+++ b/src/tests/test_contended_release/cases/array_clone/driver.c
@@ -4,34 +4,19 @@
 void fix_worker_write(void *value);
 void fix_worker_drop(void *value);
 
-// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
-// is built here out of a mutex and a condition variable, which every platform provides.
-static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
-static int arrived;
-
-// Holds a thread until both threads have reached this point, so that one is copying the storage
-// while the other lets go of the value. Without this the first thread finishes before the second is
-// created, and the release that ends up last is never the copying thread's.
-//
-// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
-// the count.
-static void rendezvous(void) {
-    pthread_mutex_lock(&gate);
-    arrived++;
-    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
-    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
-    pthread_mutex_unlock(&gate);
-}
+static pthread_barrier_t start;
 
 static void *write_thread(void *value) {
-    rendezvous();
+    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
+    // of the value. Without this the first thread finishes before the second is created, and the
+    // release that ends up last is never the copying thread's.
+    pthread_barrier_wait(&start);
     fix_worker_write(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    rendezvous();
+    pthread_barrier_wait(&start);
     fix_worker_drop(value);
     return 0;
 }
@@ -39,8 +24,10 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t writer, dropper;
+    pthread_barrier_init(&start, 0, 2);
     pthread_create(&writer, 0, write_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(writer, 0);
     pthread_join(dropper, 0);
+    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_contended_release/cases/destructor/driver.c
+++ b/src/tests/test_contended_release/cases/destructor/driver.c
@@ -11,20 +11,10 @@ void fix_drop_one(void *value);
 
 static int worker_count;
 static pthread_t workers[MAX_THREADS];
+// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
+static pthread_barrier_t round_gate;
 static void *round_value;
 static int stopping;
-
-// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
-//
-// POSIX leaves barriers optional and Darwin omits them, so this is built out of a mutex and a
-// condition variable, which every platform provides. It is reached twice per round, so it counts
-// the rounds it has opened and a thread waits for that count to move: waiting for the arrivals to
-// reach a number would let a thread that reaches the next round first mistake the arrivals of the
-// round it just left for its own.
-static pthread_mutex_t round_lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t round_opened = PTHREAD_COND_INITIALIZER;
-static int round_arrived;
-static unsigned rounds_opened;
 
 // Threads that have reached the gate, counted across every round. A round is `worker_count`
 // arrivals, so a thread waits until its own group of that many is complete.
@@ -35,21 +25,6 @@ static int destructor_runs;
 void note_destructor_ran(void) { __atomic_fetch_add(&destructor_runs, 1, __ATOMIC_SEQ_CST); }
 
 int destructor_run_count(void) { return __atomic_load_n(&destructor_runs, __ATOMIC_SEQ_CST); }
-
-// Holds a thread until every worker and the thread driving them has reached this point.
-static void rendezvous(void) {
-    pthread_mutex_lock(&round_lock);
-    unsigned opened = rounds_opened;
-    round_arrived++;
-    if (round_arrived == worker_count + 1) {
-        round_arrived = 0;
-        rounds_opened++;
-        pthread_cond_broadcast(&round_opened);
-    } else {
-        while (rounds_opened == opened) pthread_cond_wait(&round_opened, &round_lock);
-    }
-    pthread_mutex_unlock(&round_lock);
-}
 
 // Holds a thread until every thread of the round has reached this point. They leave within a few
 // hundred nanoseconds of each other, which is what puts more than one of them between reading the
@@ -69,31 +44,33 @@ void wait_at_gate(void) {
 static void *worker(void *unused) {
     (void)unused;
     for (;;) {
-        rendezvous();
+        pthread_barrier_wait(&round_gate);
         if (stopping) return 0;
         fix_drop_one(round_value);
-        rendezvous();
+        pthread_barrier_wait(&round_gate);
     }
 }
 
 // Starts the threads that take the rounds. They live across the rounds, so that a round costs the
-// two words of a rendezvous rather than the creation of a thread.
+// two words of a barrier rather than the creation of a thread.
 void start_workers(int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     worker_count = threads;
     stopping = 0;
+    pthread_barrier_init(&round_gate, 0, threads + 1);
     for (int i = 0; i < threads; i++) pthread_create(&workers[i], 0, worker, 0);
 }
 
 // Hands `value` to every worker, each holding one reference of its own, and waits for the round.
 void run_round(void *value) {
     round_value = value;
-    rendezvous();
-    rendezvous();
+    pthread_barrier_wait(&round_gate);
+    pthread_barrier_wait(&round_gate);
 }
 
 void stop_workers(void) {
     stopping = 1;
-    rendezvous();
+    pthread_barrier_wait(&round_gate);
     for (int i = 0; i < worker_count; i++) pthread_join(workers[i], 0);
+    pthread_barrier_destroy(&round_gate);
 }

--- a/src/tests/test_contended_release/cases/punched_clone/driver.c
+++ b/src/tests/test_contended_release/cases/punched_clone/driver.c
@@ -4,34 +4,19 @@
 void fix_worker_plug(void *value);
 void fix_worker_drop(void *value);
 
-// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
-// is built here out of a mutex and a condition variable, which every platform provides.
-static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
-static int arrived;
-
-// Holds a thread until both threads have reached this point, so that one is copying the storage
-// while the other lets go of the value. Without this the first thread finishes before the second is
-// created, and the release that ends up last is never the copying thread's.
-//
-// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
-// the count.
-static void rendezvous(void) {
-    pthread_mutex_lock(&gate);
-    arrived++;
-    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
-    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
-    pthread_mutex_unlock(&gate);
-}
+static pthread_barrier_t start;
 
 static void *plug_thread(void *value) {
-    rendezvous();
+    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
+    // of the value. Without this the first thread finishes before the second is created, and the
+    // release that ends up last is never the copying thread's.
+    pthread_barrier_wait(&start);
     fix_worker_plug(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    rendezvous();
+    pthread_barrier_wait(&start);
     fix_worker_drop(value);
     return 0;
 }
@@ -39,8 +24,10 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t plugger, dropper;
+    pthread_barrier_init(&start, 0, 2);
     pthread_create(&plugger, 0, plug_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(plugger, 0);
     pthread_join(dropper, 0);
+    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_thread_safety/cases/hammer/driver.c
+++ b/src/tests/test_thread_safety/cases/hammer/driver.c
@@ -8,28 +8,12 @@
 // and drops it.
 void fix_hammer_one(void *value);
 
-// POSIX leaves barriers optional and Darwin omits them, so the meeting point the threads need is
-// built here out of a mutex and a condition variable, which every platform provides.
-static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t all_arrived = PTHREAD_COND_INITIALIZER;
-static int expected;
-static int arrived;
-
-// Holds a thread until every thread has reached this point, so that the reference counting they do
-// overlaps. Without this each thread finishes before the next is created and nothing contends.
-//
-// Every thread passes here once, so a thread waits for the arrivals to reach `expected` and nothing
-// resets the count.
-static void rendezvous(void) {
-    pthread_mutex_lock(&gate);
-    arrived++;
-    if (arrived == expected) pthread_cond_broadcast(&all_arrived);
-    while (arrived < expected) pthread_cond_wait(&all_arrived, &gate);
-    pthread_mutex_unlock(&gate);
-}
+static pthread_barrier_t start;
 
 static void *worker(void *value) {
-    rendezvous();
+    // Wait for every thread to arrive, so that the reference counting they do overlaps. Without
+    // this each thread finishes before the next is created and nothing contends.
+    pthread_barrier_wait(&start);
     fix_hammer_one(value);
     return 0;
 }
@@ -38,7 +22,8 @@ static void *worker(void *value) {
 void hammer_from_threads(void *value, int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     pthread_t ids[MAX_THREADS];
-    expected = threads;
+    pthread_barrier_init(&start, 0, threads);
     for (int i = 0; i < threads; i++) pthread_create(&ids[i], 0, worker, value);
     for (int i = 0; i < threads; i++) pthread_join(ids[i], 0);
+    pthread_barrier_destroy(&start);
 }


### PR DESCRIPTION
PR #482 は、pull request 本文に書くリンクをコミットハッシュに固定する規約について、
後のコミットが何を壊し何を壊さないかを言い足すものだった。ところがそのコミットは、
`.claude/skills/pr-message/SKILL.md` のほかに C のテストドライバ 4 本を運んでいる。

この 4 本は、同じ worktree に未コミットで置かれていた別の作業だった。ブランチを
切り替えたときに作業ツリーごと運ばれ、そのままコミットに入っている。中身は壊れて
いないが、履歴は「pull request 本文の規約を直す変更が、スレッドを起こす C の
プログラムを 4 本書き換えた」と読める。

この pull request は、その 4 本を PR #479 が残した状態へ戻す。PR #482 は自分の
メッセージが述べるものだけを持つことになり、ドライバの変更は、それを説明する
pull request で改めて入る。

## 戻すファイル

いずれも Fix のテストが使うプロジェクトの一部で、`fix` のコンパイラは通らない。

| ファイル | 役割 |
| --- | --- |
| `src/tests/test_contended_release/cases/array_clone/driver.c` | 共有した配列に書き込むスレッドと手放すスレッドを 2 本起こす |
| `src/tests/test_contended_release/cases/punched_clone/driver.c` | 穴の開いた配列について同じことをする |
| `src/tests/test_contended_release/cases/destructor/driver.c` | 1 つの `Std::FFI::Destructor` を多数のスレッドへ配り、ラウンドを回す |
| `src/tests/test_thread_safety/cases/hammer/driver.c` | 1 つの値を 8 スレッドで叩き、ThreadSanitizer に見せる |

Fix にはスレッドを起こす機能が無く、複数スレッドのプログラムは FFI で pthread を
駆動する。だからこれらのテストは Fix と C の 2 本立てになっていて、C 側は
スレッドの起動と待ち合わせだけを持ち、値に触れる処理は Fix 側にある。

## この pull request を入れた直後の状態

macOS の CI は再び落ちる。戻したドライバは `pthread_barrier_t` を使い、Darwin は
POSIX のバリアを実装していないので、C のコンパイルが通らない。これは PR #479 が
入れた状態そのもので、続く pull request が直す。
