### PR TITLE
レビュー清掃 (#512): 関連型のテストが何を押さえるかを述べる

### DIFF
--- a/src/tests/test_associated_type.rs
+++ b/src/tests/test_associated_type.rs
@@ -1039,9 +1039,9 @@ main = pure();
     test_source(source, Configuration::develop_mode());
 }
 
-/// A global value whose signature carries an equality on an associated type with a type variable on
-/// its right side. Both variables of the signature stand in its main type, so both are fixed and
-/// the signature is accepted.
+/// A global value whose signature carries an equality on an associated type with a type variable
+/// on its right side, and names that variable nowhere else. The right side of an equality fixes
+/// the variables it names, so the signature is accepted.
 #[test]
 pub fn test_fixv_global_value_fixed_via_equality_rhs() {
     let source = r#"
@@ -1055,7 +1055,7 @@ impl I64 : MyTrait {
     type S I64 = I64;
 }
 
-foo : [a : MyTrait, S a = b] (a, b) -> I64;
+foo : [a : MyTrait, S a = b] a -> I64;
 foo = |_| 0;
 
 main : IO ();

--- a/src/tests/test_associated_type.rs
+++ b/src/tests/test_associated_type.rs
@@ -3,6 +3,10 @@ use crate::{
     tests::test_util::{run_source_assert_failed, test_source, test_source_fail},
 };
 
+/// A trait with an associated type and value members, implemented for arrays, dynamic iterators,
+/// and a wrapper whose element type is the element type of what it holds. Signatures that tie two
+/// containers to one element type, that tie the element type to a concrete type, and that return it
+/// all compile and produce the expected values.
 #[test]
 pub fn test_associated_type_collects() {
     let source = r##"
@@ -82,6 +86,9 @@ pub fn test_associated_type_collects() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An associated type of arity 2 standing for the sum of two type-level numbers, whose
+/// implementation for `Succ n` gives it the same associated type on the smaller number. The
+/// reduction runs to the end: `Value (Add One Two)` holds the value that `Value Three` holds.
 #[test]
 pub fn test_associated_type_type_level_arithmetic() {
     let source = r##"
@@ -124,6 +131,9 @@ pub fn test_associated_type_type_level_arithmetic() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An equality constraint in the context of a trait implementation. The body of the implementation
+/// reads the associated type as the type the equality gives it, and the implementation is found for
+/// a wrapper whose content satisfies the equality.
 #[test]
 pub fn test_associated_type_equality_in_impl_context() {
     let source = r##"
@@ -160,6 +170,9 @@ main: IO () = (
     test_source(&source, Configuration::develop_mode());
 }
 
+/// An equality constraint in the context of a trait implementation that the value it is used on
+/// does not satisfy. The implementation is not found, and the report names the equality between the
+/// two concrete types that fails.
 #[test]
 pub fn test_associated_type_equality_in_impl_context_unsatisfied() {
     let source = r##"
@@ -200,6 +213,8 @@ main: IO () = (
     );
 }
 
+/// An associated type named with no argument in the type of a trait's value member is rejected as
+/// unsaturated.
 #[test]
 pub fn test_regression_f28ea22() {
     let source = r##"
@@ -222,6 +237,9 @@ main = pure();
     );
 }
 
+/// A value whose signature carries an equality on the associated type of a trait with no value
+/// member, called at the type a type alias names. The equality reduces through an implementation
+/// that carries a constraint of its own, and the call compiles.
 #[test]
 pub fn test_regression_on_associated_type_bug() {
     let source = r##"
@@ -263,6 +281,8 @@ main = (
     test_source(&source, Configuration::develop_mode());
 }
 
+/// A signature that names an associated type on a type variable while assuming nothing about that
+/// variable is rejected: the implementation the associated type needs cannot be deduced.
 #[test]
 pub fn test_associated_type_in_type_sign_missing_assumption() {
     let source = r#"
@@ -292,6 +312,8 @@ main = (
     );
 }
 
+/// An implementation that gives an associated type a value naming a type variable its left side
+/// does not bind is rejected as an unknown type variable.
 #[test]
 pub fn test_associated_type_use_unknown_type_variable_in_associated_type_implementation() {
     let source = r#"
@@ -316,6 +338,9 @@ main: IO () = (
     );
 }
 
+/// An implementation that gives an associated type a value naming another associated type on one of
+/// its own parameters. Reducing it at a concrete argument asks for an implementation that argument
+/// does not have, and the report names it.
 #[test]
 pub fn test_regression_issue_70() {
     let source = r#"
@@ -344,6 +369,9 @@ main = (
     );
 }
 
+/// An associated type of kind `* -> *`. The trait's value member applies it to a further type, a
+/// signature ties it by an equality to a variable it constrains to be a functor, and the value runs
+/// and produces the expected result.
 #[test]
 pub fn test_higher_kinded_associated_type() {
     let source = r#"
@@ -375,6 +403,8 @@ main: IO () = do {
     test_source(source, Configuration::develop_mode());
 }
 
+/// An associated type named with no argument in the signature of a global value is rejected as
+/// unsaturated.
 #[test]
 pub fn test_unsaturated_associated_type_in_global_function_signature() {
     let source = r#"
@@ -400,6 +430,8 @@ main = (
     );
 }
 
+/// An equality constraint whose left side gives an associated type of arity 2 a single argument is
+/// rejected as a wrong number of arguments.
 #[test]
 pub fn test_unsaturated_associated_type_in_equality_constraint() {
     let source = r#"
@@ -425,6 +457,8 @@ main = (
     );
 }
 
+/// An implementation that gives an associated type a value naming another associated type with no
+/// argument is rejected as unsaturated.
 #[test]
 pub fn test_unsaturated_associated_type_in_impl_rhs() {
     let source = r#"
@@ -456,6 +490,8 @@ main = pure();
     );
 }
 
+/// An associated type named with no argument in a type annotation inside an expression is rejected
+/// as unsaturated.
 #[test]
 pub fn test_unsaturated_associated_type_in_type_annotation() {
     let source = r#"
@@ -481,6 +517,8 @@ main: IO () = (
     );
 }
 
+/// A signature whose main type gives an associated type of arity 2 a single argument is rejected as
+/// unsaturated.
 #[test]
 pub fn test_unsaturated_multi_param_associated_type() {
     let source = r#"
@@ -510,10 +548,11 @@ main = (
     );
 }
 
+/// The left side of an associated type implementation that names fewer parameters than the
+/// declaration takes — the declaration takes one beyond the type implemented, and the
+/// implementation names none — is rejected.
 #[test]
 pub fn test_unsaturated_associated_type_in_impl_lhs() {
-    // Associated type `MyAssoc` is defined with 1 extra parameter (arity 2 including impl type),
-    // but the implementation provides 0 extra parameters on the LHS.
     let source = r#"
     module Main;
     
@@ -535,9 +574,11 @@ pub fn test_unsaturated_associated_type_in_impl_lhs() {
     );
 }
 
+/// A kind constraint written on a parameter of an associated type other than the first. The
+/// implementation applies that parameter to a type, and a value annotated with the associated type
+/// at `Array` is built and read.
 #[test]
 pub fn test_higher_kinded_second_param_of_associated_type() {
-    // Test that constraint syntax [f : *->*] works for 2nd+ params of associated types.
     let source = r#"
 module Main;
 
@@ -560,9 +601,10 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// A type of kind `*` given for a parameter of an associated type declared of kind `* -> *` is
+/// reported as a kind mismatch.
 #[test]
 pub fn test_higher_kinded_second_param_kind_mismatch() {
-    // Test that passing a *-kinded type where *->* is expected gives an error.
     let source = r#"
 module Main;
 
@@ -585,13 +627,11 @@ main = pure();
     test_source_fail(source, Configuration::develop_mode(), "Kind mismatch");
 }
 
-// Tests below use opaque type syntax (`?`-prefixed type variables) and are expected
-// to fail until opaque types are implemented. They verify associated type saturation
-// in opaque type contexts (TODO 11 from plan1.md).
-
+/// An equality constraint whose left side names an associated type with no argument at all. The
+/// left side is then a bare name, and the report asks for the application of an associated type
+/// there.
 #[test]
 pub fn test_opaque_unsaturated_associated_type_in_equality_lhs() {
-    // `Item` requires 1 arg but is given 0 in the equality constraint.
     let source = r#"
 module Main;
 
@@ -611,9 +651,10 @@ main = (
     );
 }
 
+/// An equality constraint whose right side gives an associated type fewer arguments than it takes
+/// is rejected as unsaturated.
 #[test]
 pub fn test_opaque_unsaturated_associated_type_in_equality_rhs() {
-    // Unsaturated associated type on RHS of equality constraint with opaque type.
     let source = r#"
 module Main;
 
@@ -650,9 +691,10 @@ main = (
     );
 }
 
+/// An opaque type variable in return position tied by an equality on `Std::Iterator::Item` to the
+/// type of the elements it yields. The value compiles, and the caller folds what it returns.
 #[test]
 pub fn test_opaque_saturated_associated_type_in_equality() {
-    // Properly saturated associated type with opaque type — should compile and run.
     let source = r#"
 module Main;
 
@@ -670,11 +712,11 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// Two associated types of one trait, each tied to a concrete type by an equality on the same
+/// opaque type variable in return position. The caller reads both through the trait and gets the
+/// expected values.
 #[test]
 pub fn test_opaque_multiple_associated_types_in_equality() {
-    // Multiple associated types used in equality constraints with opaque type.
-    // The opaque type variable ?c appears in return position (natural for opaque types),
-    // and the caller uses get_elem / container_size through the trait interface.
     let source = r##"
 module Main;
 
@@ -710,11 +752,11 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// An equality on an associated type of arity 2 whose extra argument is a type variable, written on
+/// an opaque type variable in return position. The caller reads what it returns through the trait
+/// and gets the expected array.
 #[test]
 pub fn test_opaque_higher_arity_associated_type_in_equality() {
-    // Higher-arity associated type (Rebuild c b = Array b) with opaque type.
-    // The opaque type variable ?c appears in return position, and the caller
-    // uses to_array through the trait interface to verify the Rebuild constraint.
     let source = r#"
 module Main;
 
@@ -746,9 +788,10 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// An equality on an opaque type whose left side gives an associated type of arity 2 a single
+/// argument is rejected as a wrong number of arguments.
 #[test]
 pub fn test_opaque_unsaturated_higher_arity_associated_type_in_equality() {
-    // Higher-arity associated type with missing argument in opaque context.
     let source = r#"
 module Main;
 
@@ -777,6 +820,9 @@ main = (
     );
 }
 
+/// The left side of an associated type implementation names its type with a namespace qualifier.
+/// The name resolves to the type the implementation is for, and the implementation's value member
+/// runs.
 #[test]
 pub fn test_associated_type_namespace_qualified_impl_type() {
     let source = r#"
@@ -805,6 +851,8 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
+/// A namespace-qualified name on the left side of an associated type implementation that resolves
+/// to nothing is reported as an unknown name.
 #[test]
 pub fn test_associated_type_wrong_namespace_impl_type() {
     let source = r#"
@@ -830,11 +878,11 @@ main = pure();
     );
 }
 
+/// A namespace-qualified name on the left side of an associated type implementation that resolves
+/// to a type other than the one implemented. Name resolution accepts the name, and
+/// `validate_trait_impl` reports the disagreement, naming the type of the implementation.
 #[test]
 pub fn test_associated_type_namespace_qualified_wrong_impl_type() {
-    // `Main::MyType2` is a real type, but the impl is for `MyType1`.
-    // The namespace-qualified name resolves successfully, but the post-name-resolution
-    // check in `validate_trait_impl` should catch the mismatch.
     let source = r#"
 module Main;
 
@@ -859,6 +907,8 @@ main = pure();
     );
 }
 
+/// The left side of an associated type implementation naming a type other than the one implemented
+/// is reported, and the report names the type of the implementation.
 #[test]
 pub fn test_associated_type_mismatched_impl_type() {
     let source = r#"
@@ -885,9 +935,11 @@ main = pure();
     );
 }
 
+/// A type alias names the type of an implementation and the left side of its associated type. Both
+/// are read as the type the alias stands for, so the implementation is found for a value of that
+/// type and its value member runs.
 #[test]
 pub fn test_associated_type_type_alias_in_impl_type() {
-    // Type alias used in the impl type of an associated type implementation.
     let source = r#"
 module Main;
 
@@ -915,9 +967,9 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
-// Fixv well-formedness: a trait member whose type variable only appears as
-// an argument of an associated type application is ambiguous and must be
-// rejected (section 5.1 of "Associated Type Synonyms").
+/// A trait's value member whose type variable stands only as the argument of an associated type
+/// application. A use site would leave the variable undetermined, so the member is rejected as
+/// ambiguous.
 #[test]
 pub fn test_fixv_trait_method_under_assoc_ty_only() {
     let source = r#"
@@ -938,9 +990,8 @@ main = pure();
     );
 }
 
-// Fixv well-formedness: the same ambiguity can arise for an ordinary global
-// value binding whose generalized variable only appears under an associated
-// type application.
+/// A global value whose generalized type variable stands only as the argument of an associated type
+/// application is rejected as ambiguous.
 #[test]
 pub fn test_fixv_global_value_under_assoc_ty_only() {
     let source = r#"
@@ -965,9 +1016,8 @@ main = pure();
     );
 }
 
-// Fixv well-formedness (positive): if the trait type variable also appears
-// outside the associated type application (here in the tuple), the signature
-// is well-formed.
+/// A trait's value member whose type variable also stands outside the associated type application,
+/// in a tuple with it. The variable is fixed by the type, and the member is accepted.
 #[test]
 pub fn test_fixv_trait_method_with_standalone_occurrence() {
     let source = r#"
@@ -989,9 +1039,9 @@ main = pure();
     test_source(source, Configuration::develop_mode());
 }
 
-// Fixv well-formedness (positive): an equality constraint `S a = b` makes
-// `b` fixed because the right-hand side of the equality contributes to
-// Fixv. Both `a` (via the tuple) and `b` (via the equality RHS) are fixed.
+/// A global value whose signature carries an equality on an associated type with a type variable on
+/// its right side. Both variables of the signature stand in its main type, so both are fixed and
+/// the signature is accepted.
 #[test]
 pub fn test_fixv_global_value_fixed_via_equality_rhs() {
     let source = r#"


### PR DESCRIPTION
Refs #381
Refs #171

#512 のレビューが、変更したファイルの周りに見つけた片付けである。対象は `src/tests/test_associated_type.rs` 1 ファイル。#512 の差分を読むときの邪魔にならないよう、別の pull request に分けてある。base は `bound-type-reduction` で、これが merge されると #512 の側に入る。

## 1. 既存の 48 本のうち 33 本に doc コメントが無かった

`code-review` の comment-style は「Rust の項目はすべて `///` を持つ。`#[test]` 関数の doc は、そのテストが**何の観点を検査するか**を述べる」と定めている。#512 が末尾に足した 8 本はこれに従っているが、その前に在った 33 本 (`test_associated_type_collects` から `test_fixv_global_value_fixed_via_equality_rhs` まで) には doc が無かった。

33 本すべてに doc を書いた。それぞれ、テストがコンパイルする Fix ソースの形と、そこで何が起きなければならないか (コンパイルが通って或る値を出すのか、或る文面で拒否されるのか) を述べている。

書き足しのほかに、次の 2 つを行った。どちらも文面を移しただけで、実行には触れていない。

- **テスト本体の先頭に在った `//` コメント 11 本を doc へ上げた。** 例: `// Test that constraint syntax [f : *->*] works for 2nd+ params of associated types.` は `test_higher_kinded_second_param_of_associated_type` の doc になった。本体の中に置いたままだと、doc と同じことを 2 か所で述べることになる。
- **不透明型のテスト群の上に在った 3 行の見出しコメントを消した。** 「不透明型が実装されるまでこれらは失敗する見込み」と述べていたが、今日その群の `test_opaque_saturated_associated_type_in_equality` などは `test_source` を呼んで成功を期待している。加えて「plan1.md の TODO 11」という、計画文書の段階名への参照を持っていた。プロジェクトの規約はコードのコメントに段階名を書かないことを定めている。

Fix ソースの文字列リテラルの中に在る `//` コメント 5 本は、テスト対象のプログラムの一部なので触れていない。

## 2. 等式の右辺で Fixv が決まることを検査するテストが、それに依っていなかった

`test_fixv_global_value_fixed_via_equality_rhs` は、型変数が**等式制約の右辺に現れることで**「利用側から決まる変数」(Fixv) に入る、という規則を検査するテストである。検査していた署名はこうだった。

```fix
foo : [a : MyTrait, S a = b] (a, b) -> I64;
```

`Scheme::fixed_vars` は、主型の自由型変数と、各等式の右辺の自由型変数を合わせたものを返す。`TypeNode::fixed_vars_to_set` は `Type::TyVar` の名前を集め、`Type::AssocTy` からは何も集めない。上の主型 `(a, b) -> I64` には `a` も `b` も裸で立っているので、**主型だけで両方が Fixv に入る**。等式 `S a = b` の寄与は載っても載らなくても結果が変わらない。テストの名前が約束している観点を、テストは検査していなかった。

主型から `b` を落とした。

```fix
foo : [a : MyTrait, S a = b] a -> I64;
```

この形なら `b` を Fixv に入れるものは等式の右辺しかない。この署名が今日受理されることは、`fix check` で確かめた。doc コメントもこの形に合わせて書き直してある。

**このテストが押さえるもの**: 等式制約の右辺に立つ型変数が、利用側から決まる変数 (Fixv) に入ること。**この修正の前は**、同じテストが緑のまま通っていた — 主型だけで `b` が Fixv に入るので、規則が在っても無くても結果が変わらなかった。緑から緑への変更なので、この pull request は振る舞いを 1 つも変えていない。変えたのは、テストが何を根拠に緑なのかである。

**粗い変異では測れなかったことを記しておく。** `Scheme::fixed_vars` から等式の寄与を落とす変異を当てると、確かにこのテストは赤くなる。ただし同じ変異で `std.fix` 自身がコンパイルできなくなる (`Std::Iterator::is_equal` などが `Item iter1 = a` の形を持つ) ので、std を通すテストはすべて赤くなる。この変異はどのテストについても「持ち主が居る」としか答えられない。上の判断は `fixed_vars_to_set` を読んだ結果と、`a -> I64` の形が受理されるという実測による。

## 手を付けなかったもの

- `src/ast/program.rs` に doc コメントの無い項目が 24 個ある (`add_import_statements`、`calculate_type_env`、`check_imports`、`enum EndNode` など)。#512 がこのファイルに触れたのは 1 か所 8 行なので、24 個を書くのは変更の大きさに釣り合わない。
- `src/elaboration/typecheck.rs` に doc の欠落は無い。

## 走らせたもの

- `cargo check --release --tests`: 通る。
- `cargo test --release -- tests::test_associated_type`: 48 passed / 0 failed。