### PR TITLE
code-proof: 範囲と個数を書かせない、同一性と番号を分ける

### DIFF
--- a/.claude/skills/code-proof/SKILL.md
+++ b/.claude/skills/code-proof/SKILL.md
@@ -91,6 +91,38 @@ When two proofs need the same fact, it is lifted out — into a preceding siblin
 
 The verifier's findings are answered by inserting steps, and renumbering would break every citation in the document. So **insert with a letter suffix**: a step between `<1>1` and `<1>2` is `<1>1a`, then `<1>1b`. Lamport's own worked proof does this. Numbers and suffixed numbers are never reused within one proof, even after a deletion.
 
+### Never write a range, a count, or any other derived figure
+
+A range of names -- `P8 - P14b`, `D1`-`D34`, "assumptions A1 through A26" -- names its endpoints and
+leaves its members to be reconstructed. Nothing can resolve it: not a reader who does not know which
+numbers exist, not a tool, and not the author a year later. Measured, a lettered number placed
+between two others (`A26a`) dropped out of a range that read "A1 through A26", and two steps that
+claimed to check every assumption silently skipped it.
+
+The same holds for a count. "The 78 implementations", "the six arms of the match", "the three places
+that write the field" -- each is a figure derived from the code or from the frame, and each goes
+stale the moment either moves, silently, because a wrong number reads exactly like a right one.
+Measured across six proof documents, half of the counted claims sat next to the enumeration they
+counted, so the figure carried nothing the list did not already carry.
+
+**Write what the figure was derived from.** Name the members, or give the predicate that selects
+them -- "every `impl LLVMGen` whose `result_prov` returns a `Fresh` leaf" resolves forever, while
+"the 29 such implementations" resolves until someone adds one. Where a count is the claim itself --
+zero occurrences, or exactly one call site when uniqueness is the point -- it stays, because there
+the figure is the property rather than a description of it.
+
+### Identity is not a number
+
+A step cites `P28` and a document is named `p20-borrow-ify.md`, so numbers and names look like
+identities. They are not. A number is a display: it orders items for a reader, and ordering is the
+one thing that changes when an item is inserted. Making it the identity is what forces the letter
+suffixes of the preceding section, and those suffixes are what ranges then lose.
+
+Give each item an identity that carries no meaning -- a short random string -- and let the number
+stay a display that may be reassigned freely. A tool then answers "what cites this" and "what moved
+under this" from the identities, and renumbering costs nothing. Keep the number in the prose: an
+identity is for machines to follow, and a reader who meets `a3f9c21` in a `BY` line learns nothing.
+
 ### Calculational steps
 
 A chain of relations may replace a run of steps when each link is short:


### PR DESCRIPTION
## 何を変えるか

`code-proof` スキルに 2 つの節を足す。

- **範囲・個数・その他の派生した数を書かない** (`### Never write a range, a count, or any other derived figure`)
- **同一性は番号ではない** (`### Identity is not a number`)

## なぜ

`borrow_ify` と `cancel` の健全性証明で、どちらも実際に欠陥を出した。

**範囲。** 枠の第 7.1 節が `p20-borrow-ify.md` の担当を `P8 - P14b` と範囲で書いていた。この形は
端点しか名指さず、中身は読み手が復元することになる。復元できる者が居ない — 番号の一覧を知らない
読み手にも、道具にも、1 年後の書き手にも。実測で、**枝番の `A26a` が「A1 から A26」という範囲から
落ち、「第 4 節の仮定をすべて満たす」ことを示す 2 つの段が黙ってそれを飛ばしていた** (`p15` の
`R1` と `R2`)。

**個数。** 「`impl LLVMGen for` は 78 個」「`match` は 8 つの腕」のような数は、コードか枠から
導かれた値であり、どちらかが動いた瞬間に古くなる。**誤った数は正しい数とまったく同じに見える**ので
気付かれない。実測で `origin_inner` の腕を「8 つ」と書いた箇所が 1 周見逃され、実際は 6 腕だった。
**6 つの証明ファイルの数の主張 360 件を分類したところ、半分 (180 件) はすぐ隣に列挙が書いてあり、
数はその要素数を再掲しているだけだった。**

枠自身が既にこの規則を持っていた — A25 が「一覧でなく述語で書くのは、段が増えるたびに一覧が古く
なるからである。**数も書かない** — 数は一覧と同じだけ古くなる」と書いている。にもかかわらず証明の
側に 360 件あった。スキルに無かったのが原因である。

**同一性と番号。** 番号を同一性にすると番号を振り直せなくなる。それが既存の「挿入は枝番で行う」
規則を生み、その枝番が上の範囲から落ちた。実測で、証明の補題は `L1` が 7 つの文書に、`L5` が
8 つの文書に在り、**番号はファイルの中でしか一意でなかった**。項目にランダムな同一性を振ったところ、
番号を 1 つも振り直さずに文書を跨いだ参照とその波及の計算ができるようになった。

## 例外を残した箇所

**個数そのものが主張であるとき**は残す — 出現が 0 件であること、一意性が要るときに呼び出し元が
1 か所であること。そこでは数が性質であって、性質の記述ではない。

## 検査

このスキルは散文なので自動検査は無い。実測の根拠は上記のとおりで、いずれも
`dev-docs/proof/rc_ir/borrow-cancel/README.md` の第 10 節に記録がある。