### PR TITLE
処理の健全性を証明するスキルを追加する

### DIFF
--- a/.claude/skills/soundness-proof/SKILL.md
+++ b/.claude/skills/soundness-proof/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: soundness-proof
+description: "Prove that a piece of code is sound — that inputs satisfying a stated precondition produce outputs satisfying a stated postcondition — and write the proof as a dev doc: definitions, then a sequence of numbered propositions whose every leaf step cites exactly the facts, definitions and code it rests on, in Lamport's structured-proof style. The orchestrator fixes the target commit, states the property and calibrates it against a bug the code actually had, then alternates prover subagents that write the proof with verifier subagents that check one step at a time and report every step that is false, non-obvious, hedged, or built on an undefined word. Use when: asked to prove that a pass, a function, or a subsystem is sound or correct; or to re-verify an existing proof after the code changed."
+argument-hint: "The processing to prove sound (a pass, a function, a module), and optionally the property to prove. If omitted, the skill asks."
+---
+
+# Soundness proof
+
+The deliverable is a document: **definitions, then a sequence of propositions, each with a proof**, ending in the theorem that the target is sound. It is written for a reader who checks it rather than one who is persuaded by it, so every inference step must be obvious from the items it cites alone.
+
+The work is done by two kinds of subagent under this orchestrator: **provers**, who write proofs, and **verifiers**, who check one step at a time and are forbidden to think. The document is finished when a fresh round of verifiers returns nothing.
+
+This skill **never modifies the code under proof**. A step that cannot be proved because the code does not do what it should is a bug, and it is reported the way `bug-hunt` reports one — a failing scenario, a reproduction, a fix proposal for the author to weigh. Fixing it is a separate change.
+
+## What this is for, and what it is not
+
+`bug-hunt` searches: it finds what it happens to look at, and its silence means only that this wave looked elsewhere. A proof covers every input by construction, so it turns "no bug found" into "no bug of this kind exists". That is the whole reason to pay for it — and it is also why a proof of a property too weak to be violated by real bugs is worse than no proof, since it buys confidence it did not earn. Hence the calibration step below.
+
+## The proof language
+
+Write the proof in **Lamport's structured-proof style** (Leslie Lamport, *How to Write a 21st Century Proof*, 2012), in prose, using the notation below. It is not a formal language and nothing machine-checks it; what it buys is that **each step names the facts it uses**, so a checker can verify one step by reading that step, the items it cites, and nothing else. That property is what makes the verifier's job mechanical, and it is the reason for choosing this style over ordinary mathematical prose.
+
+Nested equational chains (see *Calculational steps*) come from the Dijkstra calculational style as extended by Back and von Wright's *structured derivations*; they are the one place where the argument may be laid out as a chain rather than as steps.
+
+### Steps
+
+A proof is a numbered list of steps. The last step of every list is `QED`, whose statement is the goal of the proof it closes.
+
+```
+<1>1. STATEMENT
+  <2>1. STATEMENT
+    BY D3, <1>0
+  <2>2. QED
+    BY <2>1, P4
+<1>2. QED
+  BY <1>1, A1
+```
+
+`<k>n` is step `n` of a level-`k` proof. A step's proof is either a nested list of `<k+1>` steps ending in `QED`, or a single `BY` line when it needs no decomposition. Every step has one or the other: a step with neither is an unproved assertion, and the verifier reports it.
+
+### `BY` — the citation
+
+```
+BY <2>1, <1>3, P4, A1, D2 DEF unit_key CODE `src/rc_ir/borrow.rs: CancelAnalysis::un_bump`
+```
+
+A `BY` line lists **everything** the step rests on, in these four groups (omit an empty group):
+
+- **Facts**: steps in scope (`<k>n`), propositions (`P<n>`), assumptions (`A<n>`), definitions used as facts (`D<n>`).
+- **`DEF`**: the definitions whose bodies are unfolded in this step. Citing `D2` as a fact means using what it states; citing it under `DEF` means substituting its text.
+- **`CODE`**: the source this step reads, as *file*: *symbol path* — a function, a method, a type, a match arm identified by its pattern. Never a line number: line numbers move, and a citation the reader cannot resolve after one edit is a citation nobody checks.
+- **External results**: a named theorem from outside the document, given its full statement in the definitions section.
+
+The rule behind the format: **a reader who is handed only the cited items must reach the step's conclusion**. Anything they would additionally need is missing from the `BY`.
+
+### `ASSUME` / `PROVE`
+
+A proposition about "any input satisfying …" is stated as an assume/prove, which is also the natural shape of a function's contract:
+
+```
+P3. ASSUME  NEW p: RcProgram,
+            p is well-formed (D1),
+            every retain in p is balanced (D4)
+    PROVE   cancel(p) is well-formed (D1)
+            and every retain in cancel(p) is balanced (D4)
+```
+
+`NEW x` introduces a variable and asserts the conclusion for every value of it. The assumptions of an assume/prove hold **inside its proof only**.
+
+A step may itself be an assume/prove; its assumptions then hold only inside that step's proof, and this is what the scoping rule below is protecting.
+
+### `SUFFICES`, `CASE`, `PICK`, `DEFINE`
+
+- `SUFFICES <statement>` — proving the statement proves the current goal. The step's own proof shows that implication; the rest of the proof then works on the new goal. Use it to strip a quantifier or set up a contradiction without adding a level.
+- `CASE <condition>` — abbreviates "assume the condition, prove the current goal". A case split is a run of `CASE` steps followed by `QED`, and **the `QED` must cite the cases and show they are exhaustive**. A case split over a Rust `match` cites the enum's definition for exhaustiveness; one over a condition cites the excluded middle. A split that silently omits an arm is the most common way a proof of a compiler pass goes wrong, so the verifier checks exhaustiveness by name against the type.
+- `PICK x SUCH THAT P(x)` — introduces `x` and asserts `P(x)`; the step's proof shows such an `x` exists.
+- `DEFINE name == expression` — names an expression for the rest of the current level. A definition local to a proof, as opposed to a `D<n>` in the definitions section, which is global.
+
+### Hierarchical numbering, and what a step may cite
+
+From inside the proof of step `<3>4`, the citable facts are exactly:
+
+- every `D<n>`, `A<n>`, and every `P<n>` that precedes this proposition in the dependency order;
+- the strictly preceding siblings at each enclosing level: `<1>1` .. `<1>(i-1)`, `<2>1` .. `<2>(j-1)`, `<3>1` .. `<3>3`, where `<1>i` and `<2>j` are the ancestors of this step.
+
+Nothing else. Not a step inside a sibling's proof, not a later step, not a step of another proposition. The reason is not tidiness: a step inside a sibling's proof may have been proved under that sibling's assume/prove assumptions, which do not hold here, so citing it is unsound. Because the rule is syntactic, the verifier applies it without understanding the argument.
+
+When two proofs need the same fact, it is lifted out — into a preceding sibling step at the level where both can see it, or into its own `P<n>`.
+
+### Inserting a step
+
+The verifier's findings are answered by inserting steps, and renumbering would break every citation in the document. So **insert with a letter suffix**: a step between `<1>1` and `<1>2` is `<1>1a`, then `<1>1b`. Lamport's own worked proof does this. Numbers and suffixed numbers are never reused within one proof, even after a deletion.
+
+### Calculational steps
+
+A chain of relations may replace a run of steps when each link is short:
+
+```
+<2>3. refs_after(v) covers refs_before(v)
+  refs_after(v)
+    = refs_before(v) + {o}        [BY <2>1 DEF apply_retain]
+    covers refs_before(v)         [BY D7: `covers` is monotone under insertion]
+```
+
+State which transitivity closes the chain when the relations differ (`=` then `covers` closes to `covers`; `covers` then `=` likewise; mixing a relation with its converse does not close, and a chain that does not close is a `FALSE` finding). Each link carries its own bracketed justification, in `BY` format.
+
+### How fine a step must be
+
+The bar is a university entrance exam answer: not a research paper, where the reader is expected to reconstruct; an exam answer, where anything the grader has to supply costs marks. Three concrete tests, which the verifier applies:
+
+- **Interpolation.** Does checking the step require the reader to invent an intermediate fact that is written nowhere? Then it is too coarse.
+- **Case.** Does the step's truth depend on which branch of the code was taken, while the step names no branch? Then the branches belong in `CASE` steps.
+- **Code distance.** If the step asserts what the code does, does the cited symbol show it plainly, or must the reader step into a function it calls? Each function stepped into is another step, with its own `CODE` citation — or, if it is used more than once, its own `P<n>`.
+
+There is no penalty for length. A proof that takes three hundred steps and is checkable beats one that takes thirty and is not.
+
+### Words that are not allowed
+
+The failure this guards against is a proof that reads as though it understands the code while carrying its weight in words that mean nothing. Each of these is a finding on its own, before the step's logic is even considered:
+
+- **An undefined word.** Every term a statement leans on is either (a) an identifier of the code under proof, (b) a `D<n>`, or (c) introduced by an earlier step in scope. A word like "生きている", "正しい位置", "整合している", "対応する" carries the argument and is not defined by being used confidently. Name it and define it, or use the code's own identifier.
+- **A word that shifts.** One word, one definition, throughout the document. When two notions need two words, they get two words — and when the code has two names for one thing, the document says so in the definitions, once.
+- **明らかに / obviously / 容易に分かる**, with no citation. Every such claim is either a `BY` or a substep.
+- **同様に / similarly / 同じ議論で**. Either the other case is written out, or the shared part is lifted into a `P<n>` that both cases cite. The case skipped as "similar" is where the asymmetry hides.
+- **Hedges**: 適切に, うまく, 基本的に, 通常, ほとんどの場合, essentially, in practice, should. A hedge marks the place where the writer does not know. The sentence is deleted or proved.
+- **An appeal to intent**: "この関数は … するつもりで書かれている", "設計上 … のはず". The proof is about what the code does. Intent belongs to the definitions section, as the property being proved.
+
+## The document
+
+Under `dev-docs/YYYY-MM-DD-<target>-soundness/`, following the `devdoc` skill for everything the conventions below leave open — in particular, written in the implementers' language, self-contained for a reader who knows the project thinly and has never opened the code under proof, and readable front to back.
+
+- `README.md` — target and commit, definitions, assumptions, the proposition list in dependency order, the calibration, the main theorem, and the verification status table.
+- `p<NN>-<slug>.md` — one file per proposition, or per tightly coupled group. One file has one owner, so two provers never edit one file.
+
+`README.md` holds, in this order:
+
+1. **Target.** The commit hash the proof is about, in full, and the files and top-level symbols covered. A proof is about one state of the code and says which.
+2. **Definitions** `D1`, `D2`, … Every notion the propositions use, including the soundness property itself. A definition is precise enough that two readers cannot disagree about whether a given program satisfies it. Where the notion is already a Rust type or function, define it by naming that item and stating what it means, so the document stays self-contained.
+3. **Assumptions** `A1`, `A2`, … Facts the proof uses and does not prove. Each carries **who discharges it**: the caller (name the call site), an earlier pass (name it), a language rule (name it), or *nobody*. The soundness of the input is normally `A1` — a pass is proved to *preserve* soundness, and the composition of the passes is a separate proposition at the end that chains the preservations. An assumption discharged by nobody is a hole in the guarantee; it stays in the list, it appears in the main theorem's hypotheses, and the closing report names it.
+4. **Propositions.** Every `P<n>` **statement** (not its proof), in an order where each depends only on earlier ones, with the dependency edges written down. Typically one proposition per function or per loop body, stated as its contract.
+5. **Calibration** — see below.
+6. **Main theorem.** The last proposition, and the shape of the chain that reaches it.
+7. **Verification status.** One row per proposition: the file, the last verifier round that examined it, its verdict, and the commit the proof was written against. This is what a re-run reads to know what to re-verify.
+
+## Calibrating the property
+
+Before any prover starts, check that the property is worth proving: **take a bug the code actually had, and check that the stated property is violated by the old code.** The most recent fixed bug in the target is the natural case; `git show` on its fix gives the old code, and the changelog and the issue tracker give the symptom.
+
+A property that the buggy code also satisfies is too weak, and a proof of it proves nothing while looking like it proves everything. Widen the property until the old bug violates it, and record in `README.md` which bug was used and which clause of the definition it breaks.
+
+This is the `bug-hunt` rule "show the detector fires before trusting its silence", applied to a specification: a soundness property is a detector, and its silence is worth exactly as much as any other detector's.
+
+Re-run the calibration whenever the property changes — above all when it changes because a proof would not close otherwise.
+
+## Procedure
+
+1. **Resolve the target and the property.** Ask with `AskUserQuestion` when either was left open. Confirm `git status --porcelain` is empty and record `git rev-parse HEAD`; that hash goes in the document. If the code changes while the work runs, re-verify every proposition whose `CODE` citations name a changed symbol.
+2. **Write the skeleton, inline.** Read the target end to end — not by grep — and write `README.md`: definitions, assumptions, the decomposition into propositions with their statements and dependency order, the calibration, and the main theorem. This is the design of the proof and it needs the whole target in one head, so the orchestrator does it rather than a subagent.
+
+   **Show the skeleton to the user before dispatching provers.** A wrong definition wastes every prover that runs under it, and the decomposition is where a proof is won or lost.
+3. **Run the provers.** One subagent per proposition file, dispatched in dependency layers: a prover may cite an earlier proposition's *statement*, so a whole layer of independent propositions goes out in one parallel block. They write documents rather than code, so they share the working tree; file ownership is what keeps them apart. Brief each with the *Briefing a prover* section below.
+4. **Run the verifiers.** One subagent per proposition, all in parallel, each given only what the *Briefing a verifier* section allows. Wait for all.
+5. **Iterate.** Hand each verifier's findings to that file's prover. `NOT-OBVIOUS` is answered by inserting substeps, never by rewording the step to sound more certain. `FALSE`, `UNDEFINED`, `BAD-CITATION` and `HEDGE` are answered as the section below prescribes. Then verify again — with **fresh** verifier subagents, which have not seen the previous round's findings, so the check is never anchored to what it already accepted.
+6. **Stop at the fixed point.** The document is finished when one full round over every proposition returns no finding of any kind. Record the round in the status table.
+7. **Report.** What was proved; under which assumptions; which assumptions nobody discharges; how many rounds it took; and every code bug the attempt turned up, in `bug-hunt` shape. Then update the hunt log's neighbours in memory if the proof changed what is known about the subsystem.
+
+## Briefing a prover
+
+Give it: the target commit; `README.md` in full; the proposition it owns and the file to write; the statements (not the proofs) of the propositions it may cite; the *proof language* and *words that are not allowed* sections of this file, inline; and, on a later round, the verifier findings against its file.
+
+Require of it:
+
+- It reads the code it cites. A `CODE` citation is a claim about the source, and a prover that cites a symbol it did not open is the failure mode this whole procedure exists to catch.
+- It writes only its own file.
+- It does not modify the code under proof, and it does not modify `README.md` — a definition or assumption it finds it needs is **reported to the orchestrator**, not added. Definitions are global, and a prover that adds one silently breaks the propositions proved under the old set.
+- When it cannot prove its proposition, it says so, with the step it got stuck at and which of the three cases below it believes it is in. A prover that cannot prove something and writes a plausible paragraph instead has done the worst available thing.
+
+## Briefing a verifier
+
+Give it, and only it:
+
+- The definitions and assumptions from `README.md`.
+- The **statements** of every proposition — never their proofs, except the one it is checking. A verifier that has read the whole argument starts reconstructing it, and a reconstructed argument is exactly what it is supposed to fail to do.
+- The one proposition file it checks.
+- The *proof language* and *words that are not allowed* sections of this file, inline.
+- Read access to the repository, for one purpose only: opening a symbol named in a `CODE` citation to check that the code says what the step claims.
+
+Instruct it in these terms:
+
+> You are grading an exam answer. **Do not think.** Your job is not to decide whether the proposition is true — it is to decide, for each step, whether that step follows **obviously** from the items its `BY` line cites, and nothing else.
+>
+> You will be tempted to fill in gaps, because you can. Do not. **Anything you supply was missing from the proof.** If you find yourself thinking "presumably this means…", or "this is true because of that other thing I know about the code", or pausing even for a moment over what a word means — that step is a finding, not an OK.
+>
+> Do not edit the document. Do not propose fixes, do not rewrite steps, do not suggest wording. Report.
+>
+> Give a verdict for **every** step, in document order, including the ones that pass. Silence is not OK; a step you did not mention is a step you did not check, and the orchestrator has no way to tell the two apart. Then detail every non-OK verdict.
+
+The verdicts:
+
+- **`OK`** — follows obviously from the cited items.
+- **`FALSE`** — does not follow, or is false. Give the counterexample or name the broken inference.
+- **`NOT-OBVIOUS`** — may well be true, but reaching it from the cited items required you to supply something. Say exactly what you had to supply.
+- **`UNDEFINED`** — the step leans on a word or symbol that is not in the definitions, not an identifier of the cited code, and not introduced by an earlier step in scope. Name the word.
+- **`BAD-CITATION`** — a cited item does not exist, is out of scope by the numbering rule, or does not say what the step claims. For a `CODE` citation, open the file and compare; report the mismatch in the code's own words.
+- **`HEDGE`** — the step's argument rests on a word from *Words that are not allowed*. Quote it.
+- **`INCOMPLETE`** — a `CASE` split whose cases are not exhaustive (name the missing case, by the arm of the type or the condition it corresponds to), a `QED` that does not cite everything its conclusion needs, a step with neither a `BY` nor a subproof, or a calculational chain whose relations do not compose.
+
+A verifier that returns `OK` for everything on its first pass over a proof of any size has almost certainly been persuaded rather than convinced; the orchestrator treats that as a signal to re-run with a fresh verifier before believing it.
+
+## When the proof will not close
+
+Three cases, and they are told apart before anything is written:
+
+1. **The proof is wrong.** The decomposition, or a step. Fix it and continue. This is the common case and needs no ceremony.
+2. **The statement is wrong** — the proposition needs a precondition nobody wrote down. The precondition is promoted to an `A<n>` **only with a named discharger**: the caller that establishes it, the earlier pass that guarantees it, the language rule that makes it impossible to violate. Adding an assumption nobody discharges does not close the proof; it moves the hole, and it must be reported as such rather than buried in the list.
+3. **The code is wrong.** The property genuinely fails for some input. Stop and report it as `bug-hunt` does: the input, the path it takes, the wrong output, and a fix proposal. Do not fix the code, and do not prove the pass sound "modulo that case".
+
+The rule that binds all three: **never weaken the property to make the proof close.** A property is weakened only deliberately, and when it is, the calibration is re-run; if the old bug now satisfies the weakened property, the weakening is rejected and the case is (2) or (3) instead.
+
+## Re-verifying after the code changes
+
+A proof is about one commit. When the code moves, the document is not thrown away:
+
+1. Diff the new commit against the one in `README.md`, and take the set of changed symbols.
+2. Every proposition whose file cites a changed symbol in a `CODE` line goes back to a prover, then to a verifier.
+3. Every proposition that cites one of those propositions is re-verified too, transitively — the statement may have moved even when the file did not.
+4. Update the target commit and the status table.
+
+A change that touches no cited symbol changes only the recorded commit. That is worth saying out loud: it means the `CODE` citations are also the index from a code change to the proof obligations it disturbs, which is most of what makes the document worth maintaining rather than rewriting.


