### PR TITLE
1 つの unit が答える leaf の所有をそろえる (#530)

### DIFF
--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -133,7 +133,7 @@ fn optimize_rc_program(
     split_rc_units(&mut prog, type_env);
     validate(&prog, "after split_rc_units");
     if config.enable_borrow_optimization() {
-        prog = borrow_ify(&prog, type_env);
+        prog = borrow_ify(&prog, type_env, config.develop_mode);
         validate(&prog, "after borrow_ify");
         prog = cancel(&prog, type_env, config.develop_mode);
         validate(&prog, "after cancel");

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -42,8 +42,8 @@ use crate::ast::types::TypeNode;
 use crate::misc::{grow_stack, Map, Set};
 use crate::parse::sourcefile::Span;
 use crate::rc_ir::ast::{
-    FieldPath, FuncRef, Ownership, OwnershipShape, RcExpr, RcExprNode, RcFunc, RcGlobalInit,
-    RcProgram, RcRhs, RcState, RcVar, VarPath,
+    for_each_node, for_each_var, FieldPath, FuncRef, Ownership, OwnershipShape, RcExpr, RcExprNode,
+    RcFunc, RcGlobalInit, RcProgram, RcRhs, RcState, RcVar, VarPath,
 };
 use crate::rc_ir::leaf_map::boxed_leaf_paths;
 use crate::rc_ir::ownership::{
@@ -82,6 +82,12 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> OwnedLeaves {
         .map(|f| (f.name.clone(), VarTable::of(f)))
         .collect();
 
+    let sites: Map<FuncRef, Vec<(RcVar, FieldPath)>> = prog
+        .funcs
+        .values()
+        .map(|f| (f.name.clone(), levelled_sites(f, type_env)))
+        .collect();
+
     let mut owned_leaves: Set<VarPath> = Set::default();
     loop {
         let mut changed = false;
@@ -108,6 +114,9 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> OwnedLeaves {
                     }
                 }
             }
+            for site in &sites[&func.name] {
+                changed |= level_ownership(vars, type_env, site, &mut owned_leaves);
+            }
         }
         if !changed {
             break;
@@ -117,6 +126,84 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> OwnedLeaves {
     OwnedLeaves(owned_leaves)
 }
 
+/// The `(value, unit)` pairs whose ownership this pass reads as a single truth value: the target of
+/// every reference-count node, and every argument unit of every call.
+///
+/// `owns_unit` answers once for such a pair, while the node it decides acts on each boxed leaf under
+/// the unit. Where those leaves come from roots the version owns differently, no single answer is
+/// right, so the leaves are levelled (`level_ownership`) before any of them is read.
+fn levelled_sites(func: &RcFunc, type_env: &TypeEnv) -> Vec<(RcVar, FieldPath)> {
+    let mut sites = vec![];
+    for_each_node(&func.body, &mut |node| match node.expr.as_ref() {
+        RcExpr::Retain(v, path, _, _) | RcExpr::Release(v, path, _, _) => {
+            sites.push((v.clone(), path.clone()))
+        }
+        RcExpr::Let(_, RcRhs::App(_, args), _) => {
+            for arg in args {
+                for unit in rc_units(&arg.ty, type_env) {
+                    sites.push((arg.clone(), unit));
+                }
+            }
+        }
+        RcExpr::Let(..) | RcExpr::Destructure(..) | RcExpr::Eval(..) | RcExpr::Ret(..) => {}
+    });
+    sites
+}
+
+/// Own every parameter leaf a site's candidate objects reach, where the version owns any of them.
+///
+/// A unit whose leaves come from different roots gets one ownership answer for all of them. Where
+/// the roots disagree, neither answer is right: `Borrow` drops the release the owned leaf needed,
+/// and `Own` disposes a reference the borrowed leaf was only lent. Owning all of them is the answer
+/// the reference counting can express, and a value owned where it could have been borrowed costs a
+/// count rather than correctness. Ownership only grows here, so the fixed point still terminates.
+fn level_ownership(
+    vars: &VarTable,
+    type_env: &TypeEnv,
+    (v, unit): &(RcVar, FieldPath),
+    owned_leaves: &mut Set<VarPath>,
+) -> bool {
+    let candidates: Vec<VarPath> = origin(vars, type_env, &v.name, unit)
+        .candidates()
+        .into_iter()
+        .cloned()
+        .collect();
+    let owns_a_candidate = candidates.iter().any(|(root, path)| {
+        match vars.param_tys.get(root) {
+            // A root this version takes no parameter for is a producer or a global, and the version
+            // owns what it produced.
+            None => true,
+            Some(ty) => covered_leaves(ty, path, type_env)
+                .iter()
+                .any(|leaf| owned_leaves.contains(&(root.clone(), leaf.clone()))),
+        }
+    });
+    if !owns_a_candidate {
+        return false;
+    }
+    let mut changed = false;
+    for (root, path) in &candidates {
+        let Some(ty) = vars.param_tys.get(root) else {
+            continue;
+        };
+        for leaf in covered_leaves(ty, path, type_env) {
+            changed |= owned_leaves.insert((root.clone(), leaf));
+        }
+    }
+    changed
+}
+
+/// The boxed leaves of `ty` that `path` covers: the ones beneath it, and the one it lies beneath.
+///
+/// A path reaches a leaf from either side. A unit path stops above the leaves of an unboxed union's
+/// variants, and a path into a variant runs below the leaf a punched array holds.
+fn covered_leaves(ty: &Arc<TypeNode>, path: &FieldPath, type_env: &TypeEnv) -> Vec<FieldPath> {
+    boxed_leaf_paths(ty, type_env)
+        .into_iter()
+        .filter(|leaf| leaf.starts_with(path) || path.starts_with(leaf))
+        .collect()
+}
+
 // --- borrow-ification ---
 
 /// Borrow-ify a program: materialize a borrowing version of every function with a borrowable
@@ -124,7 +211,7 @@ fn infer_ownership(prog: &RcProgram, type_env: &TypeEnv) -> OwnedLeaves {
 /// annotate every output version with the parameter/capture units it borrows
 /// (`RcFunc::borrowed_units`).
 // PROOF: P3, P4, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
+pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv, develop_mode: bool) -> RcProgram {
     let owned_leaves = infer_ownership(prog, type_env);
 
     // The funptr functions that get a borrow version, and the name of that version. Only funptr
@@ -159,6 +246,10 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
             }
             clones.push((borrow_version.clone(), clone, rename));
         }
+    }
+
+    if develop_mode {
+        check_clone_names_are_fresh(prog, clones.iter().map(|(_, _, rename)| rename));
     }
 
     // The parameter names and types of every output version, so a call site can read the ownership
@@ -236,6 +327,44 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
         funcs,
         globals,
         roots: prog.roots.clone(),
+    }
+}
+
+/// Check that the names a clone mints are names the program does not already bind.
+///
+/// `fresh_rename_function` makes a name by appending its pass tag and a counter, reading none of the
+/// program's names, so the name it makes is new only because no binder the earlier passes mint ends
+/// in that shape. Nothing establishes that, and a collision would put two bindings under one
+/// `unit_key`, which is read by name: cancellation would then pair a retain of one with a release of
+/// the other and delete both.
+///
+/// Walking every binder costs a pass over the program, so this runs where the test suite runs it.
+fn check_clone_names_are_fresh<'a>(
+    prog: &RcProgram,
+    renames: impl Iterator<Item = &'a Map<FullName, FullName>>,
+) {
+    let mut bound: Set<FullName> = Set::default();
+    for func in prog.funcs.values() {
+        for p in func.params.iter().chain(func.capture.iter()) {
+            bound.insert(p.name.clone());
+        }
+        for_each_var(&func.body, &mut |v| {
+            bound.insert(v.name.clone());
+        });
+    }
+    for global in &prog.globals {
+        for_each_var(&global.init, &mut |v| {
+            bound.insert(v.name.clone());
+        });
+    }
+    for rename in renames {
+        for fresh in rename.values() {
+            assert!(
+                !bound.contains(fresh),
+                "the clone's fresh name `{}` is already bound in the program",
+                fresh.to_string()
+            );
+        }
     }
 }
 

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -539,6 +539,57 @@ main = (
 );
 "#;
 
