### PR TITLE
読みを運ぶ関数ごとに抑制を置く（CI の -O basic が赤）

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -8,21 +8,36 @@
    fun:fputs
 }
 
-# Iterator::advance reads uninitialised union padding speculatively at -O max /
-# -O experimental. An iterator whose state holds a union (such as a nested
-# flat_map's inner iterator) is passed to `advance` by value; when the active
-# variant is smaller than the union's payload buffer, the unused tail of the
-# buffer is uninitialised — Fix leaves union padding uninitialised, as C and Rust
-# do. LLVM hoists the payload read above the tag check and inserts a `freeze`, so
-# the branch is well-defined and the computed result is correct; valgrind still
-# reports it because `freeze` lowers to reading that uninitialised stack slot, so
-# the read is benign. (This also hides a genuine uninitialised read that lands in
-# an `advance` funptr, so drop it when auditing the iterator runtime itself.)
+# The iterator runtime reads uninitialised union padding speculatively. An
+# iterator whose state holds a union — a nested `flat_map`'s inner iterator, a
+# `flatten`'s `Option` of one — is passed by value; when the active variant is
+# smaller than the union's payload buffer, the unused tail of the buffer is
+# uninitialised, as C and Rust also leave union padding. LLVM computes the
+# comparison that payload feeds without waiting for the tag check, freezes the
+# result and combines it with the tag, so the branch is well-defined and the
+# computed result is correct; valgrind reports it because the frozen value is read
+# out of that uninitialised stack slot, so the read is benign. (These also hide a
+# genuine uninitialised read landing in the same function, so drop them when
+# auditing the iterator runtime itself.)
 #
-# Copy this entry into the `valgrind.supp` at the root of any project you check
+# Which function carries the read is decided by how far LLVM inlined the walk, so
+# it differs by optimization level, and there is one entry per function seen to
+# carry it.
+#
+# Copy these entries into the `valgrind.supp` at the root of any project you check
 # under memcheck; fix auto-loads that file (see `Configuration::valgrind_command`).
 {
    fix-iterator-advance-uninitialised-union-padding
    Memcheck:Cond
    fun:Std::Iterator::advance#*
+}
+{
+   fix-iterator-inner-until-uninitialised-union-padding
+   Memcheck:Cond
+   fun:Std::Iterator::_inner_until#*
+}
+{
+   fix-iterator-is-equal-uninitialised-union-padding
+   Memcheck:Cond
+   fun:Std::Iterator::is_equal#*
 }


### PR DESCRIPTION
Closes #502

`-O basic` のスイートが memcheck で 2 本落ちている。`.github/workflows/test.yml` の matrix は `opt-level: [max, basic, none]` を ubuntu で valgrind 付きで回すので、**CI の basic ジョブが赤である**。

```
$ FIX_MAX_OPT_LEVEL=basic cargo test --release --no-fail-fast
running 1601 tests
test tests::test_basic::test_iterator_flatten ... FAILED
test tests::test_basic::test_iterator_flat_map ... FAILED
test result: FAILED. 1599 passed; 2 failed
```

## 何が報告されているか

union を状態に持つ反復子 — 入れ子の `flat_map` の内側、`flatten` が持つ `Option` — は値で渡される。有効な variant がペイロードバッファより小さいとき、バッファの使っていない末尾は未初期化である (C と Rust も union のパディングを初期化しない)。

LLVM はそのペイロードが供給する比較を、タグ検査を待たずに計算する。最適化後の IR で、valgrind が名指す関数の入口はこうなっている。

```llvm
define tailcc void @"Std::Iterator::_inner_until#...#funptr2"(ptr %0, ptr %1, i64 %2, i64 %3, i64 %4, i8 %5, [2 x i64] %6) {
entry:
  %7 = icmp ne i8 %5, 0                                     ; Option のタグ
  %.fca.0.extract5694 = extractvalue [2 x i64] %6, 0         ; ペイロード
  %.fca.1.extract5795 = extractvalue [2 x i64] %6, 1
  %less_than_or_eq… = icmp sgt i64 %.fca.1.extract5795, %.fca.0.extract5694
  %…fr97 = freeze i1 %less_than_or_eq…
  %or.cond99.not = select i1 %…fr97, i1 %7, i1 false         ; = 比較 && タグが some
  br i1 %or.cond99.not, label %case_133, label %case_0
}
```