### PR DESCRIPTION
処理の健全性を証明する手順を、スキル 1 本として追加する。差分は `.claude/skills/soundness-proof/SKILL.md` の 1 ファイルだけで、コンパイラのコードは変わらない。

閉じる issue はない。

## なぜ証明なのか

`borrow_ify` と `cancel` は、設計の段階から設計書レビューで設計レベルのバグが繰り返し見つかり、実装後も miscompile (segv) が何度も出ている。実装直後だけでなく、その後に何度か bug-hunt をかけても何も出なかった。それにも関わらず #519 が出た。

bug-hunt が沈黙しても、それは「今回の波は別のところを見た」以上のことを意味しない。探索は、見たところしか覆わない。証明は全入力を構造で覆うので、「見つからなかった」を「この種のバグは存在しない」に変えられる。それがこのスキルの買おうとしているものである。

同時にそれは危険でもある。弱すぎる性質の証明は、何も保証していないのに保証したように見える。買ったつもりのない安心を買ってしまう。だからスキルは、証明を始める前に性質を較正することを義務づける (後述)。

## 成果物の形

`dev-docs/YYYY-MM-DD-<target>-soundness/` の下に置く文書である。中身は **定義、次に命題、各命題に証明** という列で、最後の命題が「対象は健全である」になる。