+    // A union whose payload holds two boxed values the function owns differently. `x` is returned,
+    // so ownership inference makes it owned; `y` only goes into the union, which a `Release` node
+    // then drops, and a `Release` is not a consume, so `y` stays borrowed. The union is one
+    // reference-counting unit, and the ownership of its two leaves therefore disagrees.
+    //
+    // The borrowing version has to answer for that unit once. Dropping its `Release` leaks the
+    // reference the owned leaf carried; keeping it disposes the reference the borrowed leaf was
+    // only lent. The recursion keeps the function out of its caller so that a borrowing version is
+    // built at all, and the caller's own use of the array after the call is what routes to it.
+    const SPLIT_OWNERSHIP_UNIT_SOURCE: &str = r#"
+module Main;
+
+type Twins = unbox union { twins : (Array I64, Array I64), none : () };
+
+f : Array I64 -> Array I64 -> I64 -> (Array I64, I64);
+f = |x, y, n| (
+    if n == 0 {
+        let a = Twins::twins((x, y));
+        (x, if a.is_twins { 1 } else { 0 })
+    };
+    let (r, k) = f(x, y, n - 1);
+    (r, k)
+);
+
+main : IO ();
+main = (
+    let arr = Array::fill(3, 7);
+    let brr = Array::fill(4, 9);
+    let (r, k) = f(arr, brr, 2);
+    assert_eq(
+        |_|"a union unit whose leaves differ in ownership",
+        r.@size + k + brr.@size, 8
+    );;
+    pure()
+);
+"#;
+
+    /// Every array is freed exactly once and none of them leaks, checked under Valgrind MemCheck.
+    /// The answer is right either way, so only the leak check catches this.
+    #[test]
+    pub fn test_split_ownership_unit_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        test_source(SPLIT_OWNERSHIP_UNIT_SOURCE, Configuration::develop_mode());
+    }
+
     // A union payload built from a value a match binding carries and a second value. The binding
     // carries a name of its own -- the one every path through the match agrees on -- and that name
     // is what a retain of the binding keys to. A release of the union has to name it as well: the


