### PR TITLE
値の宣言名の上で「定義へ移動」を求めるとサーバが死ぬ (#559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 #### Tool
 
-- #559: LSP: Asking for the definition of a global value while the cursor is on the name it is declared or defined under no longer ends the language server. The server exited, taking the diagnostics, the completion and the hover of the session with it and leaving a restart as the only way back; it now answers that there is nowhere to jump to.
+- #559, #569: LSP: Asking for the definition of a global value while the cursor is on the name it is declared or defined under no longer ends the language server. The server exited, taking the diagnostics, the completion and the hover of the session with it and leaving a restart as the only way back; it now answers that there is nowhere to jump to.
 - #558, #567: LSP: A program the compiler answers with a panic — a shape a program passes through while it is being repaired — no longer stops the diagnostics of the session. The language server published nothing on any file for the rest of the session, however the program was repaired afterwards, and restarting it was the only way back. It now analyzes the next program the editor writes, and keeps the diagnostics of the last program it analyzed on screen until then.
 - #211, #400, #501: `--emit-llvm`, `--emit-rc-ir` and `--emit-symbols` now write their dumps however much of the build is cached. A build repeated in a directory answered from its object files and wrote no dump while exiting 0, so a dump an earlier build had left in place was read as this build's.
 - #256, #434, #501: `--cu-size`, and the `cu_size` field of the project file, are now honored on every build. Only the first build in a directory divided itself as asked; every later one reported `Using cached object files.` and kept the division the first had made.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 
 #### Tool
 
+- #559: LSP: Asking for the definition of a global value while the cursor is on the name it is declared or defined under no longer ends the language server. The server exited, taking the diagnostics, the completion and the hover of the session with it and leaving a restart as the only way back; it now answers that there is nowhere to jump to.
 - #558, #567: LSP: A program the compiler answers with a panic — a shape a program passes through while it is being repaired — no longer stops the diagnostics of the session. The language server published nothing on any file for the rest of the session, however the program was repaired afterwards, and restarting it was the only way back. It now analyzes the next program the editor writes, and keeps the diagnostics of the last program it analyzed on screen until then.
 - #211, #400, #501: `--emit-llvm`, `--emit-rc-ir` and `--emit-symbols` now write their dumps however much of the build is cached. A build repeated in a directory answered from its object files and wrote no dump while exiting 0, so a dump an earlier build had left in place was read as this build's.
 - #256, #434, #501: `--cu-size`, and the `cu_size` field of the project file, are now honored on every build. Only the first build in a directory divided itself as asked; every later one reported `Using cached object files.` and kept the division the first had made.

--- a/src/commands/lsp/goto_definition.rs
+++ b/src/commands/lsp/goto_definition.rs
@@ -33,8 +33,7 @@ pub(super) fn handle_goto_definition(
     };
 
     // The source location the name at the cursor is defined at. Every node the cursor can land on
-    // is answered here, so that a node whose answer is "nowhere to jump to" says so rather than
-    // reaching the end of the function.
+    // is answered here, and a node that names nothing to jump to answers with `None`.
     let def_src = match node {
         EndNode::Expr(var, _) | EndNode::Pattern(var, _) => {
             let full_name = &var.name;

--- a/src/commands/lsp/goto_definition.rs
+++ b/src/commands/lsp/goto_definition.rs
@@ -32,94 +32,57 @@ pub(super) fn handle_goto_definition(
         return;
     };
 
-    // The source location where the item is defined.
-    let mut def_src;
-
-    // First check if the node is an expression or a pattern.
-    let var_name = match &node {
-        EndNode::Expr(var, _) => Some(var.name.clone()),
-        EndNode::Pattern(var, _) => Some(var.name.clone()),
-        EndNode::Type(_) => None,
-        EndNode::Trait(_) => None,
-        EndNode::Module(_) => None,
-        EndNode::TypeOrTrait(_) => None,
-        EndNode::AssocType(_) => None,
-        EndNode::Field(_, _) => None,
-        EndNode::Variant(_, _) => None,
-        // The cursor is on the declaration name itself; there is no other definition to jump to.
-        EndNode::ValueDecl(_) => None,
-        // A `_` type wildcard has no declaration to jump to.
-        EndNode::InferredType(_) => None,
+    // The source location the name at the cursor is defined at. Every node the cursor can land on
+    // is answered here, so that a node whose answer is "nowhere to jump to" says so rather than
+    // reaching the end of the function.
+    let def_src = match node {
+        EndNode::Expr(var, _) | EndNode::Pattern(var, _) => {
+            let full_name = &var.name;
+            if full_name.is_local() {
+                find_local_occurrences(program, &pos, full_name).map(|o| o.definition)
+            } else {
+                program
+                    .global_values
+                    .get(full_name)
+                    .and_then(|gv| gv.decl_src.clone())
+            }
+        }
+        EndNode::Type(tycon) => find_tycon_def_src(program, tycon),
+        EndNode::Trait(trait_) => find_trait_or_alias_def_src(program, trait_),
+        EndNode::TypeOrTrait(name) => find_tycon_def_src(program, TyCon { name: name.clone() })
+            .or_else(|| find_trait_or_alias_def_src(program, TraitId::from_fullname(name))),
+        EndNode::Module(mod_name) => program
+            .modules
+            .iter()
+            .find(|mi| mi.name == mod_name)
+            .map(|mi| mi.source.clone()),
+        EndNode::AssocType(assoc_type) => {
+            // The associated type is declared by the trait it belongs to.
+            let trait_id = assoc_type.trait_id();
+            program
+                .trait_env
+                .traits
+                .get(&trait_id)
+                .and_then(|ti| ti.assoc_types.get(&assoc_type.name.name))
+                .and_then(|atd| atd.name_src.clone())
+        }
+        EndNode::Field(tc, name) | EndNode::Variant(tc, name) => {
+            find_field_def_src(program, &tc, &name)
+        }
+        // The cursor is on the declaration name itself, or on a `_` the compiler filled in.
+        // Neither names a definition elsewhere.
+        EndNode::ValueDecl(_) | EndNode::InferredType(_) => None,
     };
-    if let Some(var_name) = var_name {
-        let full_name = &var_name;
-        if full_name.is_local() {
-            def_src = find_local_occurrences(program, &pos, full_name).map(|o| o.definition);
-        } else {
-            def_src = program
-                .global_values
-                .get(full_name)
-                .and_then(|gv| gv.decl_src.clone());
-        }
-    } else {
-        // Then handle the case of a type or a trait or a module.
-        match node {
-            EndNode::Expr(_, _) => {
-                unreachable!()
-            }
-            EndNode::Pattern(_, _) => {
-                unreachable!()
-            }
-            EndNode::Type(tycon) => {
-                def_src = find_tycon_def_src(program, tycon);
-            }
-            EndNode::Trait(trait_) => {
-                def_src = find_trait_or_alias_def_src(program, trait_);
-            }
-            EndNode::TypeOrTrait(name) => {
-                def_src = find_tycon_def_src(program, TyCon { name: name.clone() });
-                if def_src.is_none() {
-                    def_src = find_trait_or_alias_def_src(program, TraitId::from_fullname(name));
-                }
-            }
-            EndNode::Module(mod_name) => {
-                if let Some(mi) = program.modules.iter().find(|mi| mi.name == mod_name) {
-                    def_src = Some(mi.source.clone());
-                } else {
-                    def_src = None;
-                }
-            }
-            EndNode::AssocType(assoc_type) => {
-                // Find the associated type definition in the trait.
-                let trait_id = assoc_type.trait_id();
-                def_src = program
-                    .trait_env
-                    .traits
-                    .get(&trait_id)
-                    .and_then(|ti| ti.assoc_types.get(&assoc_type.name.name))
-                    .and_then(|atd| atd.name_src.clone());
-            }
-            EndNode::Field(tc, name) | EndNode::Variant(tc, name) => {
-                def_src = find_field_def_src(program, &tc, &name);
-            }
-            EndNode::ValueDecl(_) => {
-                unreachable!()
-            }
-            EndNode::InferredType(_) => {
-                def_src = None;
-            }
-        }
-    }
 
     // If the source is not found, respond with None.
-    if def_src.is_none() {
+    let Some(def_src) = def_src else {
         send_response(id, Ok::<_, ()>(None::<()>));
         return;
-    }
-    let def_src = def_src.unwrap();
+    };
 
     // Create response value.
     let Some(cdir) = get_current_dir() else {
+        send_response(id, Ok::<_, ()>(None::<()>));
         return;
     };
     let location = span_to_location(&def_src, &cdir);

--- a/src/tests/test_lsp/cases/goto_local/lib.fix
+++ b/src/tests/test_lsp/cases/goto_local/lib.fix
@@ -77,3 +77,12 @@ and_short_circuit = (
     let b = 5 in
     if b >= 0 && b < 10 { b } else { 0 - b }
 );
+
+// A trait implementation, whose member name on the left-hand side is a declaration name too.
+trait a : Doubled {
+    doubled : a -> a;
+}
+
+impl I64 : Doubled {
+    doubled = |n| n * 2;
+}

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -319,19 +319,21 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// The name a global value is declared and defined under is answered like any other position:
-    /// the server replies that there is nowhere to jump to, and goes on serving.
+    /// The name a value is declared and defined under — a global value's, and a trait member's in
+    /// an implementation — is answered like any other position: the server replies that there is
+    /// nowhere to jump to, and goes on serving.
     ///
     /// The cursor lands there whenever the programmer asks for the definition of the value they
     /// are looking at, and the reply is the whole of what the request can say about it. A handler
     /// that treats the case as one that cannot arise ends the server process, which takes the
     /// diagnostics, the completion and the hover of the session with it.
     #[test]
-    fn test_goto_from_the_name_a_global_value_is_declared_under() {
+    fn test_goto_from_the_name_a_value_is_declared_under() {
         let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);
-        // Line 7 is `simple_let : I64;` and line 8 is `simple_let = (`, so both carry the name at
-        // column 0.
-        for (line, character) in [(7, 0), (7, 3), (8, 0), (8, 3)] {
+        // Line 7 is `simple_let : I64;`, line 8 is `simple_let = (`, and line 86 is the
+        // `doubled = |n| n * 2;` of the implementation of `Doubled` for `I64`. Each carries the
+        // name it declares at its start.
+        for (line, character) in [(7, 0), (7, 3), (8, 0), (8, 3), (86, 4), (86, 8)] {
             let result = ctx.goto_definition("lib.fix", line, character);
             assert!(
                 result.is_null(),

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -318,4 +318,30 @@ mod tests {
         assert_eq!(text, "old_func");
         ctx.shutdown();
     }
+
+    /// The name a global value is declared and defined under is answered like any other position:
+    /// the server replies that there is nowhere to jump to, and goes on serving.
+    ///
+    /// The cursor lands there whenever the programmer asks for the definition of the value they
+    /// are looking at, and the reply is the whole of what the request can say about it. A handler
+    /// that treats the case as one that cannot arise ends the server process, which takes the
+    /// diagnostics, the completion and the hover of the session with it.
+    #[test]
+    fn test_goto_from_the_name_a_global_value_is_declared_under() {
+        let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);
+        // Line 7 is `simple_let : I64;` and line 8 is `simple_let = (`, so both carry the name at
+        // column 0.
+        for (line, character) in [(7, 0), (7, 3), (8, 0), (8, 3)] {
+            let result = ctx.goto_definition("lib.fix", line, character);
+            assert!(
+                result.is_null(),
+                "the name at ({}, {}) is declared where it stands, so the reply is expected to \
+                 name no location, but it is {:?}",
+                line,
+                character,
+                result
+            );
+        }
+        ctx.shutdown();
+    }
 }


### PR DESCRIPTION
Closes #559

グローバル値の宣言名・定義名の上で「定義へ移動」を求めると、language server がプロセスごと終了していた。エディタからは、Ctrl+クリック 1 回でそのセッションの診断・補完・hover が同時に失われる形で見える。復帰の手段はサーバの再起動だけである。

## 壊れていた側の運び

`handle_goto_definition` はカーソル位置の `EndNode` を 2 つの `match` で順に扱っていた。1 つ目は「式かパターンなら名前を取る」もので、名前が取れなければ 2 つ目へ進む。

利用者が `main : IO ();` の `main` を Ctrl+クリックする。`Program::find_node_at` はグローバル値の `decl_src` に当たるので `EndNode::ValueDecl` を返す。ここから状態を追うと、

1. 1 つ目の `match` が `var_name = None` を返す。この腕にはコメントが付いていて、「カーソルは宣言名そのものの上にあり、飛び先は無い」と述べている。
2. `var_name` が `None` なので `else` の枝、すなわち 2 つ目の `match` に入る。
3. 2 つ目の `match` の `EndNode::ValueDecl(_)` の腕は `unreachable!()` である。

1 つ目が `None` を返す限り 2 つ目は必ず実行されるので、この腕は**必ず**踏まれる。`main` は CLI 全体を 1 本のスレッドで走らせるため、panic はプロセスの終了になる。

```
thread '<unnamed>' panicked at src/commands/lsp/goto_definition.rs:106:17:
internal error: entered unreachable code
```

同じ形の腕が `Expr` と `Pattern` にもあった。そちらは 1 つ目が名前を取るので到達しない。つまり 2 つ目の `match` は、1 つ目がどの変体を引き受けたかという**書かれていない取り決め**の上に立っていて、その取り決めが `ValueDecl` について破れていた。

## 直した側の運び

同じ Ctrl+クリックが `EndNode::ValueDecl` を作るところまでは変わらない。分かれるのはその次で、場合分けが 1 つになった。

1. 1 つの `match` が `EndNode::ValueDecl(_) | EndNode::InferredType(_) => None` の腕に入る。
2. `def_src` が `None` なので、「飛び先は無い」という応答 (`null`) を送って戻る。

サーバは生き続け、診断も補完も hover もそのまま働く。

この形にしたことで、`Expr` と `Pattern` の `unreachable!()` も消えた。変体を 1 つ足したときに答えを書き忘れると、コンパイラが `match` の非網羅で拒む。

## 変えた項目

**[`handle_goto_definition`](https://github.com/tttmmmyyyy/fixlang/blob/bf8111dfe1e13cc67ab488d9514ff8b4e8573a2c/src/commands/lsp/goto_definition.rs#L15-L93)**

**役割**: `textDocument/definition` に答える。カーソルの位置を解決し、そこに在る名前が定義された場所を求め、その位置を応答として返す。

**変更**: 2 つの `match` を 1 つにし、`Option<Span>` を直接返す形にした。`ValueDecl` と `InferredType` は「飛び先を名指さない」腕としてまとめ、`Expr` と `Pattern` は同じ腕で扱う。併せて、応答を返さずに戻る経路 (`get_current_dir()` が失敗する場合) を、他と同じく `null` を返す形にした。

**目的**: 変体ごとの答えを 1 か所で決めること。腕を 1 つ直すだけでは、同じ形 (片方が `None` を返した先をもう片方が到達不能と呼ぶ) が残る。

<details>
<summary><code>handle_goto_definition</code> — 2 つの match を 1 つにし、答えを返さない経路を無くす</summary>

```diff
--- src/commands/lsp/goto_definition.rs (before)
+++ src/commands/lsp/goto_definition.rs (after)
@@ -1,117 +1,79 @@
 pub(super) fn handle_goto_definition(
     id: u32,
     params: &GotoDefinitionParams,
     program: &Program,
     uri_to_content: &Map<lsp_types::Uri, LatestContent>,
 ) {
     // Resolve the cursor into a source position, then look up the AST node.
     let Some(pos) = resolve_source_pos(
         &params.text_document_position_params,
         program,
         uri_to_content,
     ) else {
         send_response(id, Ok::<_, ()>(None::<()>));
         return;
     };
     let Some(node) = program.find_node_at(&pos) else {
         send_response(id, Ok::<_, ()>(None::<()>));
         return;
     };
 
-    // The source location where the item is defined.
-    let mut def_src;
-
-    // First check if the node is an expression or a pattern.
-    let var_name = match &node {
-        EndNode::Expr(var, _) => Some(var.name.clone()),
-        EndNode::Pattern(var, _) => Some(var.name.clone()),
-        EndNode::Type(_) => None,
-        EndNode::Trait(_) => None,
-        EndNode::Module(_) => None,
-        EndNode::TypeOrTrait(_) => None,
-        EndNode::AssocType(_) => None,
-        EndNode::Field(_, _) => None,
-        EndNode::Variant(_, _) => None,
-        // The cursor is on the declaration name itself; there is no other definition to jump to.
-        EndNode::ValueDecl(_) => None,
-        // A `_` type wildcard has no declaration to jump to.
-        EndNode::InferredType(_) => None,
-    };
-    if let Some(var_name) = var_name {
-        let full_name = &var_name;
-        if full_name.is_local() {
-            def_src = find_local_occurrences(program, &pos, full_name).map(|o| o.definition);
-        } else {
-            def_src = program
-                .global_values
-                .get(full_name)
-                .and_then(|gv| gv.decl_src.clone());
-        }
-    } else {
-        // Then handle the case of a type or a trait or a module.
-        match node {
-            EndNode::Expr(_, _) => {
-                unreachable!()
-            }
-            EndNode::Pattern(_, _) => {
-                unreachable!()
-            }
-            EndNode::Type(tycon) => {
-                def_src = find_tycon_def_src(program, tycon);
-            }
-            EndNode::Trait(trait_) => {
-                def_src = find_trait_or_alias_def_src(program, trait_);
-            }
-            EndNode::TypeOrTrait(name) => {
-                def_src = find_tycon_def_src(program, TyCon { name: name.clone() });
-                if def_src.is_none() {
-                    def_src = find_trait_or_alias_def_src(program, TraitId::from_fullname(name));
-                }
-            }
-            EndNode::Module(mod_name) => {
-                if let Some(mi) = program.modules.iter().find(|mi| mi.name == mod_name) {
-                    def_src = Some(mi.source.clone());
-                } else {
-                    def_src = None;
-                }
-            }
-            EndNode::AssocType(assoc_type) => {
-                // Find the associated type definition in the trait.
-                let trait_id = assoc_type.trait_id();
-                def_src = program
-                    .trait_env
-                    .traits
-                    .get(&trait_id)
-                    .and_then(|ti| ti.assoc_types.get(&assoc_type.name.name))
-                    .and_then(|atd| atd.name_src.clone());
-            }
-            EndNode::Field(tc, name) | EndNode::Variant(tc, name) => {
-                def_src = find_field_def_src(program, &tc, &name);
-            }
-            EndNode::ValueDecl(_) => {
-                unreachable!()
-            }
-            EndNode::InferredType(_) => {
-                def_src = None;
+    // The source location the name at the cursor is defined at. Every node the cursor can land on
+    // is answered here, and a node that names nothing to jump to answers with `None`.
+    let def_src = match node {
+        EndNode::Expr(var, _) | EndNode::Pattern(var, _) => {
+            let full_name = &var.name;
+            if full_name.is_local() {
+                find_local_occurrences(program, &pos, full_name).map(|o| o.definition)
+            } else {
+                program
+                    .global_values
+                    .get(full_name)
+                    .and_then(|gv| gv.decl_src.clone())
             }
         }
-    }
+        EndNode::Type(tycon) => find_tycon_def_src(program, tycon),
+        EndNode::Trait(trait_) => find_trait_or_alias_def_src(program, trait_),
+        EndNode::TypeOrTrait(name) => find_tycon_def_src(program, TyCon { name: name.clone() })
+            .or_else(|| find_trait_or_alias_def_src(program, TraitId::from_fullname(name))),
+        EndNode::Module(mod_name) => program
+            .modules
+            .iter()
+            .find(|mi| mi.name == mod_name)
+            .map(|mi| mi.source.clone()),
+        EndNode::AssocType(assoc_type) => {
+            // The associated type is declared by the trait it belongs to.
+            let trait_id = assoc_type.trait_id();
+            program
+                .trait_env
+                .traits
+                .get(&trait_id)
+                .and_then(|ti| ti.assoc_types.get(&assoc_type.name.name))
+                .and_then(|atd| atd.name_src.clone())
+        }
+        EndNode::Field(tc, name) | EndNode::Variant(tc, name) => {
+            find_field_def_src(program, &tc, &name)
+        }
+        // The cursor is on the declaration name itself, or on a `_` the compiler filled in.
+        // Neither names a definition elsewhere.
+        EndNode::ValueDecl(_) | EndNode::InferredType(_) => None,
+    };
 
     // If the source is not found, respond with None.
-    if def_src.is_none() {
+    let Some(def_src) = def_src else {
         send_response(id, Ok::<_, ()>(None::<()>));
         return;
-    }
-    let def_src = def_src.unwrap();
+    };
 
     // Create response value.
     let Some(cdir) = get_current_dir() else {
+        send_response(id, Ok::<_, ()>(None::<()>));
         return;
     };
     let location = span_to_location(&def_src, &cdir);
     if location.is_none() {
         send_response(id, Ok::<_, ()>(None::<()>));
         return;
     }
     send_response(id, Ok::<_, ()>(location.unwrap()));
 }
```

</details>

## テスト

**`test_goto_from_the_name_a_value_is_declared_under`** (`src/tests/test_lsp/test_goto_definition.rs`)

値が宣言・定義されている名前の上で `textDocument/definition` を求めると、サーバが「飛び先なし」を答え、そのまま応答を返し続けることを固定する。見る位置は 6 か所で、`simple_let : I64;` の宣言行 2 点、`simple_let = (` の定義行 2 点、そして `impl I64 : Doubled` の中の `doubled = |n| n * 2;` の 2 点である。

この変更が無いと、最初の位置でサーバが死ぬので `Should receive a definition response` で赤になる。実装の側を元の形 (`EndNode::ValueDecl(_) => unreachable!()`) に戻して確認した。

実装のメンバの位置がこの腕に届くことは別に測った。位置を `impl` の中の 2 点だけに絞ったうえで同じ変異を当てると、やはりサーバが死ぬ。

case project `goto_local/lib.fix` の末尾に、トレイトとその実装を足している。既存のテストが行番号を直書きしているので、追加は末尾に置いて既存の行を動かしていない。

## 利用者に見えるテキスト

`CHANGELOG.md` に足したエントリ。

> - #559: LSP: Asking for the definition of a global value while the cursor is on the name it is declared or defined under no longer ends the language server. The server exited, taking the diagnostics, the completion and the hover of the session with it and leaving a restart as the only way back; it now answers that there is nowhere to jump to.

## 測ったこと

- `cargo test --release` は、lib の 179 本と bin の 1659 本がすべて通過する。
- 出荷済みの `fix 1.5.0 (f6614b8)` で、宣言行・定義行の 6 か所すべてがプロセスの終了になることを確認した (位置ごとにサーバを起動し直した)。