`README.md` が、対象のコミットハッシュ、定義 `D<n>`、仮定 `A<n>`、命題 `P<n>` の言明 (証明は含まない) とその依存順、較正の記録、主定理、検証状況の表を持つ。証明は命題ごとに `p<NN>-<slug>.md` に分かれる。1 ファイルに 1 人の書き手を割り当てるためで、こうしておくと証明者のサブエージェントを並列に走らせても互いのファイルを書き潰さない。

作業は、証明者サブエージェントと検証者サブエージェントの往復で進む。検証者が 1 件も指摘を返さない回が 1 周できたら完成とする。

## 証明言語に Lamport の構造化証明を選ぶ

証明は自然言語で書くが、書き方は Leslie Lamport の構造化証明 (*How to Write a 21st Century Proof*, 2012) の記法に従わせる。形はこうである。

```
<1>1. STATEMENT
  <2>1. STATEMENT
    BY D3, <1>0
  <2>2. QED
    BY <2>1, P4
<1>2. QED
  BY <1>1, A1
```

`<k>n` は、レベル `k` の証明の `n` 番目のステップを表す。各ステップの証明は、`<k+1>` のステップの列 (最後は必ず `QED`) か、`BY` の 1 行かのどちらかである。

この記法を選んだ理由は、**検証者が頭を使わずに済む理由が、記法そのものから出る**ことである。