### PR DESCRIPTION
Closes #530

`-O max` と `-O experimental` で、参照を 2 つ持つ payload の unbox union を借用版の中で捨てると、その参照が
漏れていた。出力は正しく、Valgrind の leak check だけが捕まえる。

## 何が起きていたか

### 登場する関数

**`infer_ownership`** (`src/rc_ir/borrow.rs`) は、各関数の各パラメータの各 **boxed leaf** について、その関数が
その参照を所有するか借用するかを不動点で決める。消費されない leaf は借用のままになる。

**`owns_unit`** は、値の **RC unit** についてこの版が所有するかを 1 つの真偽値で答える。`origin` が返す候補の
すべてが所有されるときだけ真である。

**`rewrite_rc`** は借用版の `Retain`/`Release` を書き換える。`owns_unit` が真の unit の節点だけを残し、偽の
unit の節点は落とす。**`call_rc`** は呼び出しの前後に補正を置く。呼び出し元が借用し呼び出し先が所有する unit
には前に `Retain` を、逆には後に `Release` を置く。

**leaf と unit は同じものではない。** boxed 値・配列・punched array・クロージャの capture は unit の下に leaf を
1 つしか持たないが、**unbox union は 1 つの unit の下に、各変位の payload の leaf を持つ**。leaf を 2 つ以上
持つ unit は unbox union だけである。

### 壊れていた実行

```fix
type Twins = unbox union { twins : (Array I64, Array I64), none : () };

f : Array I64 -> Array I64 -> I64 -> (Array I64, I64);
f = |x, y, n| (
    if n == 0 {
        let a = Twins::twins((x, y));
        (x, if a.is_twins { 1 } else { 0 })
    };
    let (r, k) = f(x, y, n - 1);
    (r, k)
);
```

`x` は返されるので `infer_ownership` は所有とする。`y` は union に入るだけで、その union は `Release` 節点で
捨てられる。`Release` は消費ではないので `y` は借用のまま残る。よって `a : Twins` の 1 つの unit の下で、
leaf `[0,0]` は所有された `x` に、leaf `[0,1]` は借用された `y` に届く。

借用版の中を追う。`obj(x)` を `x` が指すオブジェクト、`H` をその参照カウントとする。

1. 借用版に入った時点。`H(obj(x)) = 1`。この版は `x` を所有する。
2. `retain x` の後。`H(obj(x)) = 2`。`x` が 2 度使われる (union に入る、返り値になる) ために置かれる。
3. `struct_make` と `union_make_0` は素通しなので、参照の持ち手が `a` へ移る。`H` は 2 のまま。
4. **`release a` があるべき位置。** `owns_unit(a, [])` は候補 `{x, y}` の**すべて**が所有されることを要求し、
   `y` が借用なので偽を返す。`rewrite_rc` は `Release(a, [])` を**丸ごと落とす**。
5. `ret (x, k)` で 1 つを返す。**`obj(x)` への参照が 1 つ残ったまま関数を出る。** これが漏れである。

**判定を逆に倒しても直らない。** `owns_unit` が真なら `Release(a, [])` が残るが、この節点は unit の下の
inhabited なすべての leaf を下げるので、借りているだけの `obj(y)` の参照まで処分する。今度は過剰処分になる。
**同じ 1 つの本体で両方が起きるので、真偽値 1 つでは正しく答えられない。**

### 直した実行

`infer_ownership` の不動点に平準化を足した。`Retain`/`Release` の対象 unit と `App` の各引数 unit について、
`origin(v, u).candidates()` のいずれかを版が所有するなら、候補のパラメータ leaf をすべて所有にする。

上の例では、`a` の unit の候補は `{x, y}` で、`x` が所有されている。よって `y` も所有になる。すると `f` に
借用可能なパラメータが無くなり、借用版が作られない。呼び出しは元の版へ行き、そこでは `Release(a, [])` が
残るので、手順 4 で `H(obj(x))` が 1 に、`obj(y)` の参照も処分され、手順 5 で 1 つを返して収支が合う。

