### PR TITLE
bug-hunt: コンパイラがテストの主題を畳んでしまう形を書き足す

### DIFF
--- a/.claude/skills/bug-hunt/SKILL.md
+++ b/.claude/skills/bug-hunt/SKILL.md
@@ -183,6 +183,15 @@ Two shapes recur. **The detector never ran on the code**: the probe compiled awa
 
 This applies with most force right after a change **tightens a bound that used to be loose** — an allocation sized exactly where it used to be over-approximate, a length that used to be padded, a timeout that used to be generous. The slack was hiding every violation smaller than itself; when it goes, the violations become reachable, and a detector proven to fire is how you find out whether any existed.
 
+**A test program is a detector, and a compiler is what makes it inert.** A test whose subject is a
+decision taken while the program runs — which branch, which variant, which element — measures that
+decision only if the compiler cannot take it first. Inputs the optimizer can fold (a literal, a
+length it knows, an arithmetic identity such as `x - x`, an index into an array of constants) let it
+answer while compiling, and what is left runs nothing the test claims to check. Draw the input from
+something the compiler has to leave alone — the program's arguments, a file, a value the run
+computes — and confirm the choice by mutating the mechanism the test names and watching it go red.
+Until that, a green run says only that the program compiled.
+
 #### Run the gatekeeper's predicate at the gate
 
 A pass that exists to guarantee something for a *later* stage — a validator that rejects what code


### PR DESCRIPTION
バグハントの技法の節に、検出器の 1 つの沈み方を書き足す。

## 何を足したか

`Show the detector fires before trusting its silence` は、検出器が黙っていることを証拠として使う前に、その検出器が捕まえるはずの失敗をわざと起こして発火を見よ、と述べている。挙げている沈み方は、サニタイザが命令を解釈できずに死んで 0 件と表示する、差分実行が最適化で中身の消えた 2 つの二値を比べる、表明がコーパスの通らない経路に居る、といったものである。

**テストプログラムそのものが検出器であり、コンパイラがそれを黙らせる**、という形が抜けていた。

このリポジトリで作るテストは Fix のプログラムである。そのテストが見ているのが「実行時にどの枝を取るか」「どの variant か」「どの要素か」であるとき、その判断をコンパイラが先に済ませてしまえば、残った機械語はテストが検査すると言っているものを何も実行しない。畳める入力とは、リテラル、コンパイラの知っている長さ、`x - x` のような恒等式、定数だけを並べた配列への添字などである。

引数・ファイル・実行が計算した値のように、コンパイラが手を出せないものから入力を引くこと、そしてテストが名指す機構を変異させて赤くなることを確かめること、という 2 つを書いた。

## なぜ足りると判断したか

節の追加の基準は「別のサブシステム・別のバグのハントで役に立つこと」である。これは対象を選ばない。コンパイラのテストで実行時の判断を見るものすべてに掛かり、実際に別々の場面で 2 度当たっている。

- #424 の回帰テスト (`test_conditional_update_chain.rs`) — 入れ替えの鎖が偶数段だったため、全条件が偽でも同じ値になり、テストが空振りしていた。段数を奇数にして `const _: () = assert!(STAGES % 2 == 1);` で表明する形で直っている。
- 今回 (#460 のバグハント) — `match` のアームの順序を見るテストが `let n = args.@size - args.@size;` と書かれていた。`x - x` は畳まれ、配列の要素も定数なので `match` ごと消える。**変異を入れてもフルスイート 1,609 本が全部緑**で、finder は「実行して通した」と報告していた。`args.@size - 1` に直すと発火する。

2 例目は、finder が実行して通したと報告したテストでも、変異で赤くなることを測り直すまで信用できない、という形でもある。既存の節がまさにその規律を述べているので、その節を伸ばす形にした。

## 置き場所

新しい節を作らず、`Show the detector fires before trusting its silence` の 3 つ目の段落として足した。「境界を締めた直後に最も効く」という段落の後ろで、同じ節の主題 (沈黙を証拠にする前に発火を見よ) の続きである。
