### PR TITLE
レビュー清掃 (#521): 変更の周りに規約を当てる

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -4349,9 +4349,9 @@ impl LLVMGen for InlineLLVMStructGetBody {
         } else {
             let field_idx = self.field_index();
             Provenance::build_shape(result_ty, type_env, &|path: &FieldPath| {
-                let mut p = vec![field_idx];
-                p.extend_from_slice(path);
-                sole_origin(LeafOrigin::Arg(0, p))
+                let mut arg_path = vec![field_idx];
+                arg_path.extend_from_slice(path);
+                sole_origin(LeafOrigin::Arg(0, arg_path))
             })
         }
     }
@@ -5103,9 +5103,9 @@ fn read_component_locality(
         return ExtShape::uniform(result_ty, type_env, LeafCond::take_out_of(&container));
     }
     ExtShape::build_shape(result_ty, type_env, &|path: &FieldPath| {
-        let mut p = vec![component];
-        p.extend_from_slice(path);
-        LeafCond::input_leaf(CONTAINER_ARG, p)
+        let mut arg_path = vec![component];
+        arg_path.extend_from_slice(path);
+        LeafCond::input_leaf(CONTAINER_ARG, arg_path)
     })
 }
 
@@ -6369,9 +6369,9 @@ impl LLVMGen for InlineLLVMUnionAsBody {
         } else {
             let variant_idx = self.variant_index();
             Provenance::build_shape(result_ty, type_env, &|path: &FieldPath| {
-                let mut p = vec![variant_idx];
-                p.extend_from_slice(path);
-                sole_origin(LeafOrigin::Arg(0, p))
+                let mut arg_path = vec![variant_idx];
+                arg_path.extend_from_slice(path);
+                sole_origin(LeafOrigin::Arg(0, arg_path))
             })
         }
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1269,8 +1269,8 @@ impl<'c, 'm> Generator<'c, 'm> {
 
     /// Abort when the boxed object at `obj_ptr` is not in the local reference-counting state.
     ///
-    /// It stands where the state dispatch a `RcState::Local` annotation removed used to be, so a
-    /// wrong annotation stops at the operation that made it instead of corrupting a reference count
+    /// It stands in place of the state dispatch a `RcState::Local` annotation removes, so a wrong
+    /// annotation stops at the operation that made it instead of corrupting a reference count
     /// somewhere else. Locality inference rests on a hand-written declaration per inline-LLVM
     /// operation, and this is the only check on those: the whole test suite is built in develop
     /// mode, so every annotated site is verified dynamically on every test program.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -735,11 +735,8 @@ impl<'c, 'm> Generator<'c, 'm> {
         ptr: PointerValue<'c>,
         ty: T,
     ) {
-        let intrinsic = Intrinsic::find(intrinsic_name).unwrap();
         let ptr_ty = self.context.ptr_type(AddressSpace::from(0));
-        let func = intrinsic
-            .get_declaration(&self.module, &[ptr_ty.into()])
-            .unwrap();
+        let func = self.intrinsic_function(intrinsic_name, &[ptr_ty.into()]);
         let size = self.context.i64_type().const_int(
             self.target_data.get_store_size(&ty.as_basic_type_enum()),
             false,
@@ -749,11 +746,10 @@ impl<'c, 'm> Generator<'c, 'm> {
             .unwrap();
     }
 
-    // Store stack pointer.
+    /// The address of the current top of the stack, which `restore_stack` takes back to.
     #[allow(dead_code)]
     pub fn save_stack(&mut self) -> PointerValue<'c> {
-        let intrinsic = Intrinsic::find("llvm.stacksave").unwrap();
-        let func = intrinsic.get_declaration(&self.module, &[]).unwrap();
+        let func = self.intrinsic_function("llvm.stacksave", &[]);
         self.builder()
             .build_call(func, &[], "save_stack")
             .unwrap()
@@ -763,15 +759,30 @@ impl<'c, 'm> Generator<'c, 'm> {
             .into_pointer_value()
     }
 
-    // Restore stack pointer.
+    /// Take the top of the stack back to `pos`, an address `save_stack` gave.
     #[allow(dead_code)]
     pub fn restore_stack(&mut self, pos: PointerValue<'c>) {
-        let intrinsic = Intrinsic::find("llvm.stackrestore").unwrap();
-        assert!(!intrinsic.is_overloaded()); // So we don't need to specify type parameters in the next line.
-        let func = intrinsic.get_declaration(&self.module, &[]).unwrap();
+        let func = self.intrinsic_function("llvm.stackrestore", &[]);
         self.builder()
             .build_call(func, &[pos.into()], "restore_stack")
             .unwrap();
+    }
+
+    /// The declaration of the LLVM intrinsic `name` in this module, instantiated at `overload_tys`.
+    ///
+    /// An overloaded intrinsic names one function per instantiation, so the types it is overloaded
+    /// on decide which of them this is; an intrinsic that takes none is asked for with an empty
+    /// list. LLVM knows the intrinsics by name, so a name it does not know is a mistake in the
+    /// compiler rather than in the program being compiled.
+    fn intrinsic_function(
+        &self,
+        name: &str,
+        overload_tys: &[BasicTypeEnum<'c>],
+    ) -> FunctionValue<'c> {
+        let intrinsic = Intrinsic::find(name).unwrap_or_else(|| panic!("LLVM has no `{}`", name));
+        intrinsic
+            .get_declaration(&self.module, overload_tys)
+            .unwrap_or_else(|| panic!("LLVM cannot declare `{}` at the types given", name))
     }
 
     /// The type definitions of the program, which a Fix type is resolved to its layout through.

--- a/src/object.rs
+++ b/src/object.rs
@@ -444,7 +444,8 @@ impl ObjectFieldType {
             gc.build_traverser_work(obj, work_type, state);
         };
 
-        // After loop, do nothing.
+        /// Runs once the loop over the buffer ends. Each element's work happens in the loop
+        /// body, so this stage has none of its own.
         fn after_loop<'c, 'm>(
             _gc: &mut Generator<'c, 'm>,
             _size: IntValue<'c>,
@@ -2176,6 +2177,18 @@ pub fn create_obj<'c, 'm>(
     obj
 }
 
+/// The address of the traverser function for an object of type `ty`, for a dynamic object to store
+/// and call indirectly.
+///
+/// # Arguments
+/// * `capture` — the captured types of a dynamic object, whose traverser disposes of them.
+/// * `work` — the job the traverser performs: `TraverserWorkType::release` selects the object's
+///   destructor, `mark_global` and `mark_threaded` the corresponding markers. `None` selects the
+///   dynamic traverser, which takes the job as a second argument and dispatches on it at run time.
+///
+/// # Returns
+/// Where the type leaves the traverser no work to do, the address of an empty function, so that a
+/// caller holding this pointer always has one to call.
 pub fn get_traverser_ptr<'c, 'm>(
     ty: &Arc<TypeNode>,
     capture: &Vec<Arc<TypeNode>>, // used in destructor of lambda
@@ -2451,8 +2464,8 @@ fn build_traverse<'c, 'm>(
     }
 }
 
-// Returns the debug type for how `ty` is embedded in a field: a pointer to the boxed layout when
-// `ty` is boxed, and the layout itself when it is unboxed.
+/// The debug type for how `ty` is embedded in a field: a pointer to the boxed layout when `ty` is
+/// boxed, and the layout itself when it is unboxed.
 pub fn ty_to_debug_embedded_ty<'c, 'm>(
     ty: Arc<TypeNode>,
     gc: &mut Generator<'c, 'm>,
@@ -2476,16 +2489,16 @@ pub fn ty_to_debug_embedded_ty<'c, 'm>(
     }
 }
 
-// Returns the debug type describing `ty`'s in-memory layout, caching each type by name so recursive
-// types terminate.
+/// The debug type describing `ty`'s in-memory layout, caching each type by name so recursive types
+/// terminate.
 pub fn ty_to_debug_struct_ty<'c, 'm>(ty: Arc<TypeNode>, gc: &mut Generator<'c, 'm>) -> DIType<'c> {
     let key = ty.to_string();
     gc.get_or_build_di_type(key, |gc| ty_to_debug_struct_ty_body(ty, gc))
 }
 
-// Builds the debug type describing `ty`'s in-memory layout by expanding its fields. The caching and
-// recursion-breaking that keep this finite on recursive types live in the wrapper
-// `ty_to_debug_struct_ty`.
+/// The debug type describing `ty`'s in-memory layout, built by expanding its fields. The caching
+/// and recursion-breaking that keep this finite on recursive types live in
+/// `ty_to_debug_struct_ty`.
 fn ty_to_debug_struct_ty_body<'c, 'm>(ty: Arc<TypeNode>, gc: &mut Generator<'c, 'm>) -> DIType<'c> {
     let name = &ty.to_string();
     let obj_type = ty_to_object_ty(&ty, &vec![], gc.type_env());
@@ -2532,7 +2545,6 @@ fn ty_to_debug_struct_ty_body<'c, 'm>(ty: Arc<TypeNode>, gc: &mut Generator<'c, 
             obj_type.field_types[0].to_debug_type(gc)
         }
     } else {
-        // NOTE: Maybe we should use llvm's DataLayout::getStructLayout instead of get_abi_alignment, but it seems that the function isn't wrapped in llvm-sys.
         let struct_type = gc.struct_type_of(&ty);
         let size_in_bits = gc.target_data.get_bit_size(&struct_type);
         let align_in_bits = gc.target_data.get_abi_alignment(&struct_type) * 8;

--- a/src/object.rs
+++ b/src/object.rs
@@ -528,9 +528,9 @@ impl ObjectFieldType {
                              buf_ptr: PointerValue<'c>| {
                 let value_ty = value.ty.get_embedded_type(gc);
                 gc.retain(value.clone(), RcState::Unknown);
-                let elm_ptr =
+                let elem_ptr =
                     build_gep_array_elem(gc, value_ty, buf_ptr, idx, "ptr_to_elem_of_array");
-                gc.builder().build_store(elm_ptr, value.value(gc)).unwrap();
+                gc.builder().build_store(elem_ptr, value.value(gc)).unwrap();
             };
 
             // After loop, release value.
@@ -642,13 +642,13 @@ impl ObjectFieldType {
         }
 
         // Get element.
-        let elm_basic_ty = elem_ty.get_embedded_type(gc);
-        let elm_ptr = build_gep_array_elem(gc, elm_basic_ty, buffer, idx, "ptr_to_elem_of_array");
+        let elem_basic_ty = elem_ty.get_embedded_type(gc);
+        let elem_ptr = build_gep_array_elem(gc, elem_basic_ty, buffer, idx, "ptr_to_elem_of_array");
 
         // Get value
         let elem_val = gc
             .builder()
-            .build_load(elm_basic_ty, elm_ptr, "elem")
+            .build_load(elem_basic_ty, elem_ptr, "elem")
             .unwrap();
 
         // Return value
@@ -699,21 +699,21 @@ impl ObjectFieldType {
         }
 
         // Get ptr to the place at idx.
-        let elm_basic_ty = value.ty.get_embedded_type(gc);
-        let elm_ptr = build_gep_array_elem(gc, elm_basic_ty, buffer, idx, "ptr_to_elem_of_array");
+        let elem_basic_ty = value.ty.get_embedded_type(gc);
+        let elem_ptr = build_gep_array_elem(gc, elem_basic_ty, buffer, idx, "ptr_to_elem_of_array");
 
         // Release element that is already at the place (if required).
         if release_old_value {
-            let elm_val = gc
+            let elem_val = gc
                 .builder()
-                .build_load(elm_basic_ty, elm_ptr, "elem")
+                .build_load(elem_basic_ty, elem_ptr, "elem")
                 .unwrap();
-            let elem_obj = Object::new(elm_val, elem_ty, gc);
+            let elem_obj = Object::new(elem_val, elem_ty, gc);
             gc.release(elem_obj, state);
         }
 
         // Insert the given value to the place.
-        gc.builder().build_store(elm_ptr, value.value(gc)).unwrap();
+        gc.builder().build_store(elem_ptr, value.value(gc)).unwrap();
     }
 
     /// Copy `count` consecutive elements from `src_buffer` into `dst_buffer`, starting at index 0
@@ -729,7 +729,7 @@ impl ObjectFieldType {
         elem_ty: Arc<TypeNode>,
         state: RcState,
     ) {
-        let elm_basic_ty = elem_ty.get_embedded_type(gc);
+        let elem_basic_ty = elem_ty.get_embedded_type(gc);
         // In loop body, retain value and store it at idx. A fully unboxed element holds no
         // reference, so the copy of one is the store alone.
         let loop_body = |gc: &mut Generator<'c, 'm>,
@@ -737,12 +737,12 @@ impl ObjectFieldType {
                          _len: IntValue<'c>,
                          _ptr_to_buffer: PointerValue<'c>| {
             let src_ptr =
-                build_gep_array_elem(gc, elm_basic_ty, src_buffer, idx, "ptr_to_src_elem");
+                build_gep_array_elem(gc, elem_basic_ty, src_buffer, idx, "ptr_to_src_elem");
             let dst_ptr =
-                build_gep_array_elem(gc, elm_basic_ty, dst_buffer, idx, "ptr_to_dst_elem");
+                build_gep_array_elem(gc, elem_basic_ty, dst_buffer, idx, "ptr_to_dst_elem");
             let src_elem = gc
                 .builder()
-                .build_load(elm_basic_ty, src_ptr, "src_elem")
+                .build_load(elem_basic_ty, src_ptr, "src_elem")
                 .unwrap();
             gc.builder().build_store(dst_ptr, src_elem).unwrap();
             if !elem_ty.is_fully_unboxed(gc.type_env()) {
@@ -778,12 +778,12 @@ impl ObjectFieldType {
         match hole {
             None => Self::clone_array_range(gc, src_buffer, dst_buffer, len, elem_ty, state),
             Some(hole) => {
-                let elm_basic_ty = elem_ty.get_embedded_type(gc);
+                let elem_basic_ty = elem_ty.get_embedded_type(gc);
                 Self::clone_array_range(gc, src_buffer, dst_buffer, hole, elem_ty.clone(), state);
                 let (tail_src, tail_count) =
-                    Self::array_buf_after_hole(gc, elm_basic_ty, src_buffer, len, hole);
+                    Self::array_buf_after_hole(gc, elem_basic_ty, src_buffer, len, hole);
                 let (tail_dst, _) =
-                    Self::array_buf_after_hole(gc, elm_basic_ty, dst_buffer, len, hole);
+                    Self::array_buf_after_hole(gc, elem_basic_ty, dst_buffer, len, hole);
                 Self::clone_array_range(gc, tail_src, tail_dst, tail_count, elem_ty, state);
             }
         }

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -92,7 +92,7 @@ pub fn fix_command() -> Command {
 ///
 /// The suite runs under the level `MAX_OPT_LEVEL_VAR` names, and that level caps the one `-O` asks
 /// for, so the variable is pinned to `opt_level` beside the argument. `-O` belongs to the
-/// subcommand, which is why the subcommand is given here rather than by the caller.
+/// subcommand, so the returned command carries `subcommand` with the level after it.
 pub fn fix_command_at_opt_level(subcommand: &str, opt_level: &str) -> Command {
     let mut command = fix_command();
     command

--- a/src/tests/test_wide_return_tail_call.rs
+++ b/src/tests/test_wide_return_tail_call.rs
@@ -21,8 +21,8 @@ use crate::{
 // exercises the return rule on every target is
 // `test_return_wider_than_any_target_runs_in_constant_stack`.
 
-// The recursive call sits in tail position of a bind's continuation, and the result is an `Array`
-// plus a scalar. This is the shape a monadic loop over a growing or threaded array takes.
+/// The recursive call sits in tail position of a bind's continuation, and the result is an `Array`
+/// plus a scalar. This is the shape a monadic loop over a growing or threaded array takes.
 #[test]
 fn test_monadic_loop_with_array_result_runs_in_constant_stack() {
     let source = r#"
@@ -45,8 +45,8 @@ fn test_monadic_loop_with_array_result_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// `IOFail a` wraps `IO (Result ErrMsg a)`, and `ErrMsg` is a `String`, so the result is wide for
-// every element type. A loop in `IOFail` therefore needs the rule even when it threads no array.
+/// `IOFail a` wraps `IO (Result ErrMsg a)`, and `ErrMsg` is a `String`, so the result is wide for
+/// every element type. A loop in `IOFail` therefore needs the rule even when it threads no array.
 #[test]
 fn test_iofail_loop_runs_in_constant_stack() {
     let source = r#"
@@ -69,8 +69,8 @@ fn test_iofail_loop_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// `Std::loop_m` recurses on itself in tail position of a bind, so its own return width is what
-// decides whether the loop is constant-stack. Here `break_m` carries an array and a scalar.
+/// `Std::loop_m` recurses on itself in tail position of a bind, so its own return width is what
+/// decides whether the loop is constant-stack. Here `break_m` carries an array and a scalar.
 #[test]
 fn test_loop_m_with_wide_break_runs_in_constant_stack() {
     let source = r#"
@@ -89,9 +89,9 @@ fn test_loop_m_with_wide_break_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// A user-defined monad transformer stacked on `IO`, the form a state-carrying library monad takes.
-// Its `bind` ends with `((f(a)).@run)(s)`, so the transformer's own return width — the state plus
-// the value — decides the stack behavior of a loop written in it.
+/// A user-defined monad transformer stacked on `IO`, the form a state-carrying library monad takes.
+/// Its `bind` ends with `((f(a)).@run)(s)`, so the transformer's own return width — the state plus
+/// the value — decides the stack behavior of a loop written in it.
 #[test]
 fn test_state_transformer_over_io_runs_in_constant_stack() {
     let source = r#"
@@ -131,9 +131,9 @@ fn test_state_transformer_over_io_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// A state monad with no inner monad: its `run` carries the state in the tail call's arguments rather
-// than in a capture, so seven state leaves put the call at nine arguments — past both the return
-// registers and the six changing arguments an x86-64 sibcall can rewrite under the C convention.
+/// A state monad with no inner monad: its `run` carries the state in the tail call's arguments rather
+/// than in a capture, so seven state leaves put the call at nine arguments — past both the return
+/// registers and the six changing arguments an x86-64 sibcall can rewrite under the C convention.
 #[test]
 fn test_state_monad_carrying_state_in_arguments_runs_in_constant_stack() {
     let source = r#"
@@ -174,9 +174,9 @@ fn test_state_monad_carrying_state_in_arguments_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// The function called in tail position comes out of an array, so the call stays indirect at every
-// optimization level. Inlining and closure specialization cannot fold this chain into a
-// self-recursive loop; only turning the tail call into a jump keeps the stack flat.
+/// The function called in tail position comes out of an array, so the call stays indirect at every
+/// optimization level. Inlining and closure specialization cannot fold this chain into a
+/// self-recursive loop; only turning the tail call into a jump keeps the stack flat.
 #[test]
 fn test_dispatch_through_array_runs_in_constant_stack() {
     let source = r#"
@@ -211,8 +211,8 @@ fn test_dispatch_through_array_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// Three arrays make nine leaves, above the largest return-register budget among supported targets,
-// so this loop needs the out-pointer on AArch64 as well as on x86-64.
+/// Three arrays make nine leaves, above the largest return-register budget among supported targets,
+/// so this loop needs the out-pointer on AArch64 as well as on x86-64.
 #[test]
 fn test_return_wider_than_any_target_runs_in_constant_stack() {
     let source = r#"
@@ -238,15 +238,16 @@ fn test_return_wider_than_any_target_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// The two functions carry different numbers of arguments, so the call from the narrow one to the wide
-// one has to grow the outgoing argument area. A sibcall may only reuse the caller's own argument
-// area, while a tail call under `tailcc` may grow it, which is what keeps this loop flat. Ten
-// arguments overflow the argument registers of both supported targets, and stay under the arity where
-// the compiler's own eta expansion blows up (fixlang issue #76).
-//
-// x86-64 alone, since that is where `lambda_calling_convention_of_target` gives Fix lambdas `tailcc`.
-// AArch64 keeps the C convention, where this call stays an ordinary one and the stack grows with the
-// recursion (fixlang issue #111).
+/// The two functions carry different numbers of arguments, so the call from the narrow one to the wide
+/// one has to grow the outgoing argument area. A sibcall may only reuse the caller's own argument
+/// area, while a tail call under `tailcc` may grow it, which is what keeps this loop flat. Ten
+/// arguments overflow the argument registers of both supported targets, and stay under the arity where
+/// the compiler's own eta expansion blows up (fixlang issue #76).
+///
+/// The test runs on x86-64 alone, since that is where `lambda_calling_convention_of_target` gives
+/// Fix lambdas `tailcc`.
+/// AArch64 keeps the C convention, where this call stays an ordinary one and the stack grows with the
+/// recursion (fixlang issue #111).
 #[cfg(target_arch = "x86_64")]
 #[test]
 fn test_growing_argument_area_mutual_recursion_runs_in_constant_stack() {
@@ -275,10 +276,10 @@ fn test_growing_argument_area_mutual_recursion_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// The result crosses the floating-point half of the register budget rather than the integer half.
-// `tailcc`, the convention x86-64 Fix lambdas use, returns five floating-point leaves in registers
-// and sends six to memory, so six is where the `float` entry of the budget decides the outcome.
-// Every other loop here carries pointers and integers only.
+/// The result crosses the floating-point half of the register budget rather than the integer half.
+/// `tailcc`, the convention x86-64 Fix lambdas use, returns five floating-point leaves in registers
+/// and sends six to memory, so six is where the `float` entry of the budget decides the outcome.
+/// Every other loop here carries pointers and integers only.
 #[test]
 fn test_float_wide_return_runs_in_constant_stack() {
     let source = r#"
@@ -301,11 +302,11 @@ fn test_float_wide_return_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// Under separated compilation the unit that defines a function and the unit that calls it are
-// generated apart, so both sides derive the out-pointer decision and the calling convention from the
-// target alone. One symbol per unit puts a unit boundary on every call. The shapes cover an integer
-// result wider than the return registers, a result carrying arrays, a result mixing floating-point
-// and integer leaves, a wide global, and mutual recursion between two wide-returning functions.
+/// Under separated compilation the unit that defines a function and the unit that calls it are
+/// generated apart, so both sides derive the out-pointer decision and the calling convention from the
+/// target alone. One symbol per unit puts a unit boundary on every call. The shapes cover an integer
+/// result wider than the return registers, a result carrying arrays, a result mixing floating-point
+/// and integer leaves, a wide global, and mutual recursion between two wide-returning functions.
 #[test]
 fn test_wide_return_across_compilation_units() {
     let source = r#"
@@ -349,11 +350,11 @@ fn test_wide_return_across_compilation_units() {
     test_source(source, config);
 }
 
-// The out-pointer path must move the same bytes the register path did, for every leaf shape that
-// straddles the budget: three integer leaves against four, a union payload plus its tag, floating-
-// point leaves mixed with integer ones, a nested tuple with zero-sized members, and a boxed value.
-// Each is reached directly, in tail position, through a closure, and out of an array, so a value
-// crosses the out-pointer both as a forwarded parameter and as a caller-side buffer.
+/// The out-pointer path must move the same bytes the register path did, for every leaf shape that
+/// straddles the budget: three integer leaves against four, a union payload plus its tag, floating-
+/// point leaves mixed with integer ones, a nested tuple with zero-sized members, and a boxed value.
+/// Each is reached directly, in tail position, through a closure, and out of an array, so a value
+/// crosses the out-pointer both as a forwarded parameter and as a caller-side buffer.
 #[test]
 fn test_wide_return_shapes_compute_correctly() {
     let source = r#"
@@ -430,8 +431,8 @@ fn test_wide_return_shapes_compute_correctly() {
     test_source(source, Configuration::develop_mode());
 }
 
-// Three integer and four floating-point leaves fill both halves of the budget at once, the widest
-// result the table still returns in registers on x86-64.
+/// Three integer and four floating-point leaves fill both halves of the budget at once, the widest
+/// result the table still returns in registers on x86-64.
 #[test]
 fn test_mixed_result_filling_both_register_classes_runs_in_constant_stack() {
     let source = r#"
@@ -457,11 +458,11 @@ fn test_mixed_result_filling_both_register_classes_runs_in_constant_stack() {
     test_source(source, Configuration::develop_mode());
 }
 
-// A `Destructor` holding a wide resource. Its destructor is applied from inside the reference-
-// counting helper that releases the value -- a function with the C convention, not a Fix lambda -- so
-// that helper's own frame holds the out-pointer buffer of the call. It is the one place outside a
-// Fix lambda where a buffer is allocated and handed to a call, which is what makes the call's
-// `tail` marker load-bearing there.
+/// A `Destructor` holding a wide resource. Its destructor is applied from inside the reference-
+/// counting helper that releases the value -- a function with the C convention, not a Fix lambda -- so
+/// that helper's own frame holds the out-pointer buffer of the call. It is the one place outside a
+/// Fix lambda where a buffer is allocated and handed to a call, which is what makes the call's
+/// `tail` marker load-bearing there.
 #[test]
 fn test_destructor_with_wide_resource_is_memory_safe() {
     let source = r#"


### PR DESCRIPTION
Refs #470

PR #521 のレビューが、変更したファイルの**変更したところの周り**で見つけたものを直します。中身はコメントと局所名と、1 関数の抽出だけで、振る舞いは動きません。#521 の diff を読みやすく保つために分けてあります。

## 1. 要素とパスを、そのファイルの語で綴る (`046d722c`)

規約: **プロジェクトの語が勝つ**。名前が単体で読めても、同じものに 2 つの語があると読み手は両方を覚えることになります。

- `src/object.rs` の局所束縛 18 個、`elm_basic_ty` / `elm_ptr` / `elm_val` を `elem_*` へ。このファイルの綴りは `elem` が 199 対 18 で優勢で、同じ関数の引数が既に `elem_basic_ty` でした。
- `src/fixstd/builtin.rs` のクロージャ引数 3 個、`let mut p` を `arg_path` へ (`InlineLLVMStructGetBody::result_provenance`、`read_component_locality`、`InlineLLVMUnionAsBody::result_provenance`)。いずれも `path: &FieldPath` の 3 行以内にあって、`p` と `path` という 2 つのパスが並んでいました。同ファイルの `InlineLLVMStructPunchBody` は既にこの形を `arg_path` と呼んでいます。

どれも 1 つの関数本体に閉じた局所束縛なので、改名は機械的です。

## 2. コメントの規約を、変更の周りに当てる (`0cdbdfd1`)

規約: **Rust の項目はすべて doc コメントを持つ**、**経緯を語らない**、**肯定形で書く**。

- `src/object.rs` の `get_traverser_ptr` に `///` を新設。引数 `capture` と `work` の意味と、仕事のない型では空関数のアドレスを返すことを述べます。
- `src/object.rs` の `after_loop` / `ty_to_debug_embedded_ty` / `ty_to_debug_struct_ty` / `ty_to_debug_struct_ty_body`、`src/tests/test_wide_return_tail_call.rs` の既存 13 本の `#[test]` を、`//` から `///` へ。
- `src/object.rs` の `DataLayout::getStructLayout` を使うべきかという検討メモを削除。
- `src/generator.rs` の develop モードの locality 検査の doc から「used to be」を外し、いま何の位置に立っているかを現在形で述べる形に。
- `src/tests/test_util.rs` の `fix_command_at_opt_level` の末尾を肯定形へ。

## 3. LLVM の intrinsic を 1 か所で頼む (`f682eedc`)

規約: **2 つ目の写しで関数化する**。`src/generator.rs` の 3 か所が `Intrinsic::find(name).unwrap()` と `get_declaration(&self.module, ...).unwrap()` を並べて書いていました (`build_lifetime_marker`、`save_stack`、`restore_stack`)。`intrinsic_function` に寄せ、名前を知らないときのメッセージを `unwrap()` から「LLVM has no `<name>`」に変えます。あわせて `save_stack` / `restore_stack` の `//` コメントを `///` にしました。

同じファイル内の重複の抽出で、呼び出し側は 3 つとも同じ値を受け取ります。

## 振る舞いが動かないこと

- フルスイート **1632 本 / 0 失敗** (release)。
- `cargo fmt` の差分は、このブランチが触っていない 2 ファイル (`src/build/build_object_files.rs`、`src/tests/test_compilation_units.rs`) だけで、それは `main` から在るものです。

## 直さずに残した指摘

規模が変更の周りに釣り合わないので、それぞれ独立した作業として置いてあります。

- `src/fixstd/builtin.rs` の 647 項目に doc コメントが無い (ファイルは 10,577 行)。
- `src/generator.rs` の 61 項目が項目の説明を `///` でなく `//` で書いており、`ScopedValue::accessor` ほか 4 つのフィールド・バリアントにはコメントが無い。
- `src/object.rs` の `ObjectFieldType` のスカラー変種 10 個 (`I8`..`F64`) に説明が無い。個々に書ける文は名前の言い換えにしかならず、名前が言っていない事実 (LLVM に符号なし整数型が無く、`I8` と `U8` が同じ `i8` を占め、符号の区別は debug type と演算の側にある) は 10 個に共通なので、enum 全体の doc に置く形になります。
- `src/generator.rs` の `scope_push` / `scope_pop` は、同じ `impl` の `push_scope` と語順だけが違って意味が別。委譲先の `Scope::push_local` / `Scope::pop_local` が既に正しい語を持っています。使用箇所 10 個。
- `src/fixstd/builtin.rs` の `bulitin_tycons` と `unary_opeartor_instance` / `binary_opeartor_instance` は綴り誤り。前者は 3 つのモジュールの import に伝播しており、後者は同ファイル内で 20 回以上呼ばれています。
- `src/object.rs` は配列バッファの要素数を `size` / `len` / `count` の 3 語で呼んでいます。`loop_over_array_buf` は引数を `size` と宣言しているのに、そのコールバックを書く側が同じ値を `_size` / `_count` / `_len` と 3 通りに呼んでいます。
- 生成した IR を読むテストの 13 行のひな型は、まだ 8 つのテストファイルに 10 か所あります。#521 が `test_util.rs` の `generated_llvm_ir` へ寄せたのはそのうち 2 つです。
