### PR TITLE
union のペイロードバッファの大きさを整数で求める

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -102,8 +102,15 @@ fn union_buf_type<'c, 'm>(
         16 => gc.context.i128_type(),
         _ => panic!("Unsupported alignment: {}", max_align),
     };
-    let num_of_ints = (max_size as f32 / max_align as f32).ceil() as u32;
-    max_align_int.array_type(num_of_ints).into()
+    let num_of_ints = max_size.div_ceil(max_align);
+    assert!(
+        num_of_ints <= u32::MAX as u64,
+        "A payload of {} bytes needs {} integers of {} bytes to cover it, more than an LLVM array type holds.",
+        max_size,
+        num_of_ints,
+        max_align,
+    );
+    max_align_int.array_type(num_of_ints as u32).into()
 }
 
 impl ObjectFieldType {

--- a/src/tests/test_union_layout.rs
+++ b/src/tests/test_union_layout.rs
@@ -6,7 +6,8 @@ use crate::constants::STD_NAME;
 use crate::elaboration::elaborate_via_config;
 use crate::error::panic_if_err;
 use crate::fixstd::builtin::{
-    make_bool_ty, make_i64_ty, make_ptr_ty, make_u16_ty, make_u32_ty, make_u64_ty, make_u8_ty,
+    make_bool_ty, make_i64_ty, make_ptr_ty, make_tuple_ty, make_u16_ty, make_u32_ty, make_u64_ty,
+    make_u8_ty,
 };
 use crate::generator::Generator;
 use crate::misc::Map;
@@ -121,5 +122,51 @@ fn test_union_memory_layout() {
         layout(&mut gc, result_ty(make_u8_ty(), make_i64_ty())),
         (16, 8),
         "Result U8 I64"
+    );
+}
+
+/// A union is larger than its largest variant, whatever that variant's size: the payload buffer
+/// covers the variant, and the tag needs a byte of its own beside it.
+///
+/// The payload here is one byte past 2^24, the largest integer a single-precision float counts to
+/// exactly. Counting the buffer's elements through such a float rounds the count down from there,
+/// so a buffer that covers every smaller payload can still fall short of this one.
+#[test]
+fn test_union_is_larger_than_a_payload_past_the_single_precision_significand() {
+    let config = panic_if_err(Configuration::check_mode());
+    let program = panic_if_err(elaborate_via_config(&config));
+    let type_env = program.type_env().clone();
+    let context = Context::create();
+    let target_machine = get_target_machine(config.get_llvm_opt_level(), &config);
+    let module = Generator::create_module("union_payload_test", &context, &target_machine);
+    let mut gc = Generator::new(
+        &context,
+        &module,
+        target_machine.get_target_data(),
+        config.clone(),
+        type_env,
+        Arc::new(Map::default()),
+    );
+
+    // A pair of a type is twice its size, so pairing `U8` twenty-four times over reaches 2^24
+    // bytes; the `U8` beside it makes the payload one byte more.
+    let mut payload = make_u8_ty();
+    for _ in 0..24 {
+        payload = make_tuple_ty(vec![payload.clone(), payload]);
+    }
+    let payload = make_tuple_ty(vec![payload, make_u8_ty()]);
+
+    let (payload_size, _) = layout(&mut gc, payload.clone());
+    let (union_size, _) = layout(&mut gc, option_ty(payload));
+    assert_eq!(
+        payload_size,
+        (1 << 24) + 1,
+        "the payload built for this test"
+    );
+    assert!(
+        union_size > payload_size,
+        "a union over a payload of {} bytes is {} bytes",
+        payload_size,
+        union_size,
     );
 }


### PR DESCRIPTION
Closes #180

union の値は「タグ 1 バイト + ペイロード用バッファ」という形でメモリに置かれる。バッファは、その union のどの変種も収まる大きさでなければならない。この変更は、そのバッファの要素数を求める計算を浮動小数点から整数に移す。

## 変更した item

### [`union_buf_type`](https://github.com/tttmmmyyyy/fixlang/blob/5ece047431ffd48b6460d83dec2c803792cbef71/src/object.rs#L84-L114) (`src/object.rs`)

**役割**:
union の変種の型たちを受け取り、そのペイロードを載せるバッファの LLVM 型を答える。バッファは「整列の大きさの整数」の配列 `[N x iA]` で表される。変種すべてを走査して、いちばん大きい変種のサイズ `max_size` と、いちばん強い整列 `max_align` を求め、`A = max_align * 8` ビットの整数を `N` 個並べた配列型を返す。`N` は「`max_size` バイトを覆うのに `max_align` バイトの整数が何個要るか」、つまり `max_size` を `max_align` で割った切り上げである。