第一に、`BY` の行に、そのステップが依拠するものを全部並べる規則がある。使った先行ステップ・命題・仮定・定義、展開した定義 (`DEF`)、読んだコード (`CODE`) が 1 行に出る。「引用されたものだけを読んで結論に到達できるか」が、検証者にとっての判定条件になる。到達に何かを補ったなら、補った分が `BY` から漏れている。

第二に、あるステップの証明の中から参照してよいものが、構文だけで決まる。`<3>4` の証明から見えるのは、各祖先レベルの**先行する兄弟**だけである。兄弟の証明の内部は見えない。これは整理のためではなく健全性のためで、兄弟の証明の内部はその兄弟の仮定の下で証明されており、ここではその仮定が成り立たないからである。規則が構文的なので、検証者は議論を理解せずに適用できる。

第三に、深さが可変である。検証者が「非自明」と言ったステップの下に一段挿入すれば、そのステップだけが細かくなる。往復作業と噛み合う。挿入は `<1>1a` のように枝番で行い、番号を振り直さない (振り直すと文書中の引用が全部壊れる)。これは Lamport 自身の付録の書き方である。

等式や包含の連鎖には、下位ステップの書き方として計算的証明 (Dijkstra の calculational style を Back と von Wright の structured derivations が入れ子まで拡張したもの) を許可する。`References` の多重集合の計算のような箇所は、この形が最短になる。

