### PR TITLE
証明のエージェントに worktree を与え、表明を事実として引かせない

### DIFF
--- a/.claude/skills/code-proof/SKILL.md
+++ b/.claude/skills/code-proof/SKILL.md
@@ -216,13 +216,27 @@ Run it twice, and only twice. Running it continuously produces churn against a f
 
    **Show the skeleton to the user before dispatching provers.** A wrong definition wastes every prover that runs under it, and the decomposition is where a proof is won or lost.
 3. **Run the critic on the skeleton, and wait.** One subagent, briefed as *Briefing a critic* says. Act on what it returns before dispatching anything: a property the critic can name a wrong program for is a property to widen now, not after the proofs are written against it.
-4. **Run the provers.** One subagent per proposition file, dispatched in dependency layers: a prover may cite an earlier proposition's *statement*, so a whole layer of independent propositions goes out in one parallel block. They write documents rather than code, so they share the working tree; file ownership is what keeps them apart. Brief each with the *Briefing a prover* section below.
+4. **Run the provers.** One subagent per proposition file, dispatched in dependency layers: a prover may cite an earlier proposition's *statement*, so a whole layer of independent propositions goes out in one parallel block. **Each one gets its own git worktree** — see *Give every agent its own worktree*. Brief each with the *Briefing a prover* section below.
 
    A prover on a real subsystem is a long-running, expensive agent, so send a large layer out in batches rather than all at once — an interruption then costs one batch instead of the layer. When one is interrupted, its file is on disk: commit what is there and **resume that agent** rather than launching a fresh one, since the reading it has already done is most of what it spent.
 5. **Run the verifiers.** One subagent per proposition, all in parallel, each given only what the *Briefing a verifier* section allows. Wait for all.
 6. **Iterate.** Hand each verifier's findings to that file's prover. `NOT-OBVIOUS` is answered by inserting substeps, never by rewording the step to sound more certain. `FALSE`, `UNDEFINED`, `BAD-CITATION` and `HEDGE` are answered as the section below prescribes. Then verify again — with **fresh** verifier subagents, which have not seen the previous round's findings, so the check is never anchored to what it already accepted.
 7. **Stop at the fixed point.** The document is finished when one full round over every proposition returns no finding of any kind. Record the round in the status table.
 8. **Report.** Run the critic a second time before this, on the closed document, and carry what it says about the result's limits into the report. What was proved; under which assumptions; which assumptions nobody discharges; how many rounds it took; and every code bug the attempt turned up, in `bug-hunt` shape. Then update the hunt log's neighbours in memory if the proof changed what is known about the subsystem.
+
+### Give every agent its own worktree
+
+Dispatch provers and verifiers with `isolation: "worktree"`. A worktree of a source tree is small — measure it, but it is the tracked files and not the build directory, so a proof agent that never compiles costs almost nothing.
+
+**File ownership does not keep agents apart in a shared tree.** Each brief already says which one file the agent owns, and that is not what breaks. What breaks is a git command that writes the whole working tree: `git stash` to set work aside, `git checkout -- <path>` to undo a probe, `git reset --hard` to drop a commit. Each of those silently discards every other agent's uncommitted work, and the agent that ran it had no idea anyone else was there. Forbidding them by name does not hold either — the list has a next member, and the orchestrator is as likely to run one as any subagent.
+
+So the brief carries both: the worktree, and the line that no agent runs a git command which writes the working tree. Reads — `git rev-parse HEAD`, `git log`, `git diff` of its own file — stay open.
+
+**Name the commit in the brief.** A worktree is created from the repository's default branch, which during a proof effort is far behind the frame. An agent that reads that README grades against definitions that were replaced hours ago. So the brief opens with the commit to sync to and the command to do it, and the agent reports which commit it actually read — that report is what lets the orchestrator tell a stale finding from a live one.
+
+**The agent commits its own file** on its own branch, naming the path (never `git add -A`), and reports the branch. The orchestrator merges. Since the agents own disjoint files and only the orchestrator writes `README.md`, the merges are clean.
+
+**Hold frame changes until the round returns.** Each agent's `README.md` is frozen where it started, so a definition the orchestrator edits mid-round reaches nobody and turns every report that touches it into a claim about a document that no longer exists. Collect the frame edits a round asks for, apply them between rounds, and dispatch the next round from the new commit. This is the structural half of the rule under *Briefing a prover* that a report quoting the document must re-read it first: the rule catches a stale claim, and the batching stops most of them from being written.
 
 ## Briefing a prover
 