**変更**:
その切り上げ除算を、単精度浮動小数点を経由する形から整数の `div_ceil` に変えた。あわせて、求めた要素数を LLVM の配列型が受け取る `u32` に落とす箇所へ表明を置いた。要素数が `u32` に収まらなければ、配列型は切り詰められた個数を受け取り、返るバッファはペイロードを覆わない。表明はその 1 点を止める。

**目的**:
バッファがペイロードを覆う、という `union_buf_type` の唯一の役目を、ペイロードの大きさによらず成り立たせる。

```diff
--- src/object.rs (before)
+++ src/object.rs (after)
@@ -1,24 +1,31 @@
 fn union_buf_type<'c, 'm>(
     gc: &mut Generator<'c, 'm>,
     field_tys: &[Arc<TypeNode>],
 ) -> BasicTypeEnum<'c> {
     let mut max_size = 0;
     let mut max_align = 1;
     for field_ty in field_tys {
         let struct_ty = gc.embedded_type_of(field_ty);
         max_size = max_size.max(gc.sizeof(&struct_ty));
         // The buffer needs the payloads' ABI alignment, not the preferred alignment: the
         // preferred alignment of a small or empty aggregate is 8, which would over-pad the union.
         max_align = max_align.max(gc.abi_alignment(&struct_ty));
     }
     let max_align_int = match max_align {
         1 => gc.context.i8_type(),
         2 => gc.context.i16_type(),
         4 => gc.context.i32_type(),
         8 => gc.context.i64_type(),
         16 => gc.context.i128_type(),
         _ => panic!("Unsupported alignment: {}", max_align),
     };
-    let num_of_ints = (max_size as f32 / max_align as f32).ceil() as u32;
-    max_align_int.array_type(num_of_ints).into()
+    let num_of_ints = max_size.div_ceil(max_align);
+    assert!(
+        num_of_ints <= u32::MAX as u64,
+        "A payload of {} bytes needs {} integers of {} bytes to cover it, more than an LLVM array type holds.",
+        max_size,
+        num_of_ints,
+        max_align,
+    );
+    max_align_int.array_type(num_of_ints as u32).into()
 }
```

## 何が起きていたか

`max_size` と `max_align` はどちらも `u64` である。これを `f32` に移してから割っていた。

### 追跡に出てくる関数