外した候補は付録に挙げる。

## スキルの各節が何をするか

**What this is for, and what it is not** -- 証明と bug-hunt の関係を述べ、弱い性質の証明が危険であることを最初に置く。

**The proof language** -- 上記の記法を定める。`BY` の 4 つの引用群 (facts / `DEF` / `CODE` / 外部定理)、`ASSUME`/`PROVE`、`SUFFICES`、`CASE`、`PICK`、`DEFINE`、階層番号と参照可能範囲、挿入の枝番、計算的ステップ。`CODE` の引用はファイル名と記号の道 (関数・メソッド・型・match の腕) で書き、行番号は使わない。行番号は編集でずれ、解決できない引用は誰も検査しなくなるからである。

**How fine a step must be** -- ステップの粒度を、大学入試の答案として要求される水準に置く。判定は 3 つ。読み手が書かれていない中間事実を発明しなければならないか (補間)。ステップの真偽がどの分岐を通ったかに依存するのに、分岐が書かれていないか (場合分け)。コードの挙動を主張しているとき、引用された記号を見るだけで分かるか、それとも呼び先まで辿る必要があるか (コード距離)。辿る関数 1 つが、ステップ 1 つになる。

**Words that are not allowed** -- 未定義語、意味が動く語、引用のない「明らかに」、「同様に」、「適切に」などのぼかし、そして意図への訴え (「この関数は … するつもりで書かれている」) を、論理を見る前の段階で指摘対象にする。証明はコードが何をするかについてのものであり、意図は定義の節に属する。

