### PR TITLE
鍵が無くなった後の doc comment を直す

### DIFF
--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -359,9 +359,9 @@ pub fn borrow_ify(prog: &RcProgram, type_env: &TypeEnv, develop_mode: bool) -> R
 ///
 /// `fresh_rename_function` makes a name by appending its pass tag and a counter, reading none of the
 /// program's names, so the name it makes is new only because no binder the earlier passes mint ends
-/// in that shape. Nothing establishes that, and a collision would put two bindings under one
-/// `unit_key`, which is read by name: cancellation would then pair a retain of one with a release of
-/// the other and delete both.
+/// in that shape. Nothing establishes that, and a collision would give two bindings one name, which
+/// is what `origin` follows a value back to: cancellation would then pair a retain of one with a
+/// release of the other and delete both.
 ///
 /// Walking every binder costs a pass over the program, so this runs where the test suite runs it.
 fn check_clone_names_are_fresh<'a>(
@@ -1159,8 +1159,8 @@ pub fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
 
 /// The forward must-analysis for one function: it decides which retain and release nodes to delete.
 struct CancelAnalysis<'a> {
-    /// This function's variables: what binds each one and its type, which decide the unit key a
-    /// retain and a release pair on.
+    /// This function's variables: what binds each one and its type, which decide the objects a
+    /// retain and a release act on, and so which of them pair.
     vars: &'a VarTable,
     /// The whole program, so a call resolves to its callee's parameters.
     prog: &'a RcProgram,

--- a/src/rc_ir/ownership.rs
+++ b/src/rc_ir/ownership.rs
@@ -828,11 +828,11 @@ pub(crate) fn truncate_to_unit(
 /// The references a reference-count operation acts on: how many references of each object it bumps
 /// or un-bumps. A value holding one object's reference twice contributes two of it.
 ///
-/// Two operations that key to one `unit_key` need not act on the same references, so the key alone
-/// does not say whether a release un-bumps a retain. An unboxed union is one unit, counted on the
-/// union itself, and a retain of it bumps every reference its payload holds; a projection of that
-/// payload names those references one by one, so a release of the projection un-bumps only part of
-/// what the retain bumped.
+/// Two operations on one unit need not act on the same references, so naming the unit does not say
+/// whether a release un-bumps a retain. An unboxed union is one unit, counted on the union itself,
+/// and a retain of it bumps every reference its payload holds; a projection of that payload names
+/// those references one by one, so a release of the projection un-bumps only part of what the retain
+/// bumped. Counting the references themselves is what lets the two be compared.
 // PROOF: P15, P16, P17, P18 (dev-docs/proof/rc_ir/borrow-cancel)
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) struct References(Map<VarPath, usize>);


### PR DESCRIPTION
PR #546 が `cancel` から `unit_key` を取り除いたが、その仕組みを説明していた doc comment が 3 か所残って
いた。存在しない関数を名指しているので、読み手はコードの中にそれを探すことになる。

Refs #545

## 変更

いずれも doc comment だけで、実行される部分は 1 行も変わらない。

### `src/rc_ir/ownership.rs`: `References`

`References` は、参照カウント操作が触れる参照を、オブジェクトごとの個数として数える型である。この doc の
第 2 段落は、なぜ「どの unit を名指すか」だけでは retain と release が対になるかどうかが決まらないのかを
述べていた。

前:

> Two operations that key to one `unit_key` need not act on the same references, so the key alone
> does not say whether a release un-bumps a retain. An unboxed union is one unit, counted on the
> union itself, and a retain of it bumps every reference its payload holds; a projection of that
> payload names those references one by one, so a release of the projection un-bumps only part of
> what the retain bumped.

後:

> Two operations on one unit need not act on the same references, so naming the unit does not say
> whether a release un-bumps a retain. An unboxed union is one unit, counted on the union itself,
> and a retain of it bumps every reference its payload holds; a projection of that payload names
> those references one by one, so a release of the projection un-bumps only part of what the retain
> bumped. Counting the references themselves is what lets the two be compared.

最後の 1 文は、この型が在る理由を述べる。

### `src/rc_ir/borrow.rs`: `check_clone_names_are_fresh`

`borrow_ify` が作る借用版の複製が、入力のどの束縛名とも衝突しない名前を使っていることを検査する関数で
ある。doc は、衝突すると何が壊れるのかを述べていた。

前:

> Nothing establishes that, and a collision would put two bindings under one `unit_key`, which is
> read by name: cancellation would then pair a retain of one with a release of the other and delete
> both.

後:

> Nothing establishes that, and a collision would give two bindings one name, which is what `origin`
> follows a value back to: cancellation would then pair a retain of one with a release of the other
> and delete both.

壊れる筋は変わらない。名前で引かれるものが `unit_key` から `origin` の答え (`VarPath`) へ変わった。

### `src/rc_ir/borrow.rs`: `CancelAnalysis::vars`

`cancel` の走査が持つ変数表のフィールド。

前:

> This function's variables: what binds each one and its type, which decide the unit key a retain
> and a release pair on.

後:

> This function's variables: what binds each one and its type, which decide the objects a retain and
> a release act on, and so which of them pair.
