### PR TITLE
借用版の関数が値にならないことを validate で見張る

### DIFF
--- a/src/rc_ir/validate.rs
+++ b/src/rc_ir/validate.rs
@@ -256,12 +256,44 @@ impl<'a> Validator<'a> {
     /// A variable use must resolve to a binding in scope or to a global (a function or global value).
     // PROOF: P1, P2 (dev-docs/proof/rc_ir/borrow-cancel)
     fn use_var(&self, name: &FullName) {
+        self.use_callee(name);
+        self.borrows_nothing(name, "is used as a value");
+    }
+
+    /// A use of a name as the callee of a direct call, where naming a borrowing function is what
+    /// borrow-ification's routing does.
+    // PROOF: D/A, P1, P2 (dev-docs/proof/rc_ir/borrow-cancel)
+    fn use_callee(&self, name: &FullName) {
         if !self.scope.contains(name) && !self.globals.contains(name) {
             panic!(
                 "[RC IR validate] {}: use of unbound variable `{}` in `{}`",
                 self.stage,
                 name.to_string(),
                 self.location
+            );
+        }
+    }
+
+    /// A function whose address becomes a value is reached by an indirect call, which resolves to no
+    /// `RcFunc`, so the cancellation analysis reads every argument position of it as owning
+    /// (`resolve_callee_params` answers `None` and `rhs_consumes` takes the position as consuming).
+    /// A borrowing version does not dispose the argument at a borrowed position, so a release of the
+    /// caller's would be cancelled against a consume that never happens and the reference would leak.
+    /// Borrow-ification reaches its versions by routing direct calls, and by nothing else.
+    // PROOF: D/A, P30, A19 (dev-docs/proof/rc_ir/borrow-cancel)
+    fn borrows_nothing(&self, name: &FullName, how: &str) {
+        let target = self.prog.funcs.get(&FuncRef { name: name.clone() });
+        let Some(target) = target else {
+            return;
+        };
+        if !target.borrowed_units.is_empty() {
+            panic!(
+                "[RC IR validate] {}: `{}` borrows {} unit(s) and {} in `{}`",
+                self.stage,
+                name.to_string(),
+                target.borrowed_units.len(),
+                how,
+                self.location,
             );
         }
     }
@@ -314,7 +346,7 @@ impl<'a> Validator<'a> {
         match rhs {
             RcRhs::Var(y) => self.use_var(&y.name),
             RcRhs::App(callee, args) => {
-                self.use_var(&callee.name);
+                self.use_callee(&callee.name);
                 for a in args {
                     self.use_var(&a.name);
                 }
@@ -331,6 +363,14 @@ impl<'a> Validator<'a> {
                         self.location
                     );
                 }
+                // A closure is reached by an indirect call, which resolves to no `RcFunc`, so the
+                // cancellation analysis reads every argument position of it as owning
+                // (`resolve_callee_params` answers `None` and `rhs_consumes` takes the position as
+                // consuming). A target that borrows a unit does not dispose the argument there, so
+                // the caller's release would be cancelled against a consume that never happens, and
+                // the reference would leak. The borrowing versions are reached by the direct calls
+                // borrow-ification routes to them, and by nothing else.
+                self.borrows_nothing(&fref.name, "is the target of a closure");
                 // The closure stores its captures in this order, and the target reads them out by
                 // slot index against its own copy of the layout. The two are redundant stores of one
                 // layout, so a rewrite that reordered, retyped, added, or dropped the captures at one
@@ -748,6 +788,36 @@ mod tests {
             closure_building_func(var_of("v", make_ptr_ty())),
             projecting_func(&capture, 0, vec![make_ptr_ty()]),
         ]);
+    }
+
+    /// A closure targeting a function that borrows is caught. An indirect call resolves to no
+    /// `RcFunc`, so the cancellation analysis reads its argument positions as owning; a borrowing
+    /// target would leave the caller's release cancelled against a consume that never happens.
+    #[test]
+    #[should_panic(expected = "is the target of a closure")]
+    fn rejects_a_closure_targeting_a_borrowing_version() {
+        let capture = var_of("cap", make_dynamic_object_ty());
+        let mut target = projecting_func(&capture, 0, vec![make_ptr_ty()]);
+        target
+            .borrowed_units
+            .insert((FullName::local("p"), vec![]));
+        validate_prog(vec![
+            closure_building_func(var_of("v", make_ptr_ty())),
+            target,
+        ]);
+    }
+
+    /// A borrowing function named in a value position is caught. Its address reaches an indirect
+    /// call, which the cancellation analysis reads as owning every argument position.
+    #[test]
+    #[should_panic(expected = "is used as a value")]
+    fn rejects_a_borrowing_function_named_as_a_value() {
+        // `g` returns `f` itself rather than calling it.
+        let body = node(RcExpr::Ret(var_of("f", type_funptr(vec![], make_i64_ty()))));
+        let mut target = func("f", type_funptr(vec![], make_i64_ty()), vec![], None, body.clone());
+        target.borrowed_units.insert((FullName::local("p"), vec![]));
+        let caller = func("g", type_funptr(vec![], make_i64_ty()), vec![], None, body);
+        validate_prog(vec![caller, target]);
     }
 
     /// A capture stored at a type the target does not project is caught, so a rewrite that changes


### PR DESCRIPTION
証明が示した性質のうち、**節点の性質として書けるものを `validate` の検査にする。**
`borrow_ify` と `cancel` の証明は、A21 と A24 を「Fix の関数型の値に LLVM 関数の番地を書き込むのは
3 か所だけ」「`fix` の op は capture を持つ本体にだけ在る」という**在りかの数え上げ**として置いていた。
数え上げは、op やパスが 1 つ増えるたびに人が読み直す要がある。

**その 2 つが支えている性質は 1 つである** -- **借用版の関数が値にならないこと。** `borrow_ify` は
借用版を `func.capture.is_none()` の関数についてだけ作り、原本には全パラメータ・capture 単位を所有させる
ので、`borrowed_units` が空でないのは借用版だけである。そして借用版へ回るのは `route` が `App` の callee の
名前を書き替えた呼び出しだけである。

一方 `cancel` は、間接呼び出しの呼び出し先を解決できないとき (`resolve_callee_params` が `None`)、
**全引数位置を「呼び出し先が所有する」として読む** (`rhs_consumes` の `None => true`)。借用版がそこへ
届くと、呼び出し先は借りた参照を処分しないのに呼び出し元の `Release` が相殺で消え、**参照が漏れる。**

この PR は、その性質を在りかでなく**名前の使われ方**で検査する。

## 足した項目

### [`Validator::borrows_nothing`](https://github.com/tttmmmyyyy/fixlang/blob/b6cd6d222de7f7f7a9f0af77f8b26dc97629fd16/src/rc_ir/validate.rs#L284-L299)

- **役割**: 与えられた名前がプログラムの関数のものであるとき、その関数が単位を 1 つも借りていないことを
  確かめる。借りていれば `stage` と名前と借りている単位数を挙げて `panic!` する。
- **呼ぶ側**: `Validator::use_var` (値の位置での使用) と、`check_rhs` の `RcRhs::Closure` の腕
  (クロージャの対象)。

### [`Validator::use_callee`](https://github.com/tttmmmyyyy/fixlang/blob/b6cd6d222de7f7f7a9f0af77f8b26dc97629fd16/src/rc_ir/validate.rs#L266-L275)

- **役割**: 名前が束縛かグローバルに解決することだけを確かめる。**直接呼び出しの callee は借用版でよい** --
  借用版へ回すのが `route` の仕事だからである。
- **呼ぶ側**: `check_rhs` の `RcRhs::App` の腕と、`Validator::use_var`。

## 変えた項目

### [`Validator::use_var`](https://github.com/tttmmmyyyy/fixlang/blob/b6cd6d222de7f7f7a9f0af77f8b26dc97629fd16/src/rc_ir/validate.rs#L258-L261)

- **役割**: 値の位置での名前の使用を確かめる。
- **変更**: 解決の検査を `use_callee` へ移し、そこへ `borrows_nothing` を足した。
- **目的**: `Retain`/`Release`/`Eval`/`Destructure` の変数、`Match` の scrutinee、`Var` の右辺、
  `Closure` の capture、`Llvm` の引数、`App` の引数、`Ret` の値 -- **直接呼び出しの callee 以外のすべての
  位置**が、この 1 か所で覆われる。

### `check_rhs` の `RcRhs::App` の腕

- **変更**: callee の使用を `use_callee` に、引数の使用は `use_var` のままにした。

### `check_rhs` の `RcRhs::Closure` の腕

- **変更**: 対象が借りていないことの検査を足した。`Closure` の対象は `RcVar` でなく `FuncRef` なので、
  `use_var` の経路では覆われない。

## テスト

どちらも `src/rc_ir/validate.rs` の `tests` に置いた。**検査を `if false &&` で潰すと 2 本とも赤くなる**
ことを確かめてある。

- **[`rejects_a_closure_targeting_a_borrowing_version`](https://github.com/tttmmmyyyy/fixlang/blob/b6cd6d222de7f7f7a9f0af77f8b26dc97629fd16/src/rc_ir/validate.rs#L798-L808)** -- 借用単位を持つ関数を `Closure` の対象にした
  プログラムが弾かれる。無ければ `closure stores captures` の検査だけが走って通る。
- **[`rejects_a_borrowing_function_named_as_a_value`](https://github.com/tttmmmyyyy/fixlang/blob/b6cd6d222de7f7f7a9f0af77f8b26dc97629fd16/src/rc_ir/validate.rs#L814-L821)** -- 借用単位を持つ関数の名前を `Ret` の値に置いた
  プログラムが弾かれる。無ければ「未束縛の変数」の検査だけが走って通る。

## この PR が入れなかったもの

**「Fix の関数型の値に番地を書き込むのは 3 か所だけ」という形の検査は入れていない。** 在りかの数え上げは
op が増えるたびに古くなり、検査としても「新しい在りかが増えた」ことしか言わない。上の 2 つは、
**番地がどこで書かれたかを問わず、値になった関数が借りていないことだけ**を見る。

**`InlineLLVMFixBody` を型で見張る検査も入れていない。** 一度書いて外した -- `borrow_ify` の
`func.capture.is_none()` の条件を外す変異を入れても発火せず、**発火を示せない検査になった** (`fix` の
大半は `defunctionalize_fix` が RC IR より前に畳む)。その場合も、`fix` が組むクロージャの番地が値になれば
`use_var` の側が捕まえる。

### `use_var` の差分

```diff
--- validate.rs (before)
+++ validate.rs (after)
@@ -1,10 +1,4 @@
     fn use_var(&self, name: &FullName) {
-        if !self.scope.contains(name) && !self.globals.contains(name) {
-            panic!(
-                "[RC IR validate] {}: use of unbound variable `{}` in `{}`",
-                self.stage,
-                name.to_string(),
-                self.location
-            );
-        }
+        self.use_callee(name);
+        self.borrows_nothing(name, "is used as a value");
     }
```