- [`union_buf_type`](https://github.com/tttmmmyyyy/fixlang/blob/5ece047431ffd48b6460d83dec2c803792cbef71/src/object.rs#L84-L114) — 上のとおり、バッファの LLVM 型を答える。
- `ObjectFieldType::set_union_value` (`src/object.rs`) — union の値と変種の値を受け取り、変種の値をバッファの型へ移してから union のバッファのフィールドに差し込む。`U::big(v)` のような構築がここを通る。
- `ObjectFieldType::get_value_from_union_buf` (`src/object.rs`) — バッファの値と変種の型を受け取り、バッファの中身をその型として読み出す。`u.as_big` のような読み出しがここを通る。
- `Generator::bit_cast` (`src/generator.rs`) — ある型の値を、同じビット列として別の型の値に移す。2 つの型のうち**大きい方**を alloca し、そこへ元の値を store して、行き先の型で load する。上の 2 つはどちらもこれを通る。

### 壊れる実行

`Big` を 16,777,217 バイト (2^24 + 1)、整列 1 の unbox 型とし、`type U = union { big : Big, small : U8 };` を考える。

1. `union_buf_type` が変種を走査し、`max_size = 16777217`、`max_align = 1` を得る。
2. `max_size as f32` を評価する。`f32` の仮数は 24 ビットなので、この整数は表現できない。16,777,216 と 16,777,218 のちょうど中間にあり、最近接偶数への丸めで **16,777,216.0** になる。ここで 1 バイトが落ちる。
3. `16777216.0 / 1.0` は `16777216.0`。`.ceil()` は切り上げる先が無いので `16777216.0` のまま。`as u32` で `16777216`。
4. バッファ型は `[16777216 x i8]` となり、union の型は `{ i8, [16777216 x i8] }` になる。**ペイロードに 1 バイト足りない。**
5. `set_union_value` が `U::big(v)` を組む。`bit_cast` に渡る 2 つの型はペイロード (16,777,217 バイト) とバッファ (16,777,216 バイト) で、大きい方はペイロードである。よって 16,777,217 バイトを alloca に store し、`[16777216 x i8]` を load する。**変種の最後の 1 バイトは union に入らない。**
6. `get_value_from_union_buf` が `u.as_big` を読む。同じ `bit_cast` を逆向きに通る。大きい方はやはりペイロードなので、16,777,216 バイトのバッファを alloca に store し、16,777,217 バイトのペイロード型で load する。**最後の 1 バイトは、その alloca が握っていたスタックの中身である。**

診断は無い。書いた値と読んだ値が末尾 1 バイトだけ違う。

### 直した実行

段 2 と 3 が `max_size.div_ceil(max_align)` の 1 段に変わる。`16777217.div_ceil(1)` は `16777217` で、途中に丸めが入らない。段 4 でバッファ型は `[16777217 x i8]` になり、union は `{ i8, [16777217 x i8] }` になる。段 5 の `bit_cast` は 2 つの型の大きさが等しくなるので値をそのまま返し、段 6 も同じ。書いた 16,777,217 バイトがそのまま読める。

段 4 の後に置いた表明が、残る 1 つの経路を止める。`div_ceil` の答えが `u32` に収まらなければ、`as u32` は上位ビットを捨て、`[N x iA]` は要求より短い配列になる。ペイロードが 4 GiB を超えたときに起きる。

## 食い違いはどこから始まるか

旧実装と `div_ceil` を、5 つの整列 (1, 2, 4, 8, 16) について突き合わせた。

**`max_size` が `max_align` の倍数のとき** (union の最大の変種が、サイズと整列の両方を決める場合):

| 整列 | 最初に食い違うペイロード | 不足 |
| ---: | ---: | ---: |
| 1 | 16,777,217 B | 1 B |
| 2 | 33,554,434 B | 2 B |
| 4 | 67,108,868 B | 4 B |
| 8 | 134,217,736 B | 8 B |
| 16 | 268,435,472 B | 16 B |

**`max_size` と `max_align` が別々の変種から来るとき**、`max_size` は `max_align` の倍数とは限らない。`union { a : Big, b : F64 }` の `Big` が整列 1 の 16,777,217 バイトなら、`max_size = 16777217`、`max_align = 8` である。この場合はどの整列でも **16,777,217 バイト**が閾値になる。丸めが掛かるのは商ではなく `max_size` 自身だからで、整列が強いほど不足するバイト数は増える。

## 利用者に見える文

この変更が足す文は、表明が発火したときのコンパイラのメッセージ 1 つである。

```
A payload of 4294967296 bytes needs 4294967296 integers of 1 bytes to cover it, more than an LLVM array type holds.
```

## テスト

### 何を固定するか

[`test_union_is_larger_than_a_payload_past_the_single_precision_significand`](https://github.com/tttmmmyyyy/fixlang/blob/5ece047431ffd48b6460d83dec2c803792cbef71/src/tests/test_union_layout.rs#L135-L172) (`src/tests/test_union_layout.rs`) は、**union がその最大の変種より真に大きいこと**を固定する。タグが自分の 1 バイトを要求するので、この不等式はどの union についても成り立つ。突く形は、`U8` を対にする段を 24 回重ねて 2^24 バイトの型を作り、さらに `U8` を 1 つ並べた 2^24 + 1 バイトのペイロードを `Option` に入れたもの。

同じファイルの既存の `test_union_memory_layout` と一式をなす。この一式は `ty_to_object_ty` から型のレイアウトを直接読むので、Fix のプログラムをコンパイルせずに union の大きさを問える。2^24 バイトの型を組んでも **0.07 秒**で終わる。

### 変更が無いとどうなるか

赤くなる。`union_buf_type` を旧実装に戻して走らせると、次のメッセージで落ちる。

```
a union over a payload of 16777217 bytes is 16777217 bytes
```

union がペイロードと同じ大きさになっている。バッファが 1 バイト足りず、タグの 1 バイトがその不足を埋めてしまった形である。

### 変更が今日のプログラムを動かさないこと

`union_buf_type` に「新しい式が旧実装と同じ答えを出す」という表明を一時的に置き、全スイートを走らせた。**1570 passed / 0 failed で、表明は一度も発火しなかった。** テストがコンパイルするすべての union のレイアウトについて、この変更が 1 ビットも動かしていない。

## 変更履歴

この変更は `CHANGELOG.md` にエントリを足さない。誤りに到達するには 16 MiB を超えるペイロードの union が要るが、その大きさの union はビルドが終わらない (#476)。今日の利用者に見える振る舞いは 1 つも変わらない。

## 付録: 重複していた報告

同じ 1 行を 2 つの issue が報告していた。#180 (バグハント wave 15、2026-08-02) と #476 の 2 番目の節 (2026-08-20) で、原因も直し方も同じである。#476 の本体は 1 つ目の節 (バッファ全体を SSA 値として実体化する件) なので、そちらには 2 番目の節がここで直ることを書き添えた。
