### PR TITLE
レビュー清掃 (#489): 所有権の走査が運ぶパスと個数の名前

### DIFF
--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -580,12 +580,12 @@ fn resolve_callee_params<'a>(
     Some(func.params.as_slice())
 }
 
-/// The `(arg index, leaf path)` pairs an LLVM op passes through unchanged to its result — the pure
-/// projections `as_arg_projection` reads out of `result_prov`.
+/// The `(arg index, leaf path)` pairs an LLVM op passes through unchanged to its result: the result
+/// leaves whose sole source in `result_prov` is one argument leaf.
 ///
-/// Dropping an argument leaf's consume is sound exactly when the result aliases it, so this shares
-/// `as_arg_projection` with `origin`: a leaf that joins an argument with another source aliases nothing and
-/// keeps its consume, and one whose sole source is `Arg` does both.
+/// Dropping an argument leaf's consume is sound exactly when the result aliases that leaf, and a
+/// result leaf with a single argument leaf behind it aliases it. A leaf that joins an argument with
+/// another source aliases nothing, so it keeps its consume.
 fn passthrough_arg_leaves(
     llvm_gen: &dyn LLVMGen,
     result_ty: &Arc<TypeNode>,

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -312,9 +312,9 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
                 // Reading a field of a boxed struct retains it: a producer.
                 here()
             } else {
-                let mut p = vec![*idx];
-                p.extend_from_slice(path);
-                origin(vars, type_env, &container.name, &p)
+                let mut container_path = vec![*idx];
+                container_path.extend_from_slice(path);
+                origin(vars, type_env, &container.name, &container_path)
             }
         }
         Some(Binding::Payload(scrut, variant)) => match variant {
@@ -323,9 +323,9 @@ fn origin_inner(vars: &VarTable, type_env: &TypeEnv, var: &FullName, path: &[usi
             // An unboxed union's payload is the scrutinee's variant slot — an alias; a boxed union's
             // payload is read out (retained) — a producer.
             Some(tag) if !scrut.ty.is_box(type_env) => {
-                let mut p = vec![*tag];
-                p.extend_from_slice(path);
-                origin(vars, type_env, &scrut.name, &p)
+                let mut scrut_path = vec![*tag];
+                scrut_path.extend_from_slice(path);
+                origin(vars, type_env, &scrut.name, &scrut_path)
             }
             Some(_) => here(),
         },
@@ -484,10 +484,10 @@ pub(crate) fn destructure_consumes(
         .into_iter()
         .filter(|leaf| {
             // A boxed leaf of an unboxed container starts with a field index, so its path is non-empty.
-            let field = leaf
+            let field_idx = leaf
                 .first()
                 .expect("a boxed leaf of an unboxed container has a non-empty path");
-            !named_fields.contains(field)
+            !named_fields.contains(field_idx)
         })
         .collect()
 }
@@ -825,21 +825,22 @@ impl References {
     /// References holding one reference of `a` and two of `b` cover one holding one of each, and do
     /// not cover one holding three of `b`. Every `References` covers itself and covers an empty one.
     pub(crate) fn covers(&self, other: &References) -> bool {
-        other
-            .0
-            .iter()
-            .all(|(object, count)| self.0.get(object).is_some_and(|held| held >= count))
+        other.0.iter().all(|(object, count)| {
+            self.0
+                .get(object)
+                .is_some_and(|held_count| held_count >= count)
+        })
     }
 
     /// Drop `other`'s references from these, where `covers` holds of the two.
     pub(crate) fn subtract(&mut self, other: &References) {
         for (object, count) in &other.0 {
-            let held = self
+            let held_count = self
                 .0
                 .get_mut(object)
                 .expect("the removed references are covered by these");
-            *held -= count;
-            if *held == 0 {
+            *held_count -= count;
+            if *held_count == 0 {
                 self.0.remove(object);
             }
         }
@@ -929,9 +930,9 @@ pub(crate) fn units_under(
         Some(sty) => rc_units(&sty, type_env)
             .into_iter()
             .map(|u| {
-                let mut p = path.clone();
-                p.extend(u);
-                p
+                let mut unit_path = path.clone();
+                unit_path.extend(u);
+                unit_path
             })
             .collect(),
         None => vec![path.clone()],
@@ -1141,9 +1142,9 @@ mod tests {
     #[test]
     fn a_held_field_is_found_by_its_layout_index() {
         // A three-field value whose middle field is punched.
-        let held = vec![(0, make_i64_ty()), (2, array_of_i64())];
-        assert_eq!(held_field_type(&held, 0, "test"), make_i64_ty());
-        assert_eq!(held_field_type(&held, 2, "test"), array_of_i64());
+        let held_fields = vec![(0, make_i64_ty()), (2, array_of_i64())];
+        assert_eq!(held_field_type(&held_fields, 0, "test"), make_i64_ty());
+        assert_eq!(held_field_type(&held_fields, 2, "test"), array_of_i64());
     }
 
     /// A path index naming a punched field aborts the walk, and the message names the walk that
@@ -1155,8 +1156,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "truncate_to_unit")]
     fn a_punched_field_index_aborts_the_walk() {
-        let held = vec![(0, make_i64_ty()), (2, array_of_i64())];
-        held_field_type(&held, 1, "truncate_to_unit");
+        let held_fields = vec![(0, make_i64_ty()), (2, array_of_i64())];
+        held_field_type(&held_fields, 1, "truncate_to_unit");
     }
 
     /// A closure's step is its capture, and the fields it reports are the fields a closure is laid
@@ -1193,16 +1194,16 @@ mod tests {
     }
 
     /// The sources of one result leaf, as `result_prov` declares them.
-    fn sources(srcs: Vec<LeafOrigin>) -> Set<LeafOrigin> {
-        srcs.into_iter().collect()
+    fn sources(leaf_sources: Vec<LeafOrigin>) -> Set<LeafOrigin> {
+        leaf_sources.into_iter().collect()
     }
 
     /// A result leaf whose only source is one argument leaf aliases that leaf, and is reported with
     /// the argument's index and path.
     #[test]
     fn a_lone_arg_is_a_projection() {
-        let leaf_srcs = sole_origin(LeafOrigin::Arg(1, vec![0]));
-        assert_eq!(as_arg_projection(&leaf_srcs), Some((1, vec![0])));
+        let leaf_sources = sole_origin(LeafOrigin::Arg(1, vec![0]));
+        assert_eq!(as_arg_projection(&leaf_sources), Some((1, vec![0])));
     }
 
     /// A result leaf that is the argument on one path and a new value on another aliases neither:
@@ -1210,16 +1211,16 @@ mod tests {
     /// projection would drop the consume without the alias, releasing one object twice.
     #[test]
     fn an_arg_joined_with_another_source_is_not_a_projection() {
-        let leaf_srcs = sources(vec![LeafOrigin::Fresh, LeafOrigin::Arg(0, vec![])]);
-        assert_eq!(as_arg_projection(&leaf_srcs), None);
+        let leaf_sources = sources(vec![LeafOrigin::Fresh, LeafOrigin::Arg(0, vec![])]);
+        assert_eq!(as_arg_projection(&leaf_sources), None);
     }
 
     /// A result leaf that may come from either of two arguments aliases neither: a projection names
     /// one argument, and here the choice would fall to whichever of the two the set yields first.
     #[test]
     fn one_of_two_args_is_not_a_projection() {
-        let leaf_srcs = sources(vec![LeafOrigin::Arg(0, vec![]), LeafOrigin::Arg(1, vec![])]);
-        assert_eq!(as_arg_projection(&leaf_srcs), None);
+        let leaf_sources = sources(vec![LeafOrigin::Arg(0, vec![]), LeafOrigin::Arg(1, vec![])]);
+        assert_eq!(as_arg_projection(&leaf_sources), None);
     }
 
     /// A leaf the op itself produced — a fresh object, or one of unknown origin — aliases no


### PR DESCRIPTION
#489 のレビューが、変更の周り (`src/rc_ir/ownership.rs` のうち diff の外) で見つけた清掃である。振る舞いは変わらない — 変えたのはローカル束縛の名前と doc コメントだけで、item の名前・シグネチャ・制御の流れには触れていない。

`#489` の diff を読むときに、これらの改名が混ざっていると変更そのものが読みにくくなるので、別のブランチに分けてある。

## 名前 (`code-review` の naming の規約)

規約は「名前からその中身が予測できるか」を問う。読み手が誤った像を作る名前を直す。

- `origin_inner` の `Binding::Field` / `Binding::Payload` の腕にある `p` -> `container_path` / `scrut_path`。どちらも「フィールドの index を前に付けて作った、容器の側のパス」で、`p` は何のパスか言っていなかった。
- `units_under` の `p` -> `unit_path`。この関数が集めているのは reference-counting unit のパスである。
- `References::covers` / `References::subtract` の `held` -> `held_count`。中身は参照そのものではなく、その個数。
- `destructure_consumes` の `field` -> `field_idx`。中身は index で、`field_idx` はこのコードベースの語。
- 単体テストの `srcs` / `leaf_srcs` -> `leaf_sources`、`held` -> `held_fields`。同じファイルの本体が `sources` と綴っているので、テストだけが略語を持っていた。

取り下げた候補が 1 つある。`resolve_callee_params` の内側の `fref` が外側の `fref` を隠す件は、内側が外側と同じ値になるので誤解を生まず、改名すると `FuncRef` としての名が悪くなる。

## doc コメント (`code-review` の comment-style の規約)

規約は「コメントは、内部のヘルパを知らない読み手にも読めること」を求める。

- `passthrough_arg_leaves` の doc が `as_arg_projection` を `origin` と共有していることで説明していたのを、入力と出力の言葉に書き換えた。「結果のリーフのうち、`result_prov` における唯一の source が 1 つの引数のリーフであるもの」。

## 振る舞いが変わらないこと

改名はすべてローカル束縛 (関数の引数と `let` / `match` の束縛) で、スコープは 1 つの関数本体に閉じている。doc コメントはコンパイルされない。`cargo test --release rc_ir` は 42 件通過、`cargo check --tests` と `cargo fmt` は差分なし。
