### PR TITLE
retain と release を、名前でなく触れるオブジェクトで対にする (#545)

### DIFF
--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -133,7 +133,7 @@ fn optimize_rc_program(
     if config.enable_borrow_optimization() {
         prog = borrow_ify(&prog, type_env, config.develop_mode);
         validate(&prog, "after borrow_ify");
-        prog = cancel(&prog, type_env, config.develop_mode);
+        prog = cancel(&prog, type_env);
         validate(&prog, "after cancel");
         prune(&mut prog, "after dce following cancel");
         prog = unique_check_elim::specialize(&prog, type_env);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -47,9 +47,8 @@ use crate::rc_ir::ast::{
 };
 use crate::rc_ir::leaf_map::boxed_leaf_paths;
 use crate::rc_ir::ownership::{
-    acted_references, acted_unit_keys, all_owned_units, collect_consumes, destructure_consumes,
-    origin, rc_units, rhs_consumes, truncate_to_unit, unit_key, unit_step, units_under, Origin,
-    References, UnitStep, VarTable,
+    acted_references, all_owned_units, collect_consumes, destructure_consumes, origin, rc_units,
+    rhs_consumes, truncate_to_unit, unit_step, units_under, References, UnitStep, VarTable,
 };
 use crate::rc_ir::rename::fresh_rename_function;
 use std::sync::Arc;
@@ -1032,10 +1031,15 @@ fn split_rc(
 
 // --- retain/release cancellation ---
 
-/// The pending retains at a program point: for each object (a reference-counting unit, keyed by
-/// `unit_key`), the stack of retains that have bumped it and not yet been un-bumped. A release
-/// un-bumps the most recent — the innermost bracket, which keeps the un-bump non-zeroing.
-type PendingRetains = Map<VarPath, Vec<PendingRetain>>;
+/// The retains that have bumped references nothing has un-bumped yet, in the order the walk met
+/// them, so the innermost bracket is last.
+///
+/// A retain is not filed under a name. `origin` has no one name for a value whose boxed leaves reach
+/// several objects — an `Option (a, b)` holds two — so filing one would mean making a name up, and a
+/// release of one of those objects, named after the object, would be filed elsewhere and never meet
+/// the retain. What decides whether a release closes a retain is the objects the two act on, which
+/// `References` already carries.
+type PendingRetains = Vec<PendingRetain>;
 
 /// A retain whose bump is still outstanding, and the references of it that no release has un-bumped
 /// yet.
@@ -1051,84 +1055,40 @@ struct PendingRetain {
     outstanding: References,
 }
 
-/// What a release does to the retains pending for the unit it is counted under.
+/// What a release does to the retains pending where it happens.
 enum UnBump {
-    /// It un-bumps part or all of the innermost bracket, whose retain this is.
+    /// It un-bumps part or all of the innermost bracket that acts on what it acts on, whose retain
+    /// this is.
     InBracket(NodeId),
-    /// It reaches references the innermost bracket did not bump.
+    /// The innermost such bracket did not bump everything it disposes.
     OutsideBracket,
-    /// No retain is pending for the unit.
+    /// No pending retain acts on any object it acts on.
     NoBracket,
 }
 
-/// Check that a release un-bumping exactly what a pending retain bumped keys to that retain: two
-/// operations that act on the same references act on the same object, and one object is counted
-/// under one unit key.
+/// Take a release's references off the innermost pending retain that acts on an object it acts on.
 ///
-/// The key is read off the object's `origin`, so two keys here mean an alias chain lost the
-/// object's identity along the way. The pairing then walks past this release, the retain closes
-/// against a later release of the value it was taken from, and cancelling that pair leaves this
-/// release to free an object still in use — which nothing downstream can tell from a correct
-/// cancellation.
-///
-/// Equality of the references is what makes the two operations comparable. A retain of an unboxed
-/// union bumps every reference its payload holds, and a release of one of those payload values
-/// un-bumps one of them under that value's own key: two keys, one shared object, and both namings
-/// right. Such a release un-bumps a strict subset, which is the case `un_bump` reports as
-/// `OutsideBracket`, so only the equal case is a disagreement.
-// PROOF: P3, P4, P5, P6, P7, P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-fn check_one_key_per_object(
-    pending: &PendingRetains,
-    key: &VarPath,
-    un_bumped: &References,
-    v: &RcVar,
-    path: &FieldPath,
-) {
-    for (pending_key, stack) in pending {
-        if pending_key == key {
-            continue;
-        }
-        for retain in stack {
-            assert!(
-                &retain.outstanding != un_bumped,
-                "the release of `{}`{:?} keys to `{}`{:?} and un-bumps {:?}, which is exactly what \
-                 a retain pending under `{}`{:?} bumped: one object, two keys",
-                v.name.to_string(),
-                path,
-                key.0.to_string(),
-                key.1,
-                un_bumped,
-                pending_key.0.to_string(),
-                pending_key.1,
-            );
-        }
-    }
-}
-
-/// Take a release's references off the innermost retain pending for `key`, where that retain bumped
-/// all of them. A retain left with nothing outstanding is un-bumped whole, and stops being pending.
-// PROOF: P3, P4, P5, P6, P7, P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-fn un_bump(pending: &mut PendingRetains, key: &VarPath, un_bumped: &References) -> UnBump {
-    // A release with nothing pending for `key` disposes of a reference the walk did not add — an
-    // owned parameter, or a value produced here — so it un-bumps no retain.
-    let Some(stack) = pending.get_mut(key) else {
+/// Innermost first, so the un-bump closes the tightest bracket around the release and leaves the
+/// ones outside it bumped. A retain that shares an object with the release without carrying
+/// everything it disposes is the release reaching past that bracket. A retain left with nothing
+/// outstanding is un-bumped whole and stops being pending.
+fn un_bump(pending: &mut PendingRetains, un_bumped: &References) -> UnBump {
+    // A release no pending retain shares an object with disposes of a reference the walk did not
+    // add — an owned parameter, or a value produced here — so it un-bumps no retain.
+    let Some(index) = pending
+        .iter()
+        .rposition(|retain| retain.outstanding.shares_an_object(un_bumped))
+    else {
         return UnBump::NoBracket;
     };
-    // `un_bump` removes a stack it empties, so a stack kept in `pending` holds a pending retain to
-    // un-bump.
-    let innermost = stack
-        .last_mut()
-        .expect("a stack kept in `pending` is non-empty");
+    let innermost = &mut pending[index];
     if !innermost.outstanding.covers(un_bumped) {
         return UnBump::OutsideBracket;
     }
     innermost.outstanding.subtract(un_bumped);
     let retain = innermost.node;
     if innermost.outstanding.is_empty() {
-        stack.pop();
-    }
-    if stack.is_empty() {
-        pending.remove(key);
+        pending.remove(index);
     }
     UnBump::InBracket(retain)
 }
@@ -1150,7 +1110,7 @@ fn node_id(node: &RcExprNode) -> NodeId {
 /// the uniqueness analysis. Each call's consume sites are decided by the parameter/capture units the
 /// functions own — the complement of their `RcFunc::borrowed_units`, set by borrow-ification.
 // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-pub fn cancel(prog: &RcProgram, type_env: &TypeEnv, develop_mode: bool) -> RcProgram {
+pub fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
     let owned_units = all_owned_units(prog, type_env);
     let cancel_body = |vars: &VarTable, body: &RcExprNode| {
         let mut analysis = CancelAnalysis {
@@ -1158,7 +1118,6 @@ pub fn cancel(prog: &RcProgram, type_env: &TypeEnv, develop_mode: bool) -> RcPro
             prog,
             owned_units: &owned_units,
             type_env,
-            develop_mode,
             needed_retains: Set::default(),
             un_bump_releases: Map::default(),
             all_retains: vec![],
@@ -1210,10 +1169,6 @@ struct CancelAnalysis<'a> {
     owned_units: &'a Set<VarPath>,
     /// The type definitions, for resolving a value's type to its reference-counting units.
     type_env: &'a TypeEnv,
-    /// Whether to check that a retain and the release un-bumping it key to one object
-    /// (`check_one_key_per_object`). Stating that invariant wrongly aborts a build that should
-    /// succeed, so it is checked where the test suite runs it rather than in a user's build.
-    develop_mode: bool,
     /// Retains that are load-bearing on some path, so they cannot be cancelled.
     needed_retains: Set<NodeId>,
     /// The releases each retain is un-bumped by; they are deleted together with the retain.
@@ -1223,20 +1178,6 @@ struct CancelAnalysis<'a> {
 }
 
 impl<'a> CancelAnalysis<'a> {
-    /// The unit key a leaf of this function is counted under, which a retain and a release pair on
-    /// (`ownership::unit_key`).
-    // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-    fn unit_key(&self, var: &FullName, path: &[usize]) -> VarPath {
-        unit_key(self.vars, self.type_env, var, path)
-    }
-
-    /// Every unit an operation on a leaf of this function acts on: a pending retain on any of them
-    /// is load-bearing across the operation (`ownership::acted_unit_keys`).
-    // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-    fn acted_unit_keys(&self, var: &FullName, path: &[usize]) -> Vec<VarPath> {
-        acted_unit_keys(self.vars, self.type_env, var, path)
-    }
-
     /// The references a reference-count node of this function acts on, which decide whether a
     /// release un-bumps a retain (`ownership::acted_references`).
     // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
@@ -1284,34 +1225,22 @@ impl<'a> CancelAnalysis<'a> {
                 let retain = node_id(node);
                 self.all_retains.push(retain);
                 self.un_bump_releases.entry(retain).or_default();
-                if self.names_itself(v, path) {
-                    self.needed_retains.insert(retain);
-                }
                 let outstanding = self.acted_references(v, path);
-                pending
-                    .entry(self.unit_key(&v.name, path))
-                    .or_default()
-                    .push(PendingRetain {
-                        node: retain,
-                        outstanding,
-                    });
+                pending.push(PendingRetain {
+                    node: retain,
+                    outstanding,
+                });
                 self.walk(k, pending, returns_from_func)
             }
             RcExpr::Release(v, path, _, k) => {
-                let key = self.unit_key(&v.name, path);
                 // A release of a value whose object is path-dependent un-bumps a retain of that same
-                // value, so it pairs on the identity. On the other objects it may be, it is a drop:
-                // a retain of one of them that is still pending cannot be cancelled across it.
-                for other in self.acted_unit_keys(&v.name, path) {
-                    if other != key {
-                        self.consume_unit(&mut pending, other);
-                    }
-                }
+                // value, so it pairs on the reference it names. On the other objects it may be, it
+                // is a drop: a retain of one of them that is still pending cannot be cancelled
+                // across it.
+                let others = self.other_objects(v, path);
+                self.consume_objects(&mut pending, &others);
                 let un_bumped = self.acted_references(v, path);
-                if self.develop_mode {
-                    check_one_key_per_object(&pending, &key, &un_bumped, v, path);
-                }
-                match un_bump(&mut pending, &key, &un_bumped) {
+                match un_bump(&mut pending, &un_bumped) {
                     UnBump::InBracket(retain) => self
                         .un_bump_releases
                         .entry(retain)
@@ -1319,8 +1248,11 @@ impl<'a> CancelAnalysis<'a> {
                         .push(node_id(node)),
                     // A release that reaches references the innermost bracket did not bump closes
                     // no bracket here. It un-bumps part of what retains outside that bracket
-                    // bumped, so no retain pending for the unit can be cancelled as a whole.
-                    UnBump::OutsideBracket => self.consume_unit(&mut pending, key),
+                    // bumped, so no retain acting on those objects can be cancelled as a whole.
+                    UnBump::OutsideBracket => {
+                        let objects = un_bumped.objects();
+                        self.consume_objects(&mut pending, &objects)
+                    }
                     UnBump::NoBracket => {}
                 }
                 self.walk(k, pending, returns_from_func)
@@ -1349,31 +1281,12 @@ impl<'a> CancelAnalysis<'a> {
             RcExpr::Ret(_) => {
                 if returns_from_func {
                     // A retain still pending at the function's return closes no bracket on this path.
-                    for stack in pending.values() {
-                        for retain in stack {
-                            self.needed_retains.insert(retain.node);
-                        }
+                    for retain in &pending {
+                        self.needed_retains.insert(retain.node);
                     }
                 }
                 pending
             }
-        }
-    }
-
-    /// Whether the value at `(v, path)` answers with a name of its own rather than a name of what it
-    /// holds: the leaves under it reach several objects, and `origin` has no one name for them.
-    ///
-    /// A retain of such a value is counted under that made-up name, while a construct consuming one
-    /// of the objects it holds is counted under the object's own name. The two never meet, so the
-    /// consume leaves the retain cancellable and the pair is removed across it. Keeping the retain
-    /// costs the pair; removing it frees an object the consume has already disposed of.
-    ///
-    /// `Std::Option (a, b)` and `Std::Result e (a, b)` take this shape: the payload holds two
-    /// reference-counting units, and the union built from it holds both.
-    fn names_itself(&self, v: &RcVar, path: &FieldPath) -> bool {
-        match origin(self.vars, self.type_env, &v.name, path) {
-            Origin::Exactly(_) => false,
-            Origin::Join { identity, .. } => identity == (v.name.clone(), path.to_vec()),
         }
     }
 
@@ -1404,22 +1317,52 @@ impl<'a> CancelAnalysis<'a> {
         }
     }
 
-    /// A consume of a leaf: every retain pending for a unit it may belong to is load-bearing here.
-    // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
+    /// A consume of a leaf: every retain pending on an object the leaf may belong to is
+    /// load-bearing here.
     fn consume(&mut self, pending: &mut PendingRetains, var: &FullName, path: &[usize]) {
-        for key in self.acted_unit_keys(var, path) {
-            self.consume_unit(pending, key);
-        }
+        let objects: Vec<VarPath> = origin(self.vars, self.type_env, var, path)
+            .acted_on()
+            .into_iter()
+            .cloned()
+            .collect();
+        self.consume_objects(pending, &objects);
     }
 
-    /// A consume of one unit: every retain pending for it is load-bearing here.
-    // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
-    fn consume_unit(&mut self, pending: &mut PendingRetains, key: VarPath) {
-        if let Some(stack) = pending.remove(&key) {
-            for retain in stack {
+    /// A consume of some objects: every retain pending on one of them is load-bearing here, so it
+    /// leaves the pending list without having been un-bumped.
+    fn consume_objects(&mut self, pending: &mut PendingRetains, objects: &[VarPath]) {
+        pending.retain(|retain| {
+            if objects
+                .iter()
+                .any(|object| retain.outstanding.names(object))
+            {
                 self.needed_retains.insert(retain.node);
+                return false;
             }
+            true
+        });
+    }
+
+    /// The objects a reference-count node on `(v, path)` may act on besides the ones it names: for
+    /// each boxed leaf under the path, the candidates of its origin other than the one the leaf's
+    /// reference is counted under.
+    fn other_objects(&self, v: &RcVar, path: &FieldPath) -> Vec<VarPath> {
+        let mut out = vec![];
+        for leaf in boxed_leaf_paths(&v.ty, self.type_env) {
+            if !leaf.starts_with(path) {
+                continue;
+            }
+            let where_from = origin(self.vars, self.type_env, &v.name, &leaf);
+            let identity = where_from.identity().clone();
+            out.extend(
+                where_from
+                    .candidates()
+                    .into_iter()
+                    .filter(|candidate| **candidate != identity)
+                    .cloned(),
+            );
         }
+        out
     }
 
     /// Merge match arms into their continuation. A retain the match was entered with continues when
@@ -1439,17 +1382,12 @@ impl<'a> CancelAnalysis<'a> {
         let arm_states: Vec<Map<NodeId, &References>> = arm_exits
             .iter()
             .map(|exit| {
-                exit.values()
-                    .flatten()
+                exit.iter()
                     .map(|retain| (retain.node, &retain.outstanding))
                     .collect()
             })
             .collect();
-        let entered_with: Set<NodeId> = pending_in
-            .values()
-            .flatten()
-            .map(|retain| retain.node)
-            .collect();
+        let entered_with: Set<NodeId> = pending_in.iter().map(|retain| retain.node).collect();
         let mut uniform: Map<NodeId, References> = Map::default();
         for states in &arm_states {
             for (&retain, &outstanding) in states {
@@ -1466,22 +1404,15 @@ impl<'a> CancelAnalysis<'a> {
         }
         // Keep the retains the arms agree on, in the pre-match order so release pairing stays
         // innermost-first.
-        let mut merged = PendingRetains::default();
-        for (key, stack) in pending_in {
-            let kept: Vec<PendingRetain> = stack
-                .iter()
-                .filter_map(|retain| {
-                    uniform.get(&retain.node).map(|outstanding| PendingRetain {
-                        node: retain.node,
-                        outstanding: outstanding.clone(),
-                    })
+        pending_in
+            .iter()
+            .filter_map(|retain| {
+                uniform.get(&retain.node).map(|outstanding| PendingRetain {
+                    node: retain.node,
+                    outstanding: outstanding.clone(),
                 })
-                .collect();
-            if !kept.is_empty() {
-                merged.insert(key.clone(), kept);
-            }
-        }
-        merged
+            })
+            .collect()
     }
 
     /// The nodes to delete: every cancellable retain (one never marked needed and un-bumped by at

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -48,8 +48,8 @@ use crate::rc_ir::ast::{
 use crate::rc_ir::leaf_map::boxed_leaf_paths;
 use crate::rc_ir::ownership::{
     acted_references, acted_unit_keys, all_owned_units, collect_consumes, destructure_consumes,
-    origin, rc_units, rhs_consumes, truncate_to_unit, unit_key, unit_step, units_under, References,
-    UnitStep, VarTable,
+    origin, rc_units, rhs_consumes, truncate_to_unit, unit_key, unit_step, units_under, Origin,
+    References, UnitStep, VarTable,
 };
 use crate::rc_ir::rename::fresh_rename_function;
 use std::sync::Arc;
@@ -168,16 +168,9 @@ fn level_ownership(
         .into_iter()
         .cloned()
         .collect();
-    let owns_a_candidate = candidates.iter().any(|(root, path)| {
-        match vars.param_tys.get(root) {
-            // A root this version takes no parameter for is a producer or a global, and the version
-            // owns what it produced.
-            None => true,
-            Some(ty) => covered_leaves(ty, path, type_env)
-                .iter()
-                .any(|leaf| owned_leaves.contains(&(root.clone(), leaf.clone()))),
-        }
-    });
+    let owns_a_candidate = candidates
+        .iter()
+        .any(|(root, path)| owns_object_yet(vars, type_env, root, path, owned_leaves));
     if !owns_a_candidate {
         return false;
     }
@@ -191,6 +184,39 @@ fn level_ownership(
         }
     }
     changed
+}
+
+/// Whether the ownership decided so far already gives this version the object at `(root, path)`.
+///
+/// This is `RewriteCtx::owns_object` asked of the inference's own state. The two have to answer
+/// alike, because `level_ownership` fires on this answer and the rewrite acts on that one. A unit is
+/// owned once **any** leaf truncating to it is owned, which is how `borrow_ify` turns the inferred
+/// leaves into `owned_units`, so a unit's other leaves are owned by that step whether or not the
+/// inference ever named them. Reading the leaves directly here would miss exactly those, and the
+/// unit would be rewritten as owned while the levelling never fired.
+fn owns_object_yet(
+    vars: &VarTable,
+    type_env: &TypeEnv,
+    root: &FullName,
+    path: &FieldPath,
+    owned_leaves: &Set<VarPath>,
+) -> bool {
+    // A root this version takes no parameter for is a producer or a global, and the version owns
+    // what it produced.
+    let Some(ty) = vars.param_tys.get(root) else {
+        return true;
+    };
+    let leaves = boxed_leaf_paths(ty, type_env);
+    units_under(ty, path, type_env).iter().all(|unit| {
+        // `units_under` answers with the path itself where the path runs below a unit -- into a
+        // variant of an unboxed union, say -- so the answer is truncated before it is a key, as
+        // `owns_object` truncates it.
+        let key = truncate_to_unit(ty, unit, type_env);
+        leaves.iter().any(|leaf| {
+            truncate_to_unit(ty, leaf, type_env) == key
+                && owned_leaves.contains(&(root.clone(), leaf.clone()))
+        })
+    })
 }
 
 /// The boxed leaves of `ty` that `path` covers: the ones beneath it, and the one it lies beneath.
@@ -1258,6 +1284,9 @@ impl<'a> CancelAnalysis<'a> {
                 let retain = node_id(node);
                 self.all_retains.push(retain);
                 self.un_bump_releases.entry(retain).or_default();
+                if self.names_itself(v, path) {
+                    self.needed_retains.insert(retain);
+                }
                 let outstanding = self.acted_references(v, path);
                 pending
                     .entry(self.unit_key(&v.name, path))
@@ -1328,6 +1357,23 @@ impl<'a> CancelAnalysis<'a> {
                 }
                 pending
             }
+        }
+    }
+
+    /// Whether the value at `(v, path)` answers with a name of its own rather than a name of what it
+    /// holds: the leaves under it reach several objects, and `origin` has no one name for them.
+    ///
+    /// A retain of such a value is counted under that made-up name, while a construct consuming one
+    /// of the objects it holds is counted under the object's own name. The two never meet, so the
+    /// consume leaves the retain cancellable and the pair is removed across it. Keeping the retain
+    /// costs the pair; removing it frees an object the consume has already disposed of.
+    ///
+    /// `Std::Option (a, b)` and `Std::Result e (a, b)` take this shape: the payload holds two
+    /// reference-counting units, and the union built from it holds both.
+    fn names_itself(&self, v: &RcVar, path: &FieldPath) -> bool {
+        match origin(self.vars, self.type_env, &v.name, path) {
+            Origin::Exactly(_) => false,
+            Origin::Join { identity, .. } => identity == (v.name.clone(), path.to_vec()),
         }
     }
 

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -825,41 +825,6 @@ pub(crate) fn truncate_to_unit(
     out
 }
 
-/// The reference-counting unit a leaf belongs to, as an object identity: its `origin`'s identity,
-/// truncated to the unit. A leaf below an unboxed union keys to the union itself, so a whole-union
-/// retain and a consume of the payload get the same key: the consume marks that retain as needed,
-/// and cancellation keeps it together with the union release that un-bumps it.
-///
-/// This is the key a retain and a release are paired on, and the key a reference count is kept
-/// under, so it must name one object: a leaf whose object is path-dependent keys to the match
-/// binding that joins the paths, which every alias chain through it agrees on. The units an
-/// operation on it really touches are `acted_unit_keys`.
-// PROOF: P1, P2, P3, P4, P5, P6, P7 (dev-docs/proof/rc_ir/borrow-cancel)
-pub(crate) fn unit_key(
-    vars: &VarTable,
-    type_env: &TypeEnv,
-    var: &FullName,
-    path: &[usize],
-) -> VarPath {
-    unit_of(vars, type_env, origin(vars, type_env, var, path).identity())
-}
-
-/// Every reference-counting unit an operation on a leaf acts on: the one its reference is counted
-/// under, and the ones the object it belongs to may be counted under.
-// PROOF: P3, P4 (dev-docs/proof/rc_ir/borrow-cancel)
-pub(crate) fn acted_unit_keys(
-    vars: &VarTable,
-    type_env: &TypeEnv,
-    var: &FullName,
-    path: &[usize],
-) -> Vec<VarPath> {
-    origin(vars, type_env, var, path)
-        .acted_on()
-        .into_iter()
-        .map(|p| unit_of(vars, type_env, p))
-        .collect()
-}
-
 /// The references a reference-count operation acts on: how many references of each object it bumps
 /// or un-bumps. A value holding one object's reference twice contributes two of it.
 ///
@@ -885,6 +850,24 @@ impl References {
                 .get(object)
                 .is_some_and(|held_count| held_count >= count)
         })
+    }
+
+    /// Whether these act on the object.
+    pub(crate) fn names(&self, object: &VarPath) -> bool {
+        self.0.contains_key(object)
+    }
+
+    /// The objects these act on, each once however many of its references they carry.
+    pub(crate) fn objects(&self) -> Vec<VarPath> {
+        self.0.keys().cloned().collect()
+    }
+
+    /// Whether these and `other` act on an object in common.
+    ///
+    /// This is what tells a release which pending retain it may be closing. A retain and a release
+    /// that name no object in common act on different things, however their values are written.
+    pub(crate) fn shares_an_object(&self, other: &References) -> bool {
+        other.0.keys().any(|object| self.0.contains_key(object))
     }
 
     /// Drop `other`'s references from these, where `covers` holds of the two.
@@ -927,38 +910,6 @@ pub(crate) fn acted_references(
         *references.entry(object).or_default() += 1;
     }
     References(references)
-}
-
-/// The unit key of an object identity: the root it names, with its path truncated to the
-/// reference-counting unit that holds it. The returned path is always one of that root's units.
-// PROOF: P1, P2, P3, P4, P5, P6, P7 (dev-docs/proof/rc_ir/borrow-cancel)
-fn unit_of(vars: &VarTable, type_env: &TypeEnv, (root, path): &VarPath) -> VarPath {
-    let Some(ty) = vars.var_tys.get(root) else {
-        // A root with no type here is a global: the table holds the function's own variables.
-        // Reference counting is inserted for locals only and a global's reachable graph is
-        // refcount-exempt, so no retain or release keys to it and there is nothing to line up.
-        assert!(
-            !root.is_local(),
-            "local `{}` has no recorded type",
-            root.to_string()
-        );
-        return (root.clone(), path.clone());
-    };
-    let truncated = truncate_to_unit(ty, path, type_env);
-    // Truncation only descends, so an identity whose path stops above every unit of its type
-    // comes out naming no unit at all. A retain under such a key pairs with no release of the
-    // object, so cancellation drops it and the object is freed while it is still held. The check
-    // sits here, where every key is made.
-    let units = rc_units(ty, type_env);
-    assert!(
-        units.contains(&truncated),
-        "the key `{}{:?}` names no reference-counting unit of `{}`, whose units are {:?}",
-        root.to_string(),
-        truncated,
-        ty.to_string(),
-        units,
-    );
-    (root.clone(), truncated)
 }
 
 /// The owned parameter/capture units of every function: each version's units minus the ones it

--- a/src/tests/test_union_rc_shapes.rs
+++ b/src/tests/test_union_rc_shapes.rs
@@ -590,6 +590,172 @@ main = (
         test_source(SPLIT_OWNERSHIP_UNIT_SOURCE, Configuration::develop_mode());
     }
 
+    // A union whose payload is an unboxed aggregate holding two reference-counting units, as
+    // `Option (a, b)` and `Result e (a, b)` do. The leaves under the union reach two different
+    // objects, so `origin` has no one name for the union and answers with a name of the union's
+    // own. A retain of the union is then counted under that made-up name while a construct
+    // consuming one of the objects is counted under the object's own name, and the two never meet:
+    // the consume leaves the retain cancellable and the pair goes away across it.
+    //
+    // `drain` consumes the payload, `peek2` reads the union afterwards, and the arrays allocated in
+    // between take the freed memory, so the answer changes.
+    const UNION_PAYLOAD_TWO_UNITS_SOURCE: &str = r#"
+module Main;
+
+// An unboxed union whose `pair` payload holds the references of two distinct objects.
+type Action = unbox union { pair : (Array I64, Array I64), mark : I64 };
+
+// Reads both arrays the payload holds and disposes of no reference: the destructure names both
+// fields (a move) and element access borrows.
+read_both : Action -> I64;
+read_both = |x| match x {
+    pair(p) => (let (a, b) = p; a.@(0) * 10 + b.@(0)),
+    mark(m) => m
+};
+
+// Borrows both unions. The recursion keeps the call out of line.
+peek2 : Action -> Action -> I64 -> I64;
+peek2 = |a, b, n| (
+    if n == 0 { read_both(a) + read_both(b) };
+    peek2(a, b, n - 1)
+);
+
+// Consumes the payload: both arrays go into a fresh array, which is then dropped.
+consume_pair : (Array I64, Array I64) -> I64;
+consume_pair = |p| (
+    let (x, y) = p;
+    let z = [x, y];
+    z.@size
+);
+
+// Owns its union: the payload it takes out goes to an owning position.
+drain : Action -> I64 -> I64;
+drain = |a, n| (
+    if n == 0 {
+        match a {
+            pair(p) => consume_pair(p),
+            mark(m) => m
+        }
+    };
+    drain(a, n - 1)
+);
+
+run : I64 -> (Array I64, Array I64) -> Action -> I64;
+run = |k, payload, other| (
+    let action = Action::pair(payload);
+    let u1 = drain(action, 1);
+    // Two arrays of the sizes the payload had, allocated after `drain` disposed of it.
+    let f1 = Array::fill(k + 2, 111);
+    let f2 = Array::fill(k + 3, 222);
+    let u2 = peek2(action, other, 2);
+    let u3 = drain(other, 1);
+    u1 * 10000 + u2 * 10 + u3 + (f1.@(0) - 111) + (f2.@(0) - 222)
+);
+
+main : IO ();
+main = (
+    // The sizes come from the command line, so the arrays are not constant-folded away.
+    let args = *get_args;
+    let k = args.@size;
+    let payload = (Array::fill(k + 2, 7), Array::fill(k + 3, 9));
+    let other = Action::pair((Array::fill(k + 4, 1), Array::fill(k + 5, 2)));
+    let r = run(k, payload, other);
+    assert_eq(|_|"a union payload holding two units, retained across a consume", r, 20912);;
+    pure()
+);
+"#;
+
+    /// The reads after the consume see the payload the union was built with.
+    #[test]
+    pub fn test_union_payload_two_units_correctness() {
+        test_source_without_valgrind(UNION_PAYLOAD_TWO_UNITS_SOURCE);
+    }
+
+    /// The same under Valgrind MemCheck, which is what the read of the freed payload shows up as.
+    #[test]
+    pub fn test_union_payload_two_units_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        test_source(
+            UNION_PAYLOAD_TWO_UNITS_SOURCE,
+            Configuration::develop_mode(),
+        );
+    }
+
+    // A parameter that is an unboxed union whose variants each hold one array, where only one
+    // variant's leaf is consumed. Ownership is inferred per leaf and read per unit, and a unit
+    // counts as owned once any leaf under it is, so the union's unit is owned while the other
+    // variant's leaf was never named. A borrowing version then has to answer for the unit built
+    // from that variant's payload and a borrowed array, and the answer it gives decides whether the
+    // owned reference is disposed at all.
+    const ONE_VARIANT_OWNED_SOURCE: &str = r#"
+module Main;
+
+type U = union { a : Array I64, b : Array I64 };
+type V = union { twins : (Array I64, Array I64), nothing : () };
+
+f : I64 -> U -> Array I64 -> Array I64;
+f = |n, p, q| (
+    let m = n + 1;
+    let m = m + 2;
+    let m = m + 3;
+    let m = m + 4;
+    let m = m + 5;
+    let m = m + 6;
+    let m = m + 7;
+    let m = m + 8;
+    let m = m * 9;
+    let m = m * 10;
+    let m = m * 11;
+    let m = m * 12;
+    let m = m * 13;
+    let m = m * 14;
+    let m = m - 15;
+    let m = m - 16;
+    let m = m - 17;
+    let m = m - 18;
+    let m = m - 19;
+    let m = m - 20;
+    match p {
+        a(y0) => y0,
+        b(y1) => (
+            let v = V::twins((y1, q));
+            eval v;
+            Array::fill(1, m)
+        )
+    }
+);
+
+main : IO ();
+main = (
+    let arr1 = Array::fill(3, 1);
+    let arr2 = Array::fill(3, 2);
+    let u = U::b(arr1);
+    let r = f(0, u, arr2);
+    assert_eq(|_|"one variant of a parameter union owned", r.@size + arr2.@(0), 3);;
+    pure()
+);
+"#;
+
+    /// The array the union carried is freed exactly once. The answer is right either way, so only
+    /// the leak check catches this.
+    #[test]
+    pub fn test_one_variant_owned_memory_safety() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        test_source(ONE_VARIANT_OWNED_SOURCE, Configuration::develop_mode());
+    }
+
     // A union payload built from a value a match binding carries and a second value. The binding
     // carries a name of its own -- the one every path through the match agrees on -- and that name
     // is what a retain of the binding keys to. A release of the union has to name it as well: the


### PR DESCRIPTION
Closes #545

`-O max` と `-O experimental` で、`cancel` が `Retain`/`Release` の対を、その間にある消費をまたいで削除し、
解放されたオブジェクトを読むコードを作っていた。

あわせて、#530 の修正が残していた漏れも直す。こちらは同じファイルの別の欠陥である。

## 何が起きていたか

### 登場する関数

**`origin(v, π)`** (`src/rc_ir/ownership.rs`) は、値のある位置にある参照が、どの変数のどの位置で作られたものかを
答える。答えは `Exactly(u, σ)` か `Join { identity, candidates }` である。

**`unit_key(v, π)`** は `origin(v, π).identity()` を RC unit へ切り詰めたもので、**その参照が数えられる名前**で
ある。`cancel` はこの名前で `Retain` と `Release` を対にしていた。

**`CancelAnalysis`** (`src/rc_ir/borrow.rs`) は本体を前向きに走査し、`pending` に「まだ un-bump されていない
`Retain`」を積む。`Release` に出会うと同じ名前で引いて対にし、消費に出会うとその名前の下の `Retain` に
「載っている」印を付ける。印の付いた `Retain` は対消滅の対象から外れる。

### 壊れていた実行

```fix
type Action = unbox union { pair : (Array I64, Array I64), mark : I64 };
```

`Action` の `pair` 変位の payload は**参照を 2 つ持つ**。`Std::Option (a, b)` と `Std::Result e (a, b)` が
同じ形である。

`origin` はこの union に**名前を付けられない**。`union_make` の宣言は結果の leaf `[0,0]` を第 0 オペランドの
leaf `[0]` に、`[0,1]` を `[1]` に写す。leaf が 2 つの別々のオペランド unit に辿り着くので、
`origin_from_leaves_under` は答えを「読み出した値自身の名前」を identity とする `Join` にする。

状態を追う。`action` を union、`obj1` を payload の第 1 要素が指すオブジェクトとする。

1. `let action = Action::pair(payload)` の後。`action` は `obj1` への参照を持つ。
   `unit_key(action, []) = (action, [])` -- 作られた名前である。
2. `retain action` の後。`H(obj1) = 2`。`pending` に `(action, [])` の名前で積まれる。
3. `drain(action, 1)` は payload を取り出して所有側の位置へ渡す。**これは `obj1` の消費である。** 消費の名前は
   `obj1` を指す leaf の `origin` から引くので `(payload, [0])` になる。**`(action, [])` ではない。**
4. よって `consume_unit((payload, [0]))` は `pending` の `(action, [])` を見つけられず、手順 2 の `retain` に
   印が付かない。`H(obj1) = 1`。
5. `release action` が `(action, [])` で引いて手順 2 の `retain` と対になる。**両方削除される。**
6. 削除の結果、手順 2 の `+1` が消えるので手順 3 の消費で `H(obj1) = 0` になり、`obj1` が解放される。
7. `peek2(action, ...)` が `obj1` を読む。**解放後の読み。**

### 直した実行

**名前を捨てた。** `pending` は `Map<VarPath, Vec<PendingRetain>>` から `Vec<PendingRetain>` になり、鍵を
持たない。対応は**両者が触れるオブジェクトの重なり**で決まる。

必要な情報は最初から手元にあった。`PendingRetain` は `outstanding: References` を持っており、これは
**オブジェクトごとの参照の多重集合**である。名前だけが、それを 1 つに潰していた。

- `Release` は、内側から見て**共通のオブジェクトを持つ最初の** `Retain` を閉じる。それが処分するものを
  すべて持っていれば `InBracket`、持っていなければ `OutsideBracket`。
- 消費は、**そのオブジェクトを名指す** pending な `Retain` をすべて `needed_retains` に入れる。

上の手順 4 で、消費は `obj1` を名指す。手順 2 の `Retain` の `outstanding` は `obj1` を含む。よって印が付き、
手順 5 の対消滅は起きず、実行は 1 から 7 のとおりに進む。

## 変更した項目

**`PendingRetains`**。役割は、まだ un-bump されていない `Retain` を走査中に保つこと。`Map<VarPath, Vec<_>>`
から `Vec<_>` になった。目的は上記。順序は走査が出会った順で、内側の括弧が末尾にある。

**`un_bump`**。役割は、`Release` が閉じる `Retain` を見つけてその `outstanding` を引くこと。変更は、鍵で引く
のをやめ、内側から見て共通のオブジェクトを持つ最初の要素を探すようにしたこと。

**`CancelAnalysis::consume`**。役割は、消費される leaf について、載っている `Retain` に印を付けること。変更は、
`acted_unit_keys` の各鍵で引くのをやめ、`origin(...).acted_on()` のオブジェクトを名指す `Retain` を探すように
したこと。

**`CancelAnalysis::consume_objects`** (新規、`consume_unit` を置き換える)。役割は、与えられたオブジェクトを
名指す pending な `Retain` をすべて `needed_retains` に入れ、`pending` から外すこと。

**`CancelAnalysis::other_objects`** (新規)。役割は、RC 節点が名指す以外に触れうるオブジェクトを返すこと。
path の下の各 leaf について、その `origin` の候補のうち identity でないものである。以前は
`acted_unit_keys` から鍵の差として取っていた。

**`CancelAnalysis::walk_inner` の `Retain` / `Release` / `Ret` の腕、`merge`**。変更は、`pending` が列になった
ことに合わせた読み書き。

**`References::shares_an_object` / `names` / `objects`** (新規、`src/rc_ir/ownership.rs`)。役割は、2 つの
`References` が共通のオブジェクトを持つか、あるオブジェクトを名指すか、名指すオブジェクトを列挙すること。

**`level_ownership` の発火判定** (`owns_object_yet`、新規)。役割は、推論が決めた所有が、書き換えの側の
`owns_object` と同じ答えになるかを問うこと。これが #530 の残していた漏れである。判定が **leaf 粒度**で読み、
書き換えが **unit 粒度**で読んでいた。unit は「その下の leaf が 1 つでも所有なら所有」なので、パラメータの
unbox union の一方の変位の leaf だけが所有されているときに食い違い、平準化が発火しないまま `Release` が
落ちていた。

## 消えたもの

**`unit_key`、`acted_unit_keys`、`unit_of`** (`src/rc_ir/ownership.rs`)。`cancel` が唯一の読み手だった。

**`check_one_key_per_object`** (`src/rc_ir/borrow.rs`)。「1 つのオブジェクトは 1 つの名前の下で数えられる」を
`develop_mode` で検査する表明だった。**新しい設計はその不変条件を要求しないので、守る対象が無くなった。**

**`cancel` の `develop_mode` 引数**。上の表明が唯一の読み手だった。

## 追加したテスト

`src/tests/test_union_rc_shapes.rs` に 3 本。

- **`test_union_payload_two_units_correctness` / `_memory_safety`**: 参照を 2 つ持つ payload の union を、
  その payload を消費した後で読む。issue の再現である。
- **`test_one_variant_owned_memory_safety`**: パラメータの unbox union の一方の変位の leaf だけが所有される
  形。#530 の残していた漏れである。答えはどちらの実装でも正しいので、leak check だけが捕まえる。

3 本とも、それぞれの修正を外すと**赤くなる**ことを確認した。

## changelog

書いていない。この欠陥が住む参照カウント IR は 1.4.0 に存在せず、beta は出荷ではないので、この欠陥を持つ
コンパイラは出荷されていない。

## 付録: 検証

**再現プログラム。**

| | 修正前 | 修正後 |
|---|---|---|
| #545 の再現 `-O none` / `-O basic` | 20912 | 20912 |
| #545 の再現 `-O max` | **43432** | 20912 |
| #530 残穴の再現 `-O max` | **definitely lost 32 bytes** | 0 bytes |

**テストスイート。** 1,649 通過 / 0 失敗 (`cargo test --release`)。

**コーパスの生成物。** `benchmark/speedtest/cases` の 56 ケースは 56/56 一致。LangArena の 50 ベンチマークは
差が出て、**参照カウント操作が 28 個減った** (retain 1,683 -> 1,669、release 3,333 -> 3,319)。**鍵が一致
しないために対応が取れず、消せていなかった対が 14 組あった**ということである。減ったのは
`Std::Iterator::fold` が 16 個、`Minilib` の JSON パーサの 3 関数が 12 個である。

**性能** (`cycles:u`、`perf_counters.py --windows 3`、他の仕事は 0.08 - 0.11 コア)。

| ベンチマーク | 修正前 | 修正後 | 変化 |
|---|---|---|---|
| `Etc::Words` | 7,797,100,542 | 7,792,827,360 | -0.05% |
| `Distance::NGram` | 2,539,775,074 | 2,541,703,339 | +0.08% |
| `Json::ParseMapping` | 277,564,252,610 | 277,572,818,232 | +0.003% |

すべてノイズの内側である。

**採らなかった応急の測定も残しておく。** 「`origin` が名前を付けられなかった値の `Retain` は消さない」という
最小の修正も作って測った。正しさは同じく回復するが、対消滅を諦めるので LangArena で RC 操作が 38 個**増え**、
`HashMap::insert` だけで 15 -> 41 になり、`Etc::Words` が **+6.40%**、`cp_lib_bipartite` が **+1.63%** 遅く
なった。この PR はその形を採っていない。

## 経緯

`borrow_ify` と `cancel` の RC 規律の保存の証明 (`dev-docs/proof/rc_ir/borrow-cancel/`) で、P7b (「unit の鍵は、
その下の leaf の鍵である」) を担当した証明者が、命題の反例として報告した。形式的な追跡は
`p13-keys-and-pending.md` の第 4 節にある。

**これは #519 と #529 に続く同じ族の 3 件目だった。** どれも「1 つのオブジェクトが道ごとに 2 つ以上の名前を
持ち、`Retain` と `Release` が別の名前に分かれる」形であり、根は「`unit_key` が何を名指す量なのかという設計が
定まっていない」ことだった。この PR は名前そのものを取り除くので、この族は閉じる。

証明の側では、偽だった 4 つの命題のうち 3 つ (P5 (c)、P7b、P7c) が**不要になる**。どれも「名前が一意である」
という、成り立たない前提を守るための命題だった。README の改訂は別の PR で行う。
