### PR TITLE
レビュー清掃 (#494): RC IR の各部が何を持つかを述べる

### DIFF
--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -299,8 +299,8 @@ pub fn build_object_files<'c>(
     // the optimizations that follow mint types of their own — a capture list, a punched type, the
     // pair a newtype opens into. Those reach code generation without having been validated, so in
     // development mode the program is validated again here, where the types are the ones code
-    // generation will actually lay out. A report at this point names a type the compiler built
-    // rather than one the user wrote, which is why a user's build does not run it.
+    // generation will actually lay out. A report at this point names a type the compiler built, so
+    // only a development build runs it.
     if config.develop_mode {
         program.validate_layouts()?;
     }
@@ -348,7 +348,7 @@ pub fn build_object_files<'c>(
     let mut threads = vec![];
     let units_count = units.len();
     for (i, unit) in units.into_iter().enumerate() {
-        // We generate the main unit in the last.
+        // The main unit is generated last.
         let is_main_unit = i == units_count - 1;
 
         obj_paths.push(unit.object_file_path());

--- a/src/optimization/dead_symbol_elimination.rs
+++ b/src/optimization/dead_symbol_elimination.rs
@@ -2,19 +2,11 @@ use std::mem::take;
 
 use crate::{ast::program::Program, misc::Set};
 
+/// Drop every symbol the program cannot reach from the values the C world enters it through.
 pub fn run(prg: &mut Program) {
-    // Collect names of entry point values.
-    let mut seeds = vec![];
-    if let Some(entry_io) = &mut prg.entry_io_value {
-        seeds.push(entry_io.get_var().name.clone());
-    }
-    for export_stmt in &mut prg.export_statements {
-        if let Some(entry_io) = &mut export_stmt.value_expr {
-            seeds.push(entry_io.get_var().name.clone());
-        }
-    }
+    let mut seeds = prg.root_value_names();
 
-    // Collect names called by the entry point values.
+    // Collect names called by the root values.
     let mut called_syms = seeds.clone().into_iter().collect::<Set<_>>();
     while seeds.len() > 0 {
         let mut new_seeds = vec![];
@@ -30,7 +22,7 @@ pub fn run(prg: &mut Program) {
         seeds = new_seeds;
     }
 
-    // Discaed all symbols not in `called_syms`.
+    // Discard all symbols not in `called_syms`.
     let mut new_syms = vec![];
     for (name, sym) in take(&mut prg.symbols) {
         if called_syms.contains(&name) {

--- a/src/rc_ir/ast.rs
+++ b/src/rc_ir/ast.rs
@@ -7,13 +7,15 @@ use crate::misc::{Map, Set};
 use crate::parse::sourcefile::Span;
 use std::sync::Arc;
 
-/// A variable of the RC IR: a globally unique name together with its concrete (monomorphic) type
-/// and the source span it comes from. Because a fresh name is minted at every binding, a name
-/// resolves its binding uniquely, without scope tracking.
+/// A variable of the RC IR. Because a fresh name is minted at every binding, a name resolves its
+/// binding uniquely, without scope tracking.
 #[derive(Clone)]
 pub struct RcVar {
+    /// The name this variable is bound under, unique across the program.
     pub name: FullName,
+    /// The type of the value bound here, always concrete (monomorphic).
     pub ty: Arc<TypeNode>,
+    /// The source the value bound here is written at. `None` where no source spells it out.
     pub source: Option<Span>,
     /// The source-level name this variable denotes, when it is the binding of a `let`-pattern
     /// variable, a match-arm payload, or a projected capture. Code generation emits a debug local
@@ -31,18 +33,22 @@ pub struct RcVar {
 /// uncurried function-pointer version.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct FuncRef {
+    /// The name the function is defined under. It is the whole of the reference: a function is
+    /// identified by its name across the program.
     pub name: FullName,
 }
 
 /// A whole program: the top-level functions, the global-value initializers, and the names reached
 /// from outside them.
 pub struct RcProgram {
+    /// The top-level functions, keyed by the name each is defined under.
     pub funcs: Map<FuncRef, RcFunc>,
+    /// The initializer of each global value the program defines.
     pub globals: Vec<RcGlobalInit>,
     /// The functions and globals code generation reaches from outside this program: the entry point,
     /// the values exported as C functions, and — where the program is one unit among several — every
-    /// symbol the unit publishes for the others. `dead_code_elim::eliminate_unreachable` keeps what they reach
-    /// and drops the rest.
+    /// symbol the unit publishes for the others. `dead_code_elim::eliminate_unreachable` keeps what
+    /// they reach and drops the rest.
     pub roots: Set<FullName>,
 }
 
@@ -63,8 +69,8 @@ pub struct RcFunc {
     /// `Some` for the closure ABI: the trailing capture-pointer parameter, from which the body
     /// projects the captured values. `None` for the funptr ABI, which has no captures.
     pub capture: Option<RcVar>,
-    /// The type of the value the body returns, which for a funptr-ABI function is the result after
-    /// all of its parameters rather than the arrow taking the rest of them.
+    /// The type of the value the body returns. For a funptr-ABI function it is the result after all
+    /// of its parameters.
     pub ret_ty: Arc<TypeNode>,
     /// The body, evaluated with the parameters and the capture in scope. Its `Ret` returns the
     /// function's value.
@@ -92,14 +98,14 @@ pub struct RcFunc {
 pub type VarPath = (FullName, FieldPath);
 
 /// An RC IR expression together with its source span. An expression's value type is that of the
-/// variable its final `Ret` returns, so it is read from that variable rather than stored here.
-///
-/// The expression is shared through an `Arc`, so cloning a node is O(1). The continuation chain is
-/// thousands of nodes deep for a large body, and the simplifier clones whole bodies, so a
-/// deep-copying clone would overflow the stack.
+/// variable its final `Ret` returns, so it is read from that variable.
 #[derive(Clone)]
 pub struct RcExprNode {
+    /// The expression this node stands for. It is shared through an `Arc`, so cloning a node is
+    /// O(1). The continuation chain is thousands of nodes deep for a large body, and the simplifier
+    /// clones whole bodies, so a deep-copying clone would overflow the stack.
     pub expr: Arc<RcExpr>,
+    /// The source the expression is written at. `None` where no source spells it out.
     pub source: Option<Span>,
 }
 
@@ -120,17 +126,16 @@ pub enum RcExpr {
     /// are moved into the field variables (no per-field retain) and its fields not named here are
     /// dropped; a boxed container retains each named field and releases the container. Reference-count
     /// insertion retains the container before this node iff it is used afterward — together this
-    /// mirrors the current back end's `get_scoped_obj` retain-if-used-later plus `get_struct_fields`
-    /// whole-container extraction. Representing the whole destructure as one node (rather than
-    /// per-field getters) lets that retain be decided once, from the container's liveness after the
-    /// destructure, and placed before the extraction.
+    /// mirrors code generation's `get_scoped_obj` retain-if-used-later plus `get_struct_fields`
+    /// whole-container extraction. One node for the whole destructure lets that retain be decided
+    /// once, from the container's liveness after the destructure, and placed before the extraction.
     Destructure(RcVar, Vec<(usize, RcVar)>, RcState, RcExprNode),
     /// Force the variable's value for its effect and discard it, then continue — the RC IR form of the
     /// source `eval e0; e1`. Forcing a local is a no-op (it is already computed); forcing a global
     /// runs its call-once initializer, whose evaluation may have an effect (e.g. an `undefined`-valued
     /// global). It performs no reference-count operation itself: the variable is only observed, so a
-    /// following `Release` disposes it when it is dead. A distinct node — rather than a binding whose
-    /// result is unused — keeps a value forced for effect from being indistinguishable from dead code.
+    /// following `Release` disposes it when it is dead. A node of its own keeps a value forced for
+    /// effect distinguishable from dead code.
     Eval(RcVar, RcExprNode),
     /// The sole terminator: the value of this expression (a function body or a match arm) is this
     /// variable.
@@ -145,8 +150,7 @@ pub enum RcExpr {
 pub type FieldPath = Vec<usize>;
 
 /// The boxed leaf whose runtime uniqueness an inline-LLVM op branches on: which operand carries the
-/// container, and the path to the leaf within that operand's value. Unlike `VarPath`, `container_index`
-/// is an operand slot (resolved against the op's arguments), not a bound variable name.
+/// container, and the path to the leaf within that operand's value.
 pub struct UniqueCheckOperand {
     /// The position, among the operation's arguments, of the operand holding the container.
     pub container_index: usize,
@@ -264,29 +268,36 @@ impl RcState {
     }
 }
 
-/// The ownership of a single reference-counting unit. `Own` receives ownership: the callee consumes it (by
-/// releasing it or moving it into the result), and the caller retains it before the call at a
-/// non-last use. `Borrow` only borrows it: neither side performs a refcount operation.
+/// The ownership of a single reference-counting unit.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Ownership {
+    /// The callee receives ownership: it consumes the unit, by releasing it or by moving it into
+    /// the result, and the caller retains it before the call at a non-last use.
     Own,
+    /// The callee only borrows the unit: neither side performs a refcount operation.
     Borrow,
 }
 
-/// The ownership of one argument, shaped like the value: each reference-counting unit is `Own` or
-/// `Borrow`, and a part of the value holding no unit is `NoUnit`.
+/// The ownership of one argument, shaped like the value.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum OwnershipShape {
+    /// A part of the value holding no reference-counting unit.
     NoUnit,
+    /// An unboxed aggregate, with the shape of each of its fields. A field is at its own field
+    /// index, so a field holding no unit keeps its place as `NoUnit`.
     Fields(Vec<OwnershipShape>),
+    /// A single reference-counting unit, owned or borrowed.
     Unit(Ownership),
 }
 
-/// The initializer of a global value: the symbol, its type, and the expression that computes it,
-/// with the whole reachable graph marked global (refcount-exempt) before it is stored.
+/// The initializer of a global value, run once when a reader first asks for the value. The whole
+/// graph the value reaches is marked global (refcount-exempt) before it is stored.
 #[derive(Clone)]
 pub struct RcGlobalInit {
+    /// The name the global value is defined and read under.
     pub symbol: FullName,
+    /// The type of the value, always concrete (monomorphic).
     pub ty: Arc<TypeNode>,
+    /// The expression computing the value.
     pub init: RcExprNode,
 }

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -25,7 +25,7 @@
 //! `split_rc_units` first normalizes the lowered reference counting to that granularity: it
 //! decomposes a whole-value or subtree `Retain`/`Release` into one node per unit — a boxed leaf, a
 //! closure capture, or an unboxed union (a union is one unit, since a physical refcount operation on
-//! it must dispatch on the tag rather than name a variant).
+//! it must dispatch on the tag).
 //!
 //! Borrow-ification leaves the caller with a retain before a borrow call and a release after it,
 //! bracketing the call with no consume between. `cancel` removes those net-zero brackets: a retain is
@@ -419,8 +419,8 @@ fn trivially_returns(k: &RcExprNode, x: &FullName) -> bool {
 
 /// Clone a function as its borrow version: mint a fresh name for every bound variable (parameters,
 /// capture, `let` bindings, destructure fields, match-arm payloads) and rewrite all occurrences,
-/// keeping global name uniqueness. The recursive references to top-level functions are not bound
-/// here, so they are left for routing to retarget. Returns the clone and the binder renaming.
+/// keeping global name uniqueness. References to top-level functions stay free here, for routing to
+/// retarget. Returns the clone and the binder renaming.
 fn clone_func(
     func: &RcFunc,
     new_ref: FuncRef,
@@ -751,8 +751,7 @@ fn used_later(name: &FullName, node: &RcExprNode) -> bool {
         RcExpr::Destructure(container, _, _state, k) => {
             container.name == *name || used_later(name, k)
         }
-        // `Eval` observes its variable, so — unlike the transparent reference-count nodes — it counts
-        // as a use.
+        // `Eval` observes its variable, so it counts as a use.
         RcExpr::Eval(v, k) => v.name == *name || used_later(name, k),
     })
 }
@@ -867,9 +866,8 @@ type PendingRetains = Map<VarPath, Vec<PendingRetain>>;
 /// yet.
 ///
 /// A retain of an unboxed union bumps every reference its payload holds, while a release of a
-/// projection of that payload un-bumps one of them, so a retain is un-bumped by a group of releases
-/// rather than by a single one. Cancelling it takes the whole group, and only once the group leaves
-/// nothing outstanding.
+/// projection of that payload un-bumps one of them, so a group of releases un-bumps one retain.
+/// Cancelling it takes the whole group, and only once the group leaves nothing outstanding.
 #[derive(Clone)]
 struct PendingRetain {
     /// The retain node. The releases that un-bump it are recorded under this id.
@@ -896,8 +894,8 @@ fn un_bump(pending: &mut PendingRetains, key: &VarPath, un_bumped: &References) 
     let Some(stack) = pending.get_mut(key) else {
         return UnBump::NoBracket;
     };
-    // A stack kept in `pending` is never empty (an emptied one is removed below), so a pending
-    // retain to un-bump is always present.
+    // `un_bump` removes a stack it empties, so a stack kept in `pending` holds a pending retain to
+    // un-bump.
     let innermost = stack
         .last_mut()
         .expect("a stack kept in `pending` is non-empty");
@@ -1040,7 +1038,7 @@ impl<'a> CancelAnalysis<'a> {
         grow_stack(|| self.walk_inner(node, pending, returns_from_func))
     }
 
-    /// The body of `walk`, which owns the stack growth.
+    /// One node of the walk, threading the pending-retain state through its continuation and arms.
     fn walk_inner(
         &mut self,
         node: &RcExprNode,
@@ -1105,8 +1103,8 @@ impl<'a> CancelAnalysis<'a> {
                 }
                 self.walk(k, pending, returns_from_func)
             }
-            // `Eval` neither consumes, retains, nor releases; it is transparent to the pending-retain
-            // state (any release inserted after it is a separate `Release` node).
+            // `Eval` only observes its variable, so it is transparent to the pending-retain state
+            // (any release inserted after it is a separate `Release` node).
             RcExpr::Eval(_, k) => self.walk(k, pending, returns_from_func),
             RcExpr::Ret(_) => {
                 if returns_from_func {

--- a/src/rc_ir/locality.rs
+++ b/src/rc_ir/locality.rs
@@ -2,15 +2,15 @@
 //! certainly in the `RefcntState::LOCAL` state, so that the operation can drop the runtime state
 //! dispatch and increment or decrement the count directly.
 //!
-//! An object leaves the local state through exactly three doors: reading a global (whose initializer
-//! marks its whole result graph global), `Std::mark_threaded`, and `Std::boxed_from_retained_ptr`.
-//! Everything else — allocating, updating in place, cloning a shared container — leaves the state
-//! byte alone. A forward may-analysis over the value flow therefore decides the question, provided
-//! it distinguishes two facts about a value, because reference counting is *shallow*: a retain
-//! touches only the root object, a release recurses into children only at zero and through a
-//! dispatching traverser, and `is_unique` reads only the root. So `DeepLocal ⊑ RootLocal ⊑ MayExt`:
-//! the root fact is what an annotation needs, and the deep fact is what reading out of a container
-//! needs.
+//! Exactly three operations take an object out of the local state: reading a global (whose
+//! initializer marks its whole result graph global), `Std::mark_threaded`, and
+//! `Std::boxed_from_retained_ptr`. Everything else — allocating, updating in place, cloning a
+//! shared container — leaves the state byte alone. A forward may-analysis over the value flow
+//! therefore decides the question, provided it distinguishes two facts about a value, because
+//! reference counting is *shallow*: a retain touches only the root object, a release recurses into
+//! children only at zero and through a dispatching traverser, and `is_unique` reads only the root.
+//! So `DeepLocal ⊑ RootLocal ⊑ MayExt`: the root fact is what an annotation needs, and the deep
+//! fact is what reading out of a container needs.
 //!
 //! Two layers carry those facts, mirroring the provenance / uniqueness pair. The symbolic layer
 //! (`ExtCond`, `LeafCond`, `ExtShape`) states, for a function or an op, the condition on its inputs
@@ -81,8 +81,8 @@ pub enum Aspect {
 /// One test on an input: input `input`'s boxed leaf at `path`, read through `aspect`.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Atom {
-    /// The index of the input: a parameter, then the capture past them, in a summary; an operand
-    /// slot in an op's `result_locality`.
+    /// The index of the input: a parameter, then the capture past them, in a summary; the index of
+    /// an operand in an op's `result_locality`.
     pub input: usize,
     /// The boxed leaf of that input the test is about, as a path into the input's type.
     pub path: FieldPath,
@@ -95,10 +95,8 @@ pub struct Atom {
 /// does.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ExtCond {
-    /// Holds whatever the inputs are, and absorbs: `Always ⊔ c = Always`. It is a variant of its own
-    /// so that the absorption holds by the shape of the value — the specialization gate asks whether
-    /// a condition mentions any input at all, and a top expressed as an atom set would answer with
-    /// the inputs it happened to list beside it.
+    /// Holds whatever the inputs are, and absorbs: `Always ⊔ c = Always`. A variant of its own, so
+    /// that the absorption and `depends_on_inputs` both follow from the shape of the value.
     Always,
     /// Holds when any listed atom holds. The empty set is the bottom.
     IfAny(Set<Atom>),
@@ -131,7 +129,7 @@ impl ExtCond {
         }
     }
 
-    /// Whether this condition's answer depends on the inputs — the specialization gate's question.
+    /// Whether this condition's answer depends on the inputs — the clone gate's question.
     /// `Always` does not: it holds under every key.
     pub fn depends_on_inputs(&self) -> bool {
         match self {
@@ -141,17 +139,17 @@ impl ExtCond {
     }
 
     /// Substitute the operands' conditions for the atoms, moving a declared condition from the atom
-    /// space of its declaration (an op's operand slots, or a callee's inputs) into that of the
-    /// caller. Used both to compose an op's `result_locality` with its operands and to compose a
-    /// callee's summary with a call's arguments.
+    /// space of its declaration (an op's operand indices, or a callee's inputs) into that of the
+    /// caller.
     pub fn substitute(&self, operands: &[ExtShape]) -> ExtCond {
         let ExtCond::IfAny(atoms) = self else {
             return ExtCond::Always;
         };
         let mut out = ExtCond::bottom();
         for atom in atoms {
-            // Every atom names an operand: an op declares only its own argument slots, and a call
-            // supplies one operand per input of the callee's summary (the capture included).
+            // Every atom names an operand: an op declares atoms only for its own arguments, and
+            // a call supplies one operand per input of the callee's summary (the capture
+            // included).
             let operand = operands.get(atom.input).unwrap_or_else(|| {
                 unreachable!(
                     "a declaration names input {} but {} operands were supplied",
@@ -298,7 +296,7 @@ impl ExtShape {
     /// allocated, force-uniqued by this op, or updated in place under a uniqueness the caller
     /// guarantees. Its root is local; what it reaches is whatever any operand reaches.
     ///
-    /// The middle case is where the contract bites: a global object never passes a uniqueness check
+    /// Force-uniquing is where the contract bites: a global object never passes a uniqueness check
     /// (`build_branch_by_is_unique` sends its global arm to the shared arm), so a force-uniqued
     /// container is local. An op that hands back an operand's object *without* that backing must
     /// not declare `fresh_holding`.
@@ -349,7 +347,7 @@ impl ExtShape {
     }
 
     /// The conditions of the boxed leaves that descend through none of `fields` — what a
-    /// `Destructure` of an unboxed container drops rather than hands out.
+    /// `Destructure` of an unboxed container drops.
     pub fn leaves_outside_fields<'a>(
         &'a self,
         fields: &'a [usize],
@@ -417,7 +415,7 @@ struct Walk<'a> {
     prog: &'a RcProgram,
     /// Where a type's boxed leaf paths, and whether a type is boxed, are read from.
     type_env: &'a TypeEnv,
-    /// Each function's result, symbolic in its inputs, from the phase-1 fixed point.
+    /// Each function's result, symbolic in its inputs, as `summarize` computed it.
     summaries: &'a Map<FuncRef, ExtShape>,
     /// The symbolic locality of every local binding the walk has passed.
     env: Map<FullName, ExtShape>,
@@ -436,18 +434,24 @@ enum Rewritten {
 
 /// What a walk does besides computing shapes.
 enum Mode<'a> {
-    /// Compute shapes, leaving the body as it is, and collect what the clone gate asks: whether some
-    /// reference-counting site's answer depends on the inputs, and which direct callees this body
-    /// hands an input-dependent leaf to.
+    /// Compute shapes, leaving the body as it is, and collect what the clone gate asks of this
+    /// body.
     Survey {
+        /// Whether some reference-counting site of this body is annotated differently under
+        /// different input localities.
         has_dependent_site: bool,
+        /// The direct callees this body hands an input-dependent leaf to.
         dependent_calls: Vec<FuncRef>,
     },
     /// Annotate the reference-counting nodes and route the direct calls, under inputs the enclosing
     /// clone's key makes concrete.
     Clone {
+        /// The locality of each input of the enclosing clone: the parameters, then the capture past
+        /// them.
         inputs: &'a [LocalityKey],
+        /// The functions worth cloning (`clone_gate`); a call to one outside it stays as it is.
         gate: &'a Set<FuncRef>,
+        /// The clones named so far, which a routed call asks for its callee's version.
         clones: &'a mut CloneRegistry<Vec<LocalityKey>>,
     },
 }
@@ -474,7 +478,8 @@ impl<'a> Walk<'a> {
         grow_stack(|| self.walk_inner(node))
     }
 
-    /// The body of `walk`, which owns the stack growth.
+    /// One node of the walk: the shape of the value it evaluates to, and the node rewritten in
+    /// clone mode.
     fn walk_inner(&mut self, node: &RcExprNode) -> (ExtShape, RcExprNode) {
         match node.expr.as_ref() {
             RcExpr::Ret(x) => (self.shape_of(x), node.clone()),
@@ -544,12 +549,12 @@ impl<'a> Walk<'a> {
     }
 
     /// The symbolic locality of an operand. A global's graph was marked global by its initializer —
-    /// one of the three doors out of the local state, and the only rule that reads whether a name is
-    /// local. It has to sit here, at the one place an operand is resolved, because a global reaches
-    /// every operand position: the right-hand side of a `let`, an argument, a scrutinee, a
-    /// destructured container, and — after borrow-ification introduces a release for a value the
-    /// callee borrows — the target of a `Release`. A local is bound before it is read, so the
-    /// environment holds it.
+    /// one of the three operations that take an object out of the local state, and the only rule
+    /// that reads whether a name is local. It has to sit here, at the one place an operand is
+    /// resolved, because a global reaches every operand: the right-hand side of a `let`, an
+    /// argument, a scrutinee, a destructured container, and — after borrow-ification introduces a
+    /// release for a value the callee borrows — the target of a `Release`. A local is bound before
+    /// it is read, so the environment holds it.
     fn shape_of(&self, var: &RcVar) -> ExtShape {
         if var.name.is_global() {
             return ExtShape::always(&var.ty, self.type_env);
@@ -565,8 +570,8 @@ impl<'a> Walk<'a> {
             .clone()
     }
 
-    /// The shape of a `let`'s right-hand side (`Match` excepted, which the caller handles for the
-    /// payload bindings its arms make), and what the right-hand side is rewritten to, if anything.
+    /// The shape of a `let`'s right-hand side other than `Match`, whose arms `walk_match` walks for
+    /// the payload bindings they make, and what the right-hand side is rewritten to, if anything.
     fn walk_rhs(&mut self, result: &RcVar, rhs: &RcRhs) -> (ExtShape, Option<Rewritten>) {
         match rhs {
             RcRhs::Var(y) => (self.shape_of(y), None),
@@ -992,7 +997,8 @@ fn annotate<'a>(
 
 /// The functions worth cloning: those whose own reference-counting sites are annotated differently
 /// under different input localities, and those that hand an input-dependent leaf to such a function
-/// through a direct call. A least fixed point over the direct-call graph, as the uniqueness gate is.
+/// through a direct call. A least fixed point over the direct-call graph, as
+/// `funcs_reaching_unique_check` is.
 ///
 /// Closing it transitively is what keeps a forwarding function — one that counts no reference
 /// itself — from staying canonical, which would make it derive its callee's key from inputs proving

--- a/src/rc_ir/lower.rs
+++ b/src/rc_ir/lower.rs
@@ -26,17 +26,24 @@ use crate::rc_ir::ast::{
 use std::mem;
 use std::sync::Arc;
 
-/// A pending binding accumulated during A-normalization: either a single `let var = rhs`, or a
-/// whole struct/tuple destructure binding several fields at once (`Destructure`).
+/// A binding accumulated during A-normalization, together with the source it comes from. Once the
+/// expression it belongs to is lowered, `fold_bindings` turns each into the RC IR node of the same
+/// name.
 enum PendingBinding {
+    /// `let var = rhs`, binding one variable to the value of a compound expression.
     Let(RcVar, RcRhs, Option<Span>),
+    /// A struct/tuple destructure of the first variable, binding field `index` to `var` for each
+    /// `(index, var)`.
     Destructure(RcVar, Vec<(usize, RcVar)>, Option<Span>),
+    /// The variable forced for its effect and discarded.
     Eval(RcVar, Option<Span>),
 }
 
 /// The result of lowering one AST symbol.
 enum LoweredSymbol {
+    /// A symbol of funptr type, which becomes a top-level function under the symbol's own name.
     Func(RcFunc),
+    /// A symbol of any other type, which becomes a global value computed by its initializer.
     Global(RcGlobalInit),
 }
 
@@ -102,6 +109,8 @@ struct Lowerer<'a> {
 }
 
 impl<'a> Lowerer<'a> {
+    /// A context with nothing lowered yet: an empty scope, no functions, and the fresh-name counter
+    /// at its start.
     fn new(type_env: &'a TypeEnv, global_types: &'a Map<FullName, Arc<TypeNode>>) -> Self {
         Lowerer {
             type_env,
@@ -300,7 +309,7 @@ impl<'a> Lowerer<'a> {
             let mut capture_var = self.fresh_var("cap", make_dynamic_object_ty(), None);
             // A non-empty capture is a real allocation, so the capture object is non-null; an empty
             // capture is the null pointer. Recording this lets the capture's release skip the null
-            // check (matching the current back end). Set it before any clone so it propagates.
+            // check. Set it before any clone so it propagates.
             capture_var.skip_null_check = !captures.is_empty();
             // Bind the capture object under the implicit name `#CAP` too, so a built-in that reads the
             // raw capture object by that name (the `fix` combinator's `FixBody`) resolves to it.
@@ -478,8 +487,7 @@ impl<'a> Lowerer<'a> {
         source: Option<Span>,
         bindings: &mut Vec<PendingBinding>,
     ) -> RcVar {
-        // Evaluation order (matching the current generator): the callee first, then the arguments
-        // left to right.
+        // Evaluation order: the callee first, then the arguments left to right.
         let callee = self.lower_to_var(fun, bindings);
         let arg_vars: Vec<RcVar> = args
             .iter()
@@ -841,7 +849,7 @@ impl<'a> Lowerer<'a> {
                     // parameter), so it has no defining binding to name. Represent the rename
                     // faithfully with a move binding, which carries the source name. The move is
                     // reference-count-neutral: RC insertion retains `obj` before it exactly when it
-                    // is used after, matching the current back end's `let j = i`.
+                    // is used after.
                     let mut renamed =
                         self.fresh_var(&v.name.name, obj.ty.clone(), pat.info.source.clone());
                     renamed.debug_name = Some(v.name.to_string());
@@ -873,7 +881,7 @@ impl<'a> Lowerer<'a> {
                     if let Pattern::Var(v, _) = &subpat.pattern {
                         // The field binds a source variable directly: carry its name for debug info
                         // and bind it. The field variable is always freshly produced by the
-                        // destructure, so no rename move is needed (unlike the top-level `Var` case).
+                        // destructure, so the name attaches to that binding.
                         field_var.debug_name = Some(v.name.to_string());
                         self.bind(&v.name, field_var.clone());
                         bound_names.push(v.name.clone());

--- a/src/rc_ir/print.rs
+++ b/src/rc_ir/print.rs
@@ -17,7 +17,11 @@ use crate::rc_ir::provenance::Provenance;
 /// ownership.
 #[derive(Clone, Copy, Default)]
 pub struct Annotations<'a> {
+    /// The provenance the analysis computed for each variable, keyed by variable name. `None`
+    /// leaves the bindings unannotated.
     pub provs: Option<&'a Map<FullName, Provenance>>,
+    /// The ownership inferred for each parameter and capture, keyed by its variable name. `None`
+    /// leaves the parameters unannotated.
     pub param_ownerships: Option<&'a Map<FullName, OwnershipShape>>,
 }
 

--- a/src/rc_ir/specialization.rs
+++ b/src/rc_ir/specialization.rs
@@ -10,8 +10,8 @@
 //! The clone keyed on the least informative inputs keeps the original function's name and is called
 //! the *canonical* one. Every function keeps its canonical version, since a pass that routes calls
 //! reads no root set and so takes any function to be callable; specialization only adds the more
-//! specific clones the call sites reach. `dead_code_elim::eliminate_unreachable` then drops the versions
-//! nothing calls.
+//! specific clones the call sites reach. `dead_code_elim::eliminate_unreachable` then drops the
+//! versions nothing calls.
 
 use crate::misc::{Map, Set};
 use crate::rc_ir::ast::{FuncRef, RcExprNode, RcFunc, RcProgram, RcVar};
@@ -26,7 +26,7 @@ use std::hash::Hash;
 /// product, so a body of a few lines can name thousands of clones and a caller chain multiplies
 /// them. Nothing in a key's meaning bounds this, and a pass whose lattice happens to collapse — as
 /// uniqueness does, since duplicating a reference costs a value its claim to be the only one — is
-/// bounded by luck rather than by design.
+/// bounded only by luck.
 ///
 /// So the count is bounded outright. Past it, a call routes to the canonical version, which is keyed
 /// on the least informative inputs and therefore carries no annotation at all: exceeding the budget

--- a/src/rc_ir/unique_check_elim.rs
+++ b/src/rc_ir/unique_check_elim.rs
@@ -185,8 +185,8 @@ impl<'a> Specializer<'a> {
             }
             // `Var` and `Closure` need no routing (a closure's target keeps its original name, whose
             // all-`Dynamic` version is always kept), so their right-hand sides pass through unchanged.
-            // Listed explicitly (not a catch-all) so a new `RcRhs` that might need routing fails to
-            // compile here instead of silently passing through.
+            // Each is listed explicitly, so a new `RcRhs` that might need routing fails to compile
+            // here instead of silently passing through.
             RcExpr::Let(x, rhs @ (RcRhs::Var(_) | RcRhs::Closure(_, _)), k) => {
                 RcExpr::Let(x.clone(), rhs.clone(), self.rewrite_expr(k, inputs))
             }

--- a/src/rc_ir/validate.rs
+++ b/src/rc_ir/validate.rs
@@ -8,11 +8,11 @@
 //!
 //! It checks the structural invariants of the RC IR: within each function every bound name is
 //! unique (no shadowing), every variable use resolves to a binding in scope, or to a global — a
-//! function or a global value, both referenceable by name (a direct call's callee is a function
-//! name, not a local binding) — every `Retain`/`Release` names one reference-counting unit of its
-//! variable; a function carries a capture parameter exactly for the closure ABI; every match has at
-//! least one arm, with any catch-all arm last; an `Llvm` operation's embedded operand names match
-//! its argument list; and a closure value stores the capture layout its target function projects.
+//! function or a global value, both referenceable by name (a direct call names its callee by that
+//! name) — every `Retain`/`Release` names one reference-counting unit of its variable; a function
+//! carries a capture parameter exactly for the closure ABI; every match has at least one arm, with
+//! any catch-all arm last; an `Llvm` operation's embedded operand names match its argument list;
+//! and a closure value stores the capture layout its target function projects.
 
 use crate::ast::name::FullName;
 use crate::ast::program::TypeEnv;
@@ -528,6 +528,8 @@ mod tests {
         v.check_expr(body);
     }
 
+    /// A body binding one variable to a parameter and returning it passes: every use resolves and
+    /// every name is bound once.
     #[test]
     fn accepts_well_formed() {
         // let x = p; ret x   (p is a parameter)
@@ -539,6 +541,8 @@ mod tests {
         check(&body, &["p"]);
     }
 
+    /// A use of a name that neither a binding nor a global provides is caught — the shape a rewrite
+    /// leaves behind when it drops the binding of a variable it still reads.
     #[test]
     #[should_panic(expected = "use of unbound variable")]
     fn rejects_unbound_use() {
@@ -546,6 +550,8 @@ mod tests {
         check(&node(RcExpr::Ret(var("y"))), &[]);
     }
 
+    /// A name bound a second time in one function is caught, so a name resolves its binding
+    /// uniquely and no binding shadows another.
     #[test]
     #[should_panic(expected = "duplicate binding")]
     fn rejects_duplicate_binding() {
@@ -559,9 +565,11 @@ mod tests {
         check(&body, &["p"]);
     }
 
+    /// A use that no binding in scope answers passes when it names a global, since a function or
+    /// global value is referenceable by name from anywhere.
     #[test]
     fn accepts_use_of_a_global_name() {
-        // let r = call g(); ret r   where g is a global (not a local binding)
+        // let r = call g(); ret r   where g is a global
         let body = node(RcExpr::Let(
             var("r"),
             RcRhs::App(var("g"), vec![]),
@@ -570,6 +578,8 @@ mod tests {
         check_with_globals(&body, &[], &["g"]);
     }
 
+    /// A closure-ABI function without the capture parameter is caught, one direction of the
+    /// agreement between a function's arrow type and its parameter list.
     #[test]
     #[should_panic(expected = "capture-present=false disagrees with closure-ABI=true")]
     fn rejects_capture_missing_for_closure_abi() {
@@ -583,6 +593,8 @@ mod tests {
         )]);
     }
 
+    /// A match with no arms is caught: it selects a body for no value, so the expression it binds
+    /// has none.
     #[test]
     #[should_panic(expected = "match with no arms")]
     fn rejects_empty_match_arms() {
@@ -595,6 +607,8 @@ mod tests {
         check(&body, &["s"]);
     }
 
+    /// A catch-all arm ahead of another arm is caught: code generation compiles it as the tag
+    /// switch's default case, which takes every value the arms after it were written for.
     #[test]
     #[should_panic(expected = "catch-all match arm precedes a later arm")]
     fn rejects_catch_all_before_a_later_arm() {
@@ -621,6 +635,8 @@ mod tests {
         check(&body, &["s"]);
     }
 
+    /// A funptr-ABI function carrying a capture parameter is caught, the other direction of the
+    /// agreement between a function's arrow type and its parameter list.
     #[test]
     #[should_panic(expected = "capture-present=true disagrees with closure-ABI=false")]
     fn rejects_capture_present_for_funptr_abi() {
@@ -634,6 +650,8 @@ mod tests {
         )]);
     }
 
+    /// An operation whose embedded operand names differ from its argument list is caught, so what
+    /// code generation reads and what the reference-counting analyses track stay the same names.
     #[test]
     #[should_panic(expected = "disagree with argument names")]
     fn rejects_llvm_operand_name_mismatch() {


### PR DESCRIPTION
Refs #163

`code-review` の neighborhood pass (ring 2) が、#494 が触ったファイルのハンクの外に当てた清掃である。**1 つを除いてコメントと doc コメントしか変えていない** — 規約が ring 2 で許すのは、振る舞いを構成上変えない編集だけだからである。例外は最後の節に挙げた `dead_symbol_elimination` で、作者の判断で入れている。

base は #494 のブランチなので、この PR 単体では issue を閉じない。#494 を読み終えたあと、(a) これを #494 へ merge してから main へ、(b) #494 を main へ merge してブランチを削除する (GitHub がこの PR の base を main へ付け替える)、のどちらでもよい。

## 何を変えたか

### すべてのフィールドと variant に doc コメントを付けた

`src/rc_ir/ast.rs` の 13 個 (`RcVar` / `FuncRef` / `RcProgram` / `RcExprNode` / `Ownership` / `OwnershipShape` / `RcGlobalInit`)、`src/rc_ir/print.rs` の `Annotations` の 2 個、`src/rc_ir/lower.rs` の `PendingBinding` / `LoweredSymbol` の variant と `Lowerer::new`。

`RcProgram` は #494 が `roots` に doc を付けたので、**同じ struct で 1 つのフィールドだけが文書化されている**状態になっていた。それが揃った。

### 検証器のテスト 9 本に、何の観点を突くかを書いた

`src/rc_ir/validate.rs` の `#[test]` 9 本には doc コメントが無かった。規約の Test comment shape に従い、それぞれが検査する振る舞い・境界・不変条件を 1 文で述べた。

### 退けた読みを否定して述べていた説明を、肯定形にした

「A ではなく B」「A というより B」の形が `src/rc_ir/ast.rs` に 4 か所、`src/rc_ir/borrow.rs` に 4 か所、`src/rc_ir/specialization.rs` と `src/build/build_object_files.rs` に各 1 か所あった。A を本文で扱っていない読み手に「A ではない」は意味を持たないので、B を直接述べる形にした。

例 (`RcFunc::ret_ty`):

```diff
-    /// The type of the value the body returns, which for a funptr-ABI function is the result after
-    /// all of its parameters rather than the arrow taking the rest of them.
+    /// The type of the value the body returns. For a funptr-ABI function it is the result after all
+    /// of its parameters.
```

### 比喩と造語を、コードが持つ名前に置き換えた

`src/rc_ir/locality.rs` のモジュール doc は「オブジェクトが局所状態を出る 3 つの**扉**」と書いていた。扉はコードのどこにも無い。「3 つの**操作**」に直した。同じく「specialization gate」「slot」「phase-1」「the caller」を、`clone_gate` / `summarize` / `funcs_reaching_unique_check` / `walk_match` という**実在する名前**に置き換えた。読み手が grep できる語になる。

### 以前の版と比べる余談を消した

「matching the current back end」「matching the current generator」の類が `src/rc_ir/lower.rs` に 3 か所。読み手は以前の版を見ていないので、現在の振る舞いをそれ自体として述べる形にした。

### 呼び手の列挙と、位置による参照を消した

`src/rc_ir/locality.rs` の `substitute` が呼び手を列挙していた (新しい呼び手が増えるたびに古くなる)。同じファイルの「the middle case」という位置による参照も、指すものの名前に直した。


### 「根とは何か」の定義を 1 か所にした

`Program::root_value_names` は「C の世界がプログラムに入る口」— エントリポイントと `FFI_EXPORT` した値 — を名指すアクセサで、`inline` がインライン化から守るシンボルを決めるのに使い、#494 が RC IR の掃除のルートを決めるのに使う。

`dead_symbol_elimination::run` は同じものを自分で書き下していた。同じ 2 つのフィールドから同じ式で同じ名前を集めており、意味は完全に一致する。これを `prg.root_value_names()` に置き換えた (12 行が 4 行に)。

**1 つの規定が 2 か所に書かれていると、片方にだけ新しい入口が足されたとき、2 つの掃除が別々の答えを出す。** `dead_symbol_elimination` にだけ足されると RC IR の掃除が生きているシンボルを落とし、`root_value_names` にだけ足されると AST 側の掃除が落とす。どちらも症状は原因から遠い。現に #494 は、この規定を 3 つ目に書き下しかけた。

これは #494 が触っていないファイルなので、規約上は ring 3 (findings only) に当たる。作者の判断でこの PR に入れている。

**振る舞いが変わらないこと**: 集める名前も順序も同一 (`root_value_exprs` はエントリ、続いて export の順で、書き下し版と同じ)。最適化パスを触るので、この PR で唯一フルスイートを回した変更である — **1,581 本 / 0 failed**。

## 書かずに残したもの

newtype のタプルフィールド (`OwnedLeaves` / `ExtShape` / `LocalityKey`) と、`ExtCond::IfAny` などの variant のペイロードには doc を付けていない。付けるには newtype を複数行に割る必要があり、書ける文は item の doc の言い直しにしかならない。規約は「名前を言い直すだけの文しか書けないなら、書かずに flag する」と述べている。

## 振る舞いが変わらないこと

`cargo check --tests` と `cargo fmt --check` が通り、ユニットテスト 169 本が緑。編集は散文だけなので、生成されるコードは 1 バイトも動かない。