**The document** -- 上記のファイル構成と `README.md` の中身を定める。仮定 `A<n>` には必ず**誰が満たすのか**を書かせる (呼び出し側・前段の pass・言語規則・誰も)。入力の健全性は通常 `A1` になる。pass の証明は preservation として書き、pipeline 全体は最後に鎖でつなぐ命題 1 本にする。誰も満たさない仮定は主定理の仮定として残り、報告で名指しされる。穴を埋めることではなく、穴の位置を確定させることが目的である。

**Calibrating the property** -- 証明を始める前に、そのコードが実際に持っていた既知のバグを 1 つ取り、**旧コードがその性質に違反することを確かめる**。違反しないなら性質が弱すぎて、証明しても何も言えないのに証明したように見える状態になる。bug-hunt の「検出器が発火することを確かめてから沈黙を信じる」を、仕様に対して適用したものである。性質が変わるたびに較正をやり直す。

**Procedure** -- オーケストレータの段取り。対象とコミットの固定、骨組みをオーケストレータ自身が書くこと (定義の誤りは配下の証明者を全部無駄にするので、証明者を出す前にユーザに見せる)、依存の層ごとの並列、検証、往復、不動点。最後の 1 周は**前の周の指摘を見ていない**新しい検証者にやらせる。前の周を知っている検証者は、一度通したものをもう一度通す。

**Briefing a prover** / **Briefing a verifier** -- 各サブエージェントに渡すものと課す規則。検証者には、他の命題の**証明を渡さない**。全体を読むと議論を再構成してしまい、再構成こそが失敗させたい行為だからである。

**When the proof will not close** -- 証明が誤り / 命題に前提が足りない / コードが誤り、の 3 分岐。3 番目なら bug-hunt の形で報告して止まる。そして 3 つを縛る規則として、**証明を通すために性質を弱めることを禁止する**。弱めるなら較正をやり直し、旧バグが弱めた性質を満たしてしまうならその弱めを却下する。

**Re-verifying after the code changes** -- コードが動いたときに、`CODE` 引用が変わった記号を指している命題と、それを引用している命題だけを再検証する。この節があることで、`CODE` の引用がコード変更から証明義務への索引にもなる。文書を維持する価値の大半はここにある。

## 検証者への指示

このスキルの中でサブエージェントに渡る文言のうち、成否を最も左右するのは検証者への指示なので、全文を引用する。

> You are grading an exam answer. **Do not think.** Your job is not to decide whether the proposition is true — it is to decide, for each step, whether that step follows **obviously** from the items its `BY` line cites, and nothing else.
>
> You will be tempted to fill in gaps, because you can. Do not. **Anything you supply was missing from the proof.** If you find yourself thinking "presumably this means…", or "this is true because of that other thing I know about the code", or pausing even for a moment over what a word means — that step is a finding, not an OK.
>
> Do not edit the document. Do not propose fixes, do not rewrite steps, do not suggest wording. Report.
>
> Give a verdict for **every** step, in document order, including the ones that pass. Silence is not OK; a step you did not mention is a step you did not check, and the orchestrator has no way to tell the two apart. Then detail every non-OK verdict.