候補に producer やグローバルが混ざる場合は、`owns_object` がそれらに無条件で真を返すので、パラメータ側が
すべて所有になる。所有は増える方向にしか動かないので、不動点は変わらず停止する。

**借りられたはずの値を所有することの代償は、正しさではなく参照カウント 1 つである。**

## 変更した項目

**`infer_ownership`**。役割は、各関数の各パラメータ leaf の所有を不動点で決めること。変更は、消費の帰属の後に
平準化の段 (`level_ownership`) を各サイトについて回すこと。目的は、`owns_unit` が 1 つの真偽値で答える単位の
下で、leaf の所有が分かれないようにすること。

**`levelled_sites`** (新規)。役割は、この版が所有を 1 つの真偽値として読む `(値, unit)` の対を、関数の本体から
集めること。`Retain`/`Release` の対象と、`App` の各引数の各 unit である。

**`level_ownership`** (新規)。役割は、1 つのサイトについて、候補のいずれかを版が所有するなら候補のパラメータ
leaf をすべて所有にすること。何も変えなければ偽を返すので、不動点の停止判定に乗る。

**`covered_leaves`** (新規)。役割は、型の boxed leaf のうち path が覆うものを返すこと。path は leaf の上にも
下にも来る -- unit path は unbox union の変位の leaf の上で止まり、変位への path は punched array の leaf の
下へ入る。

**`borrow_ify`**。変更は `develop_mode` を受け取り、複製を作った直後に `check_clone_names_are_fresh` を
呼ぶこと。目的は下記のとおり。

**`check_clone_names_are_fresh`** (新規)。役割は、複製が作る名前が入力プログラムの束縛名に無いことを確かめる
こと。`fresh_rename_function` は名前に pass tag と counter を足すだけで、**入力の名前を 1 つも読まない**。
その名前が新しいのは、以前のパスが作る束縛名がその形で終わらないからにすぎず、それを確かめるものが今まで
無かった。名前が衝突すると、`unit_key` は名前で引くので 2 つの束縛が 1 つの鍵の下に入り、`cancel` は一方の
retain と他方の release を対にして両方消す。本体を 1 度歩く費用がかかるので、テストが走らせる場所で走る。

**`optimize_rc_program`** (`src/build/build_object_files.rs`)。変更は `borrow_ify` に `config.develop_mode` を
渡すこと。`cancel` が既に同じものを受け取っている。

## 追加したテスト

**`SPLIT_OWNERSHIP_UNIT_SOURCE`** と **`test_split_ownership_unit_memory_safety`**
(`src/tests/test_union_rc_shapes.rs`)。押さえるのは、所有の分かれる unit を借用版が捨てても参照が漏れないこと。
**このプログラムはどちらの実装でも正しい答え (8) を出すので、Valgrind の leak check だけが捕まえる。**

平準化の呼び出しを外すと**赤くなる**ことを確認した。

## changelog

書いていない。この欠陥が住む参照カウント IR は 1.4.0 に存在せず (`git ls-tree -r --name-only v1.4.0 |
grep -c src/rc_ir` は 0)、beta は出荷ではないので、この欠陥を持つコンパイラは出荷されていない。

## 付録: 検証

**再現プログラム。**

| 最適化レベル | 修正前 | 修正後 |
|---|---|---|
| `-O basic` | definitely lost 0 | definitely lost 0 |
| `-O max` | **definitely lost 32 bytes** | definitely lost 0 |

**テストスイート。** 1,640 通過 / 0 失敗 (`cargo test --release`)。追加した 1 本を含めて 1,641 本。

**コーパスの生成物。** 修正の前後で、最適化後の RC IR が 106 プログラムすべてで一致する。LangArena の
50 ベンチマーク (RC IR 11.4 MB が同一 md5) と `benchmark/speedtest/cases` の 56 ケース (56/56)。生成コードが
同じなので性能は動かない。

平準化が発火するのは「unbox union の payload が所有の異なる root から来た値を 2 つ以上持ち、その union に
RC 節点か呼び出しがかかる」形だけで、両コーパスにその形が 1 つも無い。

この差分が空振りしていないことは確かめた。issue の再現プログラムに当てると差が出る -- 修正後は `f` に借用
可能なパラメータが無くなるので、借用版そのものが消える。比べた 2 つのコンパイラのバイナリは md5 が異なる。

## 経緯

`borrow_ify` の RC 規律の保存 (P14) を担当した証明者が、証明が閉じない箇所として報告した
(`dev-docs/proof/rc_ir/borrow-cancel/p20-borrow-ify.md` の第 3 節)。直し方は、続く回で同じ証明者が特定した。
最初に立てた仮説 -- 「パラメータの unit の下の leaf の所有が一致する」-- は**的を外していた**。反例はその仮説を
満たす。縛るべきは局所の値の unit であり、そろえるべきは `origin` の候補である。