@@ -271,6 +285,8 @@ The verdicts:
 - **`INCOMPLETE`** — a `CASE` split whose cases are not exhaustive (name the missing case, by the arm of the type or the condition it corresponds to), a `QED` that does not cite everything its conclusion needs, a step with neither a `BY` nor a subproof, or a calculational chain whose relations do not compose.
 
 A verifier that returns `OK` for everything on its first pass over a proof of any size has almost certainly been persuaded rather than convinced; the orchestrator treats that as a signal to re-run with a fresh verifier before believing it.
+
+A verifier edits nothing, so it makes no commit, but it still reports the commit its worktree ended up on. A finding of the form "the document claims the frame lacks X, and the frame has X" is only worth acting on when the verifier read the frame the orchestrator meant.
 
 ## When the proof will not close
 


### PR DESCRIPTION
`code-proof` スキルへの 2 件。

## 1. 証明のエージェントに worktree を与える

スキルは、証明者がコードでなく文書を書くから作業ツリーを共有してよく、ファイルの持ち主を決めておけば衝突しない、と書いていた。実際には衝突する。

1 回の証明の作業の中で、**作業ツリー全体へ書く git コマンドが 3 度、他のエージェントの未コミットの作業を捨てた**。

- 証明者が probe を戻すための `git checkout -- src/fixstd/builtin.rs` が、未コミットの宣言 8 個を消した
- 別の証明者が作業を退避するための `git stash` が、同時に動いていた 2 つのエージェントの編集を巻き込んだ
- **オーケストレータ自身の `git reset --hard`** が、2 件目を診断している最中に 3 件目を起こした

ブリーフには既に「自分の 1 ファイルだけを書け」と書いてあり、それは破られていない。壊れているのは、その規律が**作業ツリー全体へ書くコマンドを覆っていない**ことである。危険なサブコマンドを名指しで禁じる形は採らなかった。3 件目をオーケストレータが起こしたことがその理由で、列挙には次の要素がある。

`### Give every agent its own worktree` を追加し、手順 4 の該当文を差し替えた。

- **`isolation: "worktree"` で配る。** 証明のエージェントはコンパイルしないので、費用は追跡ファイルの分だけ
- **ブリーフで commit を名指す。** worktree は既定のブランチから作られ、証明の作業の間それは骨格からかなり遅れている。同期先の commit をブリーフの先頭に置き、**実際に読んだ commit を報告させる**
- **枠の変更は 1 周が返るまで溜める。** worktree は README を凍結するので、周の途中の編集は誰にも届かず、それに触れる報告が全部「もう存在しない文書についての主張」になる
- 検証者も**着地した commit を報告する**

## 2. 表明を事実として引かせない

`assert!` / `assert_eq!` / `expect` / 条件を名乗る `unwrap` / 到達しないと author が呼んだ腕の `panic!` は、**誰かがそう信じたことの記録であって、そうであることの根拠ではない**。表明の条件が成り立つとして段を進めると、**証明が立てようとしているものをそのまま仮定した**ことになり、しかもコードの中で最も検分されない場所で仮定したことになる。

表明の価値はヒントである — 誰かが成り立たせようとした不変条件の名前であり、議論を探す場所を教える。だから `CODE` 引用で「何が主張されているか」を引くのはよく、段はなお**成り立つ理由**を負う (型の体系、入力を診断で弾く検査、先行する命題)。

**代償は「証明が不完全」に留まらない。** 表明だけが支える仮定は、それを破るプログラムが**利用者のコードのコンパイル中にコンパイラを落とす**ことを意味する。miscompile よりはましだが不具合であり、果たされた仮定として通すのでなく不具合として報告に載せるべきものである。**開発モードの旗の下の表明はさらに弱い** — 利用者が使うコンパイラでは走らないので、破れても捕まらず、結局 miscompile になる。

証明者が意識し、検証者が検査する。理由が単に無いなら `NOT-OBVIOUS`、表明そのものを理由として差し出しているなら `BAD-CITATION`。