判定は 7 つである。`OK` / `FALSE` (従わない) / `NOT-OBVIOUS` (真かもしれないが、到達に自分で何かを補った) / `UNDEFINED` (依拠している語が定義にも、引用されたコードの識別子にも、スコープ内の先行ステップにもない) / `BAD-CITATION` (引用が存在しない、参照範囲の外、または実際のコードと言っていることが違う) / `HEDGE` (ぼかし語に論理が乗っている) / `INCOMPLETE` (場合分けが尽くされていない、`QED` が必要なものを引用していない、`BY` も部分証明も無い、連鎖の関係が合成できない)。

全ステップに判定を出させるのは、沈黙が「検査して通した」と「検査していない」の区別を消すからである。

## このスキルがしないこと

対象のコードを直さない。証明が閉じない原因がコードにあるとき、それはバグの報告になり、修正は別の変更になる。bug-hunt と同じ立場を取る。

## 付録: 検討して外した形式手法

証明を機械検査可能な形式言語で書く道も検討し、外した。分かれ目は形式か非形式かではなく、**証明が何について語っているか**である。

**手で書いたモデルについて語るもの** (Coq/Rocq, Isabelle/HOL, Lean 4, TLA+ の TLAPS): 分量が爆発することに加えて、モデルと実装の隙間が残る。#519 は「アルゴリズムが間違っていた」のではなく「`origin_from_leaves_under` が意図と違うものを返していた」バグだった。手でモデルを書くとき人は意図の方を書くので、証明は通り、バグは Rust の中に残る。我々が実際に踏んでいる種類のバグに対して構造的に無力である。この隙間は自然言語の証明にもあるが、そちらは `CODE` 引用を義務づけて検証者にファイルを開かせるという安い対策が効く (`BAD-CITATION` がそれである)。

**Rust のソースそのものについて語るもの** (Verus, Creusot, Prusti, RefinedRust, Flux, Aeneas, Kani): 隙間がなく原理的には最適だが、サブセット制限で落ちる。`borrow.rs` と `ownership.rs` の 2,866 行が使っているものを数えると、`Map`/`Set` (HashMap/HashSet) が 31、`for` ループが 104、`.iter()`/`.map(` が 44、クロージャが約 97、`Arc` が 30 ある。Verus は `for`、Iterator、HashMap を未サポートまたは部分サポートなので、採用は「証明のために 2 つの pass を書き直す」ことを意味する。防ごうとしているバグより大きくて危険な変更になる。Aeneas は safe/sequential Rust に限られ、interior mutability と一部のループ構文を通さない。Creusot は比較的素直な Rust を通すが、Rust の真の意味論をモデル化しておらず WhyML への翻訳も SMT-LIB への翻訳も未検証であることを Creusot 自身が明記している。

形式化の予算を投じる価値があるのは、証明ではなく**定義**の側である。分量が爆発するのは証明の側で、品質を決めているのは定義の側だからである。それを踏まえた次の一手 (判定可能な定義を `src/rc_ir/validate.rs` の実行可能な述語として置き、文書の `D<n>` がそれを引用する形) は、このスキルには入れていない。入れるかどうかは、最初の適用で定義を書いてみてから決める方が確かである。