`select i1 %fr97, i1 %7, i1 false` は `%fr97 && %7` なので、タグが `none` のとき結果は frozen な値によらず false である。**未初期化のペイロードは取る枝を変えられず、答えは正しい。** valgrind が報告するのは、frozen な値がその未初期化のスタックスロットから読まれるからで、読み自体は benign である。

`--track-origins=yes` の出どころも一致する。

```
Uninitialised value was created by a stack allocation
   at 0x4012D0: InitValue#Main::main#...
```

## なぜ抑制が効かないか

`valgrind.supp` の項目はフレームの**名前**で書かれており、名指していたのは 1 つだけだった。

```
fun:Std::Iterator::advance#*
```

**読みがどの関数に立つかは、LLVM がどこまで畳んだかで決まる。** `-O basic` では 2 つの別の関数に立つ。

| 落ちるテスト | 報告されるフレーム |
| --- | --- |
| `test_iterator_flatten` | `Std::Iterator::_inner_until#…#funptr2` |
| `test_iterator_flat_map` | `Std::Iterator::is_equal#…#funptr2` |

`-O max` はこの入力では畳んで読み自体が消え、`-O none` は投機的なロードを作らない。**`-O basic` だけが「読みが起きてなお標準ライブラリの関数がフレームである」水準**である。

## この変更

読みを運ぶ関数ごとに項目を 1 つ置く。`_inner_until` と `is_equal` を足し、コメントを「どの関数に立つかは LLVM の畳み方で決まるので、運ぶことが分かっている関数ごとに項目がある」と述べる形に直した。

```
{
   fix-iterator-advance-uninitialised-union-padding
   Memcheck:Cond
   fun:Std::Iterator::advance#*
}
{
   fix-iterator-inner-until-uninitialised-union-padding
   Memcheck:Cond
   fun:Std::Iterator::_inner_until#*
}
{
   fix-iterator-is-equal-uninitialised-union-padding
   Memcheck:Cond
   fun:Std::Iterator::is_equal#*
}
```

`valgrind.supp` はユーザも自分のプロジェクトの根に置いてよいファイルで (`Configuration::valgrind_command` が `./valgrind.supp` を自動で読む)、コメントはそのために「これらの項目を写せ」と案内している。項目が 1 つから 3 つになるので、その文面も複数形にした。

## 名前で書くことの代償

この形は、標準ライブラリの反復子を書き換えるか LLVM を上げるたびに、また同じことが起きうる。読みを運ぶ関数の名前が動くからである。

代替は 2 つあり、どちらもこの PR では採っていない。

- `fun:Std::Iterator::*` に広げる。名前の移動に強い代わりに、抑制のコメントが警告している「同じ関数に落ちる本物の未初期化読みも隠す」範囲が広がる。
- union のペイロードのうち使っていないバイトを構築時に初期化する。報告そのものが消えて抑制が要らなくなるが、`Option` は標準ライブラリの至る所にあるので、union 構築ごとのストアの費用をコーパスで測る必要がある。

## 計測

| | 変更前 | 変更後 |
| --- | --- | --- |
| `FIX_MAX_OPT_LEVEL=basic` | 1599 passed / **2 failed** | **1601 passed / 0 failed** |
| `FIX_MAX_OPT_LEVEL=max` | 1601 passed / 0 failed | 1601 passed / 0 failed |

## CHANGELOG

項目を足していない。`_inner_until` は `v1.4.0` に含まれず (`git tag --contains b019d3c9` が空)、抑制が一致しなくなったのも同じ未リリースの作業によるので、リリース済みの版を使うユーザが踏める欠陥ではない。
