### PR TITLE
pr-message: 本文に書いた例を項目の doc コメントにも置く

### DIFF
--- a/.claude/skills/pr-message/SKILL.md
+++ b/.claude/skills/pr-message/SKILL.md
@@ -104,6 +104,8 @@ The result goes in a fenced `diff` block, under the prose for that item.
 
 **An added item carries no diff**, only its link: every line of it is new, so the diff would repeat the file the link already opens.
 
+**An example written here belongs in the code as well.** The `devdoc` skill's *An example of input and output* applies to these entries, so an entry often carries one input and the output it produces. That pair was judged worth a reader's attention — and the reader of the pull request meets it once, where the reader of the code meets the item on every reading. So put it in the item's doc comment too, under `# Examples`, in the shape the `code-review` skill's `comment-style` aspect gives. Writing the example is the moment to check that the code has one; nothing later looks back at the item.
+
 ## Where the coverage goes
 
 A pull request body is capped at 65,536 characters, and the per-item coverage — prose, links and diffs, one entry per item — is what grows fastest as a change touches more code. Growing it inside the body also costs the reader the argument: the case for the change stops being readable in one pass once the entries outweigh it.


### PR DESCRIPTION
`pr-message` スキルに 1 段落を足す。

## 何が起きたか

#578 (`U8` リテラルにダブルクォートを書けるようにする) で、追加した関数 `take_hex_number` の項目に、pull request 本文が入力と出力の組を書いた。

```
take_hex_number(&mut "7f".chars(), 2)    ->  127
take_hex_number(&mut "2764".chars(), 4)  ->  10084
```

同じ組が、その関数の doc コメントには無かった。作者の指摘で気付いた。

## 規則は在ったが、つながりが無かった

`code-review` スキルの `comment-style` アスペクトは、doc コメントに `# Examples` を書く条件を持っている。「エンコーディング、生成した名前、書式付き文字列は、結果の形が関数の中身そのものなので、例が閉じる隙間になる」— 16 進の桁を読んで数を返す関数はこれに当たる。つまり規則の抜けではなく、**その実行が取りこぼした**。

取りこぼしても後から気付く道が無い。`code-review` は pull request 本文を書く前に終わっており、本文を書く段には、コードへ戻って見比べさせるものがどこにも無い。`devdoc` の *An example of input and output* は本文の側の例だけを述べ、`comment-style` の `# Examples` はコードの側だけを述べていて、2 つがつながっていない。

## 足すもの

`pr-message` の「Every item the diff touches」の末尾、`An added item carries no diff` の直後に 1 段落。例を書くその瞬間 — 「この組は読み手の注意に値する」と判断した瞬間 — に、コードの側にも在るかを確かめさせる。本文の読み手は 1 度しか会わないが、コードの読み手はその項目に読むたび会う、というのが理由である。

置き場所を `comment-style` でなく `pr-message` にしたのは、`# Examples` の書き方の規則が `comment-style` に既に在るからで、同じ規則を 2 か所に書くと片方だけ直る。ここからは形を `comment-style` に譲って参照している。

## 検証

このスキルの変更が実際に効いたかは、次に `pr-message` を使う pull request で分かる。#578 の側では、指摘を受けて doc コメントに `# Examples` を足した (`a70b85c7`)。
