### PR TITLE
cancel の走査の不変条件を検査にする (P16・P17・P18)

### DIFF
--- a/src/build/build_object_files.rs
+++ b/src/build/build_object_files.rs
@@ -134,7 +134,7 @@ fn optimize_rc_program(
     if config.enable_borrow_optimization() {
         prog = borrow_ify(&prog, type_env, config.develop_mode);
         validate(&prog, "after borrow_ify");
-        prog = cancel(&prog, type_env);
+        prog = cancel(&prog, type_env, config.develop_mode);
         validate(&prog, "after cancel");
         prune(&mut prog, "after dce following cancel");
         prog = unique_check_elim::specialize(&prog, type_env);

--- a/src/rc_ir/borrow.rs
+++ b/src/rc_ir/borrow.rs
@@ -1337,6 +1337,73 @@ fn un_bump(pending: &mut PendingRetains, un_bumped: &References) -> UnBump {
     UnBump::InBracket(retain)
 }
 
+/// What `un_bump` did to `pending`, read back from its answer (P17).
+///
+/// The answer is what the walk acts on -- `InBracket` records the release as one that closes its
+/// retain, and the other two mark retains needed -- so an answer that does not describe what the
+/// call did to `pending` would pair a release with a retain it does not close.
+// PROOF: P17 (dev-docs/proof/rc_ir/borrow-cancel)
+fn check_un_bump(
+    before: &PendingRetains,
+    after: &PendingRetains,
+    un_bumped: &References,
+    answer: &UnBump,
+) {
+    let unchanged = |expected: &PendingRetains| {
+        expected.len() == after.len()
+            && expected
+                .iter()
+                .zip(after)
+                .all(|(a, b)| a.node == b.node && a.outstanding == b.outstanding)
+    };
+    let innermost = before
+        .iter()
+        .rposition(|retain| retain.outstanding.shares_an_object(un_bumped));
+    match answer {
+        UnBump::NoBracket => {
+            assert!(
+                innermost.is_none(),
+                "un_bump answered NoBracket where a pending retain shares an object with the release"
+            );
+            assert!(
+                unchanged(before),
+                "un_bump answered NoBracket and changed the pending retains"
+            );
+        }
+        UnBump::OutsideBracket => {
+            let at = innermost.expect("un_bump answered OutsideBracket with no bracket to be outside of");
+            assert!(
+                !before[at].outstanding.covers(un_bumped),
+                "un_bump answered OutsideBracket where the innermost bracket covers the release"
+            );
+            assert!(
+                unchanged(before),
+                "un_bump answered OutsideBracket and changed the pending retains"
+            );
+        }
+        UnBump::InBracket(retain) => {
+            let at = innermost.expect("un_bump answered InBracket with no pending retain to close");
+            assert_eq!(
+                before[at].node, *retain,
+                "un_bump answered InBracket naming a retain that is not the innermost bracket"
+            );
+            assert!(
+                before[at].outstanding.covers(un_bumped),
+                "un_bump answered InBracket where the innermost bracket does not cover the release"
+            );
+            let mut expected = before.clone();
+            expected[at].outstanding.subtract(un_bumped);
+            if expected[at].outstanding.is_empty() {
+                expected.remove(at);
+            }
+            assert!(
+                unchanged(&expected),
+                "un_bump answered InBracket and left the pending retains in another state"
+            );
+        }
+    }
+}
+
 /// A node's identity within one tree: the address of its expression, stable while the tree is
 /// borrowed. Nodes to drop are recorded under this identity and recognized by it again in a later
 /// walk over the same borrowed tree.
@@ -1355,7 +1422,7 @@ fn node_id(node: &RcExprNode) -> NodeId {
 /// the uniqueness analysis. Each call's consume sites are decided by the parameter/capture units the
 /// functions own — the complement of their `RcFunc::borrowed_units`, set by borrow-ification.
 // PROOF: D/A, P1, P2, P2a, P7c, P7f, P8, P9, P10, P11, P12, P13, P14, P14a, P14b, P15, P16, P17, P18, P18a, P18b, P18c, P19, P20, P21, P22, P23, P24, P26, P27, P29, P30, P31, A19, T (dev-docs/proof/rc_ir/borrow-cancel)
-pub(crate) fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
+pub(crate) fn cancel(prog: &RcProgram, type_env: &TypeEnv, develop_mode: bool) -> RcProgram {
     let owned_units = all_owned_units(prog, type_env);
     let cancel_body = |vars: &VarTable, body: &RcExprNode| {
         let mut analysis = CancelAnalysis {
@@ -1366,6 +1433,7 @@ pub(crate) fn cancel(prog: &RcProgram, type_env: &TypeEnv) -> RcProgram {
             needed_retains: Set::default(),
             un_bump_releases: Map::default(),
             all_retains: vec![],
+            develop_mode,
         };
         analysis.walk(body, PendingRetains::default(), true);
         drop_nodes(body, &analysis.cancelled())
@@ -1421,6 +1489,8 @@ struct CancelAnalysis<'a> {
     un_bump_releases: Map<NodeId, Vec<NodeId>>,
     /// Every retain the walk saw, so the cancellable retains are those never marked needed.
     all_retains: Vec<NodeId>,
+    /// Whether to check the walk's own invariants as it goes.
+    develop_mode: bool,
 }
 
 // PROOF: P2a, P15, P16, P17, P18, P18c, P19, P20, P21, P22, P23, P24 (dev-docs/proof/rc_ir/borrow-cancel)
@@ -1467,6 +1537,7 @@ impl<'a> CancelAnalysis<'a> {
         mut pending: PendingRetains,
         returns_from_func: bool,
     ) -> PendingRetains {
+        self.check_pending(&pending);
         match node.expr.as_ref() {
             RcExpr::Retain(v, path, _, k) => {
                 let retain = node_id(node);
@@ -1487,7 +1558,12 @@ impl<'a> CancelAnalysis<'a> {
                 let others = self.other_objects(v, path);
                 self.consume_objects(&mut pending, &others);
                 let un_bumped = self.acted_references(v, path);
-                match un_bump(&mut pending, &un_bumped) {
+                let before = self.develop_mode.then(|| pending.clone());
+                let answer = un_bump(&mut pending, &un_bumped);
+                if let Some(before) = before {
+                    check_un_bump(&before, &pending, &un_bumped, &answer);
+                }
+                match answer {
                     UnBump::InBracket(retain) => self
                         .un_bump_releases
                         .entry(retain)
@@ -1655,7 +1731,7 @@ impl<'a> CancelAnalysis<'a> {
         }
         // Keep the retains the arms agree on, in the pre-match order so release pairing stays
         // innermost-first.
-        pending_in
+        let merged: PendingRetains = pending_in
             .iter()
             .filter_map(|retain| {
                 uniform.get(&retain.node).map(|outstanding| PendingRetain {
@@ -1663,7 +1739,80 @@ impl<'a> CancelAnalysis<'a> {
                     outstanding: outstanding.clone(),
                 })
             })
-            .collect()
+            .collect();
+        self.check_merge(pending_in, arm_exits, &merged);
+        merged
+    }
+
+    /// The walk's state at a node's entry: no pending retain is fully un-bumped, and no retain is
+    /// pending twice.
+    ///
+    /// A retain left with nothing outstanding would be cancelled by the next release that reaches
+    /// any object it acts on, whatever that release disposes; a retain pending twice would be
+    /// un-bumped once and left pending, so the release that closed it would be deleted with a retain
+    /// that is still bumped.
+    // PROOF: P16 (dev-docs/proof/rc_ir/borrow-cancel)
+    fn check_pending(&self, pending: &PendingRetains) {
+        if !self.develop_mode {
+            return;
+        }
+        let mut seen = Set::default();
+        for retain in pending {
+            assert!(
+                !retain.outstanding.is_empty(),
+                "a pending retain has nothing outstanding"
+            );
+            assert!(seen.insert(retain.node), "one retain is pending twice");
+        }
+    }
+
+    /// What `merge` returns: a subsequence of what entered the match, holding the retains every arm
+    /// exits with at the same outstanding, and every other retain an arm exits with is needed.
+    ///
+    /// A retain kept that an arm left differently bumped would be cancelled against the releases of
+    /// one path while another path leaves it bearing a reference; a retain dropped from both the
+    /// result and `needed_retains` would be cancellable while no release closed it.
+    // PROOF: P18 (dev-docs/proof/rc_ir/borrow-cancel)
+    fn check_merge(
+        &self,
+        pending_in: &PendingRetains,
+        arm_exits: &[PendingRetains],
+        merged: &PendingRetains,
+    ) {
+        if !self.develop_mode {
+            return;
+        }
+        let mut previous: Option<usize> = None;
+        for retain in merged {
+            let at = pending_in
+                .iter()
+                .position(|entered| entered.node == retain.node)
+                .expect("merge kept a retain that did not enter the match");
+            assert!(
+                previous.is_none_or(|before| before < at),
+                "merge reordered the pending retains"
+            );
+            previous = Some(at);
+            for exit in arm_exits {
+                let at_exit = exit
+                    .iter()
+                    .find(|left| left.node == retain.node)
+                    .expect("merge kept a retain an arm fully un-bumped");
+                assert!(
+                    at_exit.outstanding == retain.outstanding,
+                    "merge kept a retain the arms leave differently bumped"
+                );
+            }
+        }
+        let kept: Set<NodeId> = merged.iter().map(|retain| retain.node).collect();
+        for exit in arm_exits {
+            for retain in exit {
+                assert!(
+                    kept.contains(&retain.node) || self.needed_retains.contains(&retain.node),
+                    "merge dropped a retain an arm exits with without marking it needed"
+                );
+            }
+        }
     }
 
     /// The nodes to delete: every cancellable retain (one never marked needed and un-bumped by at


### PR DESCRIPTION
`cancel` の走査は、削除する retain/release の組を**手で運ぶ状態から決める** -- `pending` の各要素と、その
要素がまだ bump したままにしている参照 (`outstanding`) である。証明はこの状態について 3 つの命題を持つ。
それをそのまま検査にする。

## 足した項目

### [`check_pending`](https://github.com/tttmmmyyyy/fixlang/blob/d39fb2d6515856eb3a414e17750a1e198400d02d/src/rc_ir/borrow.rs#L1755-L1767) (P16)

- **役割**: 節点の入口で `pending` を見て、(b) どの要素も `outstanding` が空でないこと、(c) 1 つの retain が
  2 度 pending に無いことを確かめる。
- **なぜ**: 何も outstanding が無い retain は、**それが acts on するどのオブジェクトに触れた release でも**
  相殺されてしまう -- その release が何を処分するかに関わらず。2 度 pending に在る retain は 1 度だけ
  un-bump されて残るので、閉じたはずの release が、まだ bump したままの retain と一緒に消える。
- **呼ぶ側**: `CancelAnalysis::walk_inner` の入口。

### [`check_merge`](https://github.com/tttmmmyyyy/fixlang/blob/d39fb2d6515856eb3a414e17750a1e198400d02d/src/rc_ir/borrow.rs#L1776-L1816) (P18)

- **役割**: `merge` の返り値が、`pending_in` の**部分列**であり、各要素が**全アームの出口に同じ
  `outstanding` で現れる**ものだけであること。加えて、どれかのアームの出口に現れて返り値に無い retain は
  `needed_retains` に入っていること。
- **なぜ**: アームによって bump の残りが違う retain を残すと、一方の路の release と相殺されるのに他方の路
  ではまだ参照を担っている。返り値にも `needed_retains` にも入らない retain は、閉じた release が 1 つも
  無いまま相殺の対象になる。
- **呼ぶ側**: `CancelAnalysis::merge` の末尾。

### [`check_un_bump`](https://github.com/tttmmmyyyy/fixlang/blob/d39fb2d6515856eb3a414e17750a1e198400d02d/src/rc_ir/borrow.rs#L1346-L1405) (P17)

- **役割**: `un_bump` の**答えが、その呼び出しが `pending` に何をしたかを述べている**ことを、前後を
  突き合わせて確かめる。`NoBracket` なら共有する要素が無く `pending` は不変、`OutsideBracket` なら最内の
  要素が release を `covers` せず `pending` は不変、`InBracket(t)` なら `t` が最内の要素であり、その
  `outstanding` から release の分が引かれ、空になれば取り除かれ、ほかの要素は同じ順で同じである。
- **なぜ**: 走査が読むのは答えの側である -- `InBracket` はその release を「その retain を閉じたもの」
  として記録し、他の 2 つは retain を needed にする。答えが実際の変化と食い違えば、閉じていない retain と
  release が対にされる。
- **呼ぶ側**: `CancelAnalysis::walk_inner` の `Release` の腕。

## 変えた項目

### [`cancel`](https://github.com/tttmmmyyyy/fixlang/blob/d39fb2d6515856eb3a414e17750a1e198400d02d/src/rc_ir/borrow.rs#L1425-L1471)

- **役割**: 相殺できる retain/release を削除したプログラムを返す。
- **変更**: `develop_mode: bool` を引数に取り、`CancelAnalysis` へ渡す。
- **目的**: 検査を開発モードだけで走らせる。`borrow_ify` が既に同じ形で受け取っている。

### `CancelAnalysis`

- **変更**: `develop_mode` の欄を足した。

### `optimize_rc_program`

- **変更**: `cancel(&prog, type_env)` を `cancel(&prog, type_env, config.develop_mode)` にした。

## 発火の確認

**5 つの変異で 4 つの検査が鳴ることを確かめた。**

| 変異 | 鳴った検査 |
|---|---|
| `un_bump` が空になった要素を取り除かない | `un_bump answered InBracket and left the pending retains in another state` |
| `Retain` を `pending` に 2 度積む | `one retain is pending twice` |
| P17 の検査を外し、空の要素を残す | `a pending retain has nothing outstanding` |
| `merge` が一様でない retain も残す | `merge kept a retain an arm fully un-bumped` |
| **`un_bump` が `covers` を見ない** | **鳴らなかった** |

**最後の 1 つは、`OutsideBracket` の枝が `tests::test_basic` の 490 件で一度も踏まれていないことを意味する。**
コーパス全体でどうかは測っていない (測ろうとしたが実行が止まった)。P17 のうち `InBracket` と `NoBracket` の
枝は上のとおり発火する。

フルスイートは release で **1,665 + 182 件すべて緑**、偽陽性は 0 である。
