### PR TITLE
macOS に無いバリアを使わず、テストのスレッドを mutex と条件変数で待ち合わせる

### DIFF
--- a/src/tests/test_contended_release/cases/array_clone/driver.c
+++ b/src/tests/test_contended_release/cases/array_clone/driver.c
@@ -4,19 +4,34 @@
 void fix_worker_write(void *value);
 void fix_worker_drop(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
+// is built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
+static int arrived;
+
+// Holds a thread until both threads have reached this point, so that one is copying the storage
+// while the other lets go of the value. Without this the first thread finishes before the second is
+// created, and the release that ends up last is never the copying thread's.
+//
+// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
+// the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
+    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *write_thread(void *value) {
-    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
-    // of the value. Without this the first thread finishes before the second is created, and the
-    // release that ends up last is never the copying thread's.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_write(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_drop(value);
     return 0;
 }
@@ -24,10 +39,8 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t writer, dropper;
-    pthread_barrier_init(&start, 0, 2);
     pthread_create(&writer, 0, write_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(writer, 0);
     pthread_join(dropper, 0);
-    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_contended_release/cases/destructor/driver.c
+++ b/src/tests/test_contended_release/cases/destructor/driver.c
@@ -26,7 +26,7 @@ static pthread_cond_t round_opened = PTHREAD_COND_INITIALIZER;
 static int round_arrived;
 static unsigned rounds_opened;
 
-// Threads that have reached the gate, counted across every round. A round is `worker_count`
+// Threads that have reached `wait_at_gate`, counted across every round. A round is `worker_count`
 // arrivals, so a thread waits until its own group of that many is complete.
 static unsigned gate_arrived;
 
@@ -76,8 +76,8 @@ static void *worker(void *unused) {
     }
 }
 
-// Starts the threads that take the rounds. They live across the rounds, so that a round costs the
-// two words of a rendezvous rather than the creation of a thread.
+// Starts the threads that take the rounds. They live across the rounds, so that a round costs a
+// pass through the rendezvous rather than the creation of a thread.
 void start_workers(int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     worker_count = threads;

--- a/src/tests/test_contended_release/cases/destructor/driver.c
+++ b/src/tests/test_contended_release/cases/destructor/driver.c
@@ -11,10 +11,20 @@ void fix_drop_one(void *value);
 
 static int worker_count;
 static pthread_t workers[MAX_THREADS];
-// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
-static pthread_barrier_t round_gate;
 static void *round_value;
 static int stopping;
+
+// Holds the workers and the thread driving the rounds, so a round starts and ends on its word.
+//
+// POSIX leaves barriers optional and Darwin omits them, so this is built out of a mutex and a
+// condition variable, which every platform provides. It is reached twice per round, so it counts
+// the rounds it has opened and a thread waits for that count to move: waiting for the arrivals to
+// reach a number would let a thread that reaches the next round first mistake the arrivals of the
+// round it just left for its own.
+static pthread_mutex_t round_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t round_opened = PTHREAD_COND_INITIALIZER;
+static int round_arrived;
+static unsigned rounds_opened;
 
 // Threads that have reached the gate, counted across every round. A round is `worker_count`
 // arrivals, so a thread waits until its own group of that many is complete.
@@ -25,6 +35,21 @@ static int destructor_runs;
 void note_destructor_ran(void) { __atomic_fetch_add(&destructor_runs, 1, __ATOMIC_SEQ_CST); }
 
 int destructor_run_count(void) { return __atomic_load_n(&destructor_runs, __ATOMIC_SEQ_CST); }
+
+// Holds a thread until every worker and the thread driving them has reached this point.
+static void rendezvous(void) {
+    pthread_mutex_lock(&round_lock);
+    unsigned opened = rounds_opened;
+    round_arrived++;
+    if (round_arrived == worker_count + 1) {
+        round_arrived = 0;
+        rounds_opened++;
+        pthread_cond_broadcast(&round_opened);
+    } else {
+        while (rounds_opened == opened) pthread_cond_wait(&round_opened, &round_lock);
+    }
+    pthread_mutex_unlock(&round_lock);
+}
 
 // Holds a thread until every thread of the round has reached this point. They leave within a few
 // hundred nanoseconds of each other, which is what puts more than one of them between reading the
@@ -44,33 +69,31 @@ void wait_at_gate(void) {
 static void *worker(void *unused) {
     (void)unused;
     for (;;) {
-        pthread_barrier_wait(&round_gate);
+        rendezvous();
         if (stopping) return 0;
         fix_drop_one(round_value);
-        pthread_barrier_wait(&round_gate);
+        rendezvous();
     }
 }
 
 // Starts the threads that take the rounds. They live across the rounds, so that a round costs the
-// two words of a barrier rather than the creation of a thread.
+// two words of a rendezvous rather than the creation of a thread.
 void start_workers(int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     worker_count = threads;
     stopping = 0;
-    pthread_barrier_init(&round_gate, 0, threads + 1);
     for (int i = 0; i < threads; i++) pthread_create(&workers[i], 0, worker, 0);
 }
 
 // Hands `value` to every worker, each holding one reference of its own, and waits for the round.
 void run_round(void *value) {
     round_value = value;
-    pthread_barrier_wait(&round_gate);
-    pthread_barrier_wait(&round_gate);
+    rendezvous();
+    rendezvous();
 }
 
 void stop_workers(void) {
     stopping = 1;
-    pthread_barrier_wait(&round_gate);
+    rendezvous();
     for (int i = 0; i < worker_count; i++) pthread_join(workers[i], 0);
-    pthread_barrier_destroy(&round_gate);
 }

--- a/src/tests/test_contended_release/cases/punched_clone/driver.c
+++ b/src/tests/test_contended_release/cases/punched_clone/driver.c
@@ -4,19 +4,34 @@
 void fix_worker_plug(void *value);
 void fix_worker_drop(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the two threads need
+// is built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t both_arrived = PTHREAD_COND_INITIALIZER;
+static int arrived;
+
+// Holds a thread until both threads have reached this point, so that one is copying the storage
+// while the other lets go of the value. Without this the first thread finishes before the second is
+// created, and the release that ends up last is never the copying thread's.
+//
+// Both threads pass here once, so a thread waits for the arrivals to reach two and nothing resets
+// the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == 2) pthread_cond_broadcast(&both_arrived);
+    while (arrived < 2) pthread_cond_wait(&both_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *plug_thread(void *value) {
-    // Wait for both threads to arrive, so that one is copying the storage while the other lets go
-    // of the value. Without this the first thread finishes before the second is created, and the
-    // release that ends up last is never the copying thread's.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_plug(value);
     return 0;
 }
 
 static void *drop_thread(void *value) {
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_worker_drop(value);
     return 0;
 }
@@ -24,10 +39,8 @@ static void *drop_thread(void *value) {
 // Hands `value` to two threads, each holding one reference of its own, and waits for them.
 void run_workers(void *value) {
     pthread_t plugger, dropper;
-    pthread_barrier_init(&start, 0, 2);
     pthread_create(&plugger, 0, plug_thread, value);
     pthread_create(&dropper, 0, drop_thread, value);
     pthread_join(plugger, 0);
     pthread_join(dropper, 0);
-    pthread_barrier_destroy(&start);
 }

--- a/src/tests/test_thread_safety/cases/hammer/driver.c
+++ b/src/tests/test_thread_safety/cases/hammer/driver.c
@@ -12,19 +12,19 @@ void fix_hammer_one(void *value);
 // built here out of a mutex and a condition variable, which every platform provides.
 static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t all_arrived = PTHREAD_COND_INITIALIZER;
-static int expected;
+static int participants;
 static int arrived;
 
 // Holds a thread until every thread has reached this point, so that the reference counting they do
 // overlaps. Without this each thread finishes before the next is created and nothing contends.
 //
-// Every thread passes here once, so a thread waits for the arrivals to reach `expected` and nothing
-// resets the count.
+// Every thread passes here once, so a thread waits for the arrivals to reach `participants` and
+// nothing resets the count.
 static void rendezvous(void) {
     pthread_mutex_lock(&gate);
     arrived++;
-    if (arrived == expected) pthread_cond_broadcast(&all_arrived);
-    while (arrived < expected) pthread_cond_wait(&all_arrived, &gate);
+    if (arrived == participants) pthread_cond_broadcast(&all_arrived);
+    while (arrived < participants) pthread_cond_wait(&all_arrived, &gate);
     pthread_mutex_unlock(&gate);
 }
 
@@ -38,7 +38,7 @@ static void *worker(void *value) {
 void hammer_from_threads(void *value, int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     pthread_t ids[MAX_THREADS];
-    expected = threads;
+    participants = threads;
     for (int i = 0; i < threads; i++) pthread_create(&ids[i], 0, worker, value);
     for (int i = 0; i < threads; i++) pthread_join(ids[i], 0);
 }

--- a/src/tests/test_thread_safety/cases/hammer/driver.c
+++ b/src/tests/test_thread_safety/cases/hammer/driver.c
@@ -8,12 +8,28 @@
 // and drops it.
 void fix_hammer_one(void *value);
 
-static pthread_barrier_t start;
+// POSIX leaves barriers optional and Darwin omits them, so the meeting point the threads need is
+// built here out of a mutex and a condition variable, which every platform provides.
+static pthread_mutex_t gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t all_arrived = PTHREAD_COND_INITIALIZER;
+static int expected;
+static int arrived;
+
+// Holds a thread until every thread has reached this point, so that the reference counting they do
+// overlaps. Without this each thread finishes before the next is created and nothing contends.
+//
+// Every thread passes here once, so a thread waits for the arrivals to reach `expected` and nothing
+// resets the count.
+static void rendezvous(void) {
+    pthread_mutex_lock(&gate);
+    arrived++;
+    if (arrived == expected) pthread_cond_broadcast(&all_arrived);
+    while (arrived < expected) pthread_cond_wait(&all_arrived, &gate);
+    pthread_mutex_unlock(&gate);
+}
 
 static void *worker(void *value) {
-    // Wait for every thread to arrive, so that the reference counting they do overlaps. Without
-    // this each thread finishes before the next is created and nothing contends.
-    pthread_barrier_wait(&start);
+    rendezvous();
     fix_hammer_one(value);
     return 0;
 }
@@ -22,8 +38,7 @@ static void *worker(void *value) {
 void hammer_from_threads(void *value, int threads) {
     assert(threads >= 1 && threads <= MAX_THREADS);
     pthread_t ids[MAX_THREADS];
-    pthread_barrier_init(&start, 0, threads);
+    expected = threads;
     for (int i = 0; i < threads; i++) pthread_create(&ids[i], 0, worker, value);
     for (int i = 0; i < threads; i++) pthread_join(ids[i], 0);
-    pthread_barrier_destroy(&start);
 }


### PR DESCRIPTION
PR #484 と同じ変更を、`main` を base にして出し直すもの。#484 の base は #483 の
ブランチだったので、2 つがほぼ同時に merge された結果、この変更は `main` ではなく
#483 のブランチへ入った。いま `main` にあるのは #483 の revert だけで、macOS の CI は
落ちたままである。

---

PR #479 が入れた 8 本のテストは macOS のすべての最適化段で落ちる。落ちるのは
テストの中身ではなく、それが使う C のプログラムのコンパイルである。

```
driver.c:7:8: error: unknown type name 'pthread_barrier_t'
driver.c:13:5: error: call to undeclared function 'pthread_barrier_wait'
make: *** [driver.o] Error 1
error: Command "make driver.o" failed with exit code 2.
```

## なぜ C のプログラムがテストにあるのか

Fix にはスレッドを起こす機能が無い。`Document.md` の Multithreading 節が
「Fix has no function that starts a thread or creates a lock. A multi-threaded
program uses the FFI to drive a threading library such as pthread.」と述べる
とおりである。ところがこれらのテストが確かめるのは、**2 つ以上のスレッドが 1 つの値を
同じ瞬間に手放したとき、最後になった解放が値を最後まで壊すか**という性質なので、
複数のスレッドが要る。

そこで各テストは Fix と C の 2 本立てになっている。Fix 側が値を作り、
`Std::mark_threaded` で参照カウントを原子的にしてから、参照をスレッドの数だけ取り、
そのポインタを C へ渡す。C 側は pthread を起こし、`FFI_EXPORT` で公開された Fix の
関数を各スレッドから呼ぶ。**C 側が持つのはスレッドの起動と待ち合わせだけで、値に触れる
処理はすべて Fix 側にある。**

## 何が壊れているか

待ち合わせに `pthread_barrier_t` を使っていた。POSIX はバリアを省略可能な機能と
しており、Darwin はこれを実装していない。macOS の SDK の `pthread.h` にこの型も
関数も無いので、コンパイラは型を知らないと言って止まる。Linux の glibc は実装して
いるため、手元でもコンパイラの CI の ubuntu 側でも通っていた。

同じ非移植性は `hammer` のドライバにもあり、そちらは表に出ていない。ワークフローの
`test` ジョブが `cargo test --release -- --skip tests::test_thread_safety` で
外し、それを走らせる `thread-safety` ジョブが `runs-on: ubuntu-latest` だけだから
である。macOS へ届いた C のドライバは PR #479 のものが最初だった。

## 何をしたか

4 本のドライバから `pthread_barrier_t` を無くし、それぞれが必要とする待ち合わせを
**mutex と条件変数**から組む。この 2 つはどのプラットフォームにもあるので、
`#ifdef __APPLE__` のような場合分けは要らない。

待ち合わせの要求は 2 通りある。

- **1 回きり** — スレッドは起動直後にここを 1 度だけ通る。到着数が参加者数に達したら
  全員を起こす。誰も数を戻さないので、世代を数える必要が無い。
- **繰り返し** — `destructor` のラウンドの進行だけがこれで、1 ラウンドに 2 度通る。
  到着数が参加者数に達するのを待つ形だと、次のラウンドへ先に着いたスレッドが、
  自分が去ったラウンドの到着を自分のものと取り違える。そこで**開いたラウンドの数**を
  数え、スレッドはその数が動くのを待つ。

### `array_clone` と `punched_clone` のドライバ

2 本は、呼ぶ Fix の関数の名前だけが違う。共有した配列を書き換えるスレッドと、
その最中に値を手放すスレッドを 1 本ずつ起こす。

- [`rendezvous`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/array_clone/driver.c#L19-L25) — 追加。2 本のスレッドが
  揃うまで押さえる。片方が記憶域をコピーしている最中にもう片方が値を手放す、という
  重なりを作るためにある。これが無いと 1 本目が 2 本目の生成より先に終わり、
  最後になる解放がコピーしている側のものにならない。押さえる状態は
  [mutex と条件変数と到着数](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/array_clone/driver.c#L9-L11)。
  `punched_clone` の[同じ関数](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/punched_clone/driver.c#L19-L25)と
  [同じ状態](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/punched_clone/driver.c#L9-L11)も同様。
- [`write_thread`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/array_clone/driver.c#L27-L31) /
  [`plug_thread`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/punched_clone/driver.c#L27-L31) と
  [`drop_thread`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/array_clone/driver.c#L33-L37) /
  [`drop_thread`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/punched_clone/driver.c#L33-L37) — スレッドの入口。
  待ち合わせてから、担当の Fix の関数を呼ぶ。`pthread_barrier_wait(&start)` が
  `rendezvous()` になった。待ち合わせの理由を述べていたコメントは、その理由が
  属する `rendezvous` へ移した。
- [`run_workers`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/array_clone/driver.c#L40-L46) /
  [`run_workers`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/punched_clone/driver.c#L40-L46) — 2 本を起こして
  待ち合わせる。バリアの初期化と破棄が消え、生成と join だけが残った。待ち合わせの
  状態は静的初期化子で用意されるので、実行時の初期化が要らない。

### `hammer` のドライバ

1 つの値を `threads` 本のスレッドで叩き、ThreadSanitizer に参照カウントの競合を
見せる。

- [`rendezvous`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_thread_safety/cases/hammer/driver.c#L23-L29) — 追加。全スレッドが揃うまで
  押さえる。参加者数は実行時に決まるので
  [`participants`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_thread_safety/cases/hammer/driver.c#L13-L16) から読む。
- [`worker`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_thread_safety/cases/hammer/driver.c#L31-L35) — スレッドの入口。
  `pthread_barrier_wait` が `rendezvous()` になった。
- [`hammer_from_threads`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_thread_safety/cases/hammer/driver.c#L38-L44) — スレッドを起こして
  join する。`pthread_barrier_init(&start, 0, threads)` が `participants = threads`
  になり、破棄が消えた。

### `destructor` のドライバ

1 つの `Std::FFI::Destructor` を多数のスレッドへ配り、全員に同時に手放させる。
これを 5000 ラウンド繰り返す。

- [`rendezvous`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L40-L52) — 追加。ワーカ全部と
  ラウンドを回すスレッドが揃うまで押さえる。最後に着いたスレッドが到着数を 0 に戻し、
  [開いたラウンドの数](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L24-L27)を 1 進めて全員を起こす。
  他のスレッドはその数が自分の見た値から動くまで待つ。
- [`worker`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L69-L77) — ラウンドを取り続ける。
  ラウンドの始めと終わりの `pthread_barrier_wait` が `rendezvous()` になった。
- [`start_workers`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L81-L86) — ワーカを起こす。
  バリアの初期化が消えた。
- [`run_round`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L89-L93) — 値をワーカへ渡し、
  ラウンドの始めと終わりで待ち合わせる。2 つの `pthread_barrier_wait` が
  `rendezvous()` になった。
- [`stop_workers`](https://github.com/tttmmmyyyy/fixlang/blob/8f1f0e564cf7854e88846c1f20048386c47c4c5e/src/tests/test_contended_release/cases/destructor/driver.c#L95-L99) — 終了を告げて join する。
  バリアの破棄が消えた。

`wait_at_gate` は触っていない。これは Fix 側から `FFI_CALL_IO` で呼ばれ、
**解放が落ちる窓を締める**ための別のゲートで、`__atomic` の組み込み関数と
`sched_yield` で書かれている。どちらもどのプラットフォームにもあるので、
移植性の問題が無い。

## 直った run と壊れていた run

壊れていた run は Fix のプログラムに届かない。`fix` が `fixproj.toml` の
`preliminary_commands` に従って `make driver.o` を走らせ、clang が
`pthread_barrier_t` という型を知らないと言って `make` が失敗し、`fix` は
`Command "make driver.o" failed with exit code 2.` を返して終わる。テストは
プログラムが完走しなかったことだけを見る。

直った run では `driver.o` が出来る。スレッドが起こされ、`rendezvous` で揃い、
Fix の関数が呼ばれ、値の解放が重なり、Fix 側の `main` が `ok` を印字する。

## 付録: 確かめたこと

**移植性** — 4 本とも `gcc -std=c11 -Wall -Wextra -Wpedantic` で警告ゼロ。
使っている API は `pthread_mutex_*`、`pthread_cond_*`、`pthread_create/join`、
`sched_yield`、`__atomic_*` のみで、いずれも Darwin にある。macOS 実機は
手元に無いので、最終的な確認は CI が与える。

**テストがまだ捕まえること** — 待ち合わせを変えると、狙っている重なりが起きなく
なってテストが素通りする恐れがある。そこでコンパイラに #461 のバグを 2 つとも
戻して（配列の共有記憶域を裸で解放する、デストラクタを減算前の一意性検査の枝で
走らせる）再ビルドしたところ、8 本すべてが赤になった。

```
the storage was freed without releasing the elements it held
the destructor ran 4924 times for 5000 values
```

**新旧の締まり具合** — 同じ変異コンパイラで、同じプログラムを古いドライバと
新しいドライバでそれぞれ 3 回走らせた。デストラクタが走った回数が少ないほど、
取りこぼした解放が多い、すなわち重なりが起きている。

| 待ち合わせ | 走った回数 / 5000 | 取りこぼし |
| --- | --- | --- |
| 旧 (`pthread_barrier`) | 1096, 1200, 1276 | 75-78% |
| 新 (`rendezvous`) | 894, 782, 657 | 82-87% |

**テストの実行** — Linux で `test_contended_release` 8 本と
`test_thread_safety` 3 本が緑。後者の 3 本は `Std::mark_threaded` 抜きの実行で
ThreadSanitizer が競合を 1 件以上報告することを自分で確かめる作りなので、
新しい待ち合わせでも競合が起きていることが同時に示されている。

**変更履歴** — 項目を足していない。Fix の利用者から見た振る舞いは変わらず、
変わったのはテストが使う C のプログラムだけである。
