### PR TITLE
レビュー清掃 (#585): リテラルの範囲の検査が読む群に doc を書く

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -540,12 +540,13 @@ pub fn floating_types() -> Vec<Arc<TypeNode>> {
     vec![make_f32_ty(), make_f64_ty()]
 }
 
-// Get the TyCon of String type.
+/// The `TyCon` of `Std::String`.
 pub fn make_string_tycon() -> Arc<TyCon> {
     tycon(FullName::from_strs(&[STD_NAME], STRING_NAME))
 }
 
-// Get integral types from its name.
+/// The integral type of that name, and `None` where the name is not one of the eight integral
+/// types (`I8` to `I64`, `U8` to `U64`).
 pub fn make_integral_ty(name: &str) -> Option<Arc<TypeNode>> {
     if name == I8_NAME {
         Some(make_i8_ty())
@@ -568,6 +569,12 @@ pub fn make_integral_ty(name: &str) -> Option<Arc<TypeNode>> {
     }
 }
 
+/// The smallest and the largest value the integral type of that name holds.
+///
+/// Panics where the name is not one of the eight integral types.
+///
+/// # Examples
+/// `integral_ty_range("I8")` is `(-128, 127)`, and `integral_ty_range("U8")` is `(0, 255)`.
 pub fn integral_ty_range(name: &str) -> (BigInt, BigInt) {
     if name == I8_NAME {
         (BigInt::from(i8::MIN), BigInt::from(i8::MAX))
@@ -609,7 +616,7 @@ pub fn integral_ty_range_with_bit_patterns(name: &str) -> (BigInt, BigInt) {
     (ty_min, width_max)
 }
 
-// Get floating types from its name.
+/// The floating point type of that name, and `None` where the name is neither `F32` nor `F64`.
 pub fn make_floating_ty(name: &str) -> Option<Arc<TypeNode>> {
     if name == F32_NAME {
         Some(make_f32_ty())
@@ -620,8 +627,12 @@ pub fn make_floating_ty(name: &str) -> Option<Arc<TypeNode>> {
     }
 }
 
-// Get numeric types from its name.
-// Returns (type, is_float)
+/// The numeric type of that name, and whether it is a floating point type.
+///
+/// # Returns
+/// The type is `None` where the name is not a numeric type; the flag then says whether the name
+/// would have been a floating point one, so a caller comparing it against the form of a literal
+/// reads `false`.
 pub fn make_numeric_ty(name: &str) -> (Option<Arc<TypeNode>>, bool) {
     let int_opt = make_integral_ty(name);
     if int_opt.is_some() {

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -2752,7 +2752,13 @@ fn parse_expr_number_lit(
     }
 }
 
-// Parse integer literal string such as "-5", "-0xff" or "123e4", and return its value and radix.
+/// Read an integer literal, written in any of the four bases with an optional sign, and return
+/// its value and the base it is written in. The `e` of a decimal literal multiplies it by that
+/// power of ten, and a negative exponent leaves no integer, so it gives `None`.
+///
+/// # Examples
+/// `parse_integer_literal_string("-0xff")` is `Some((-255, 16))`, and `"123e4"` is
+/// `Some((1230000, 10))`.
 fn parse_integer_literal_string(s: &str) -> Option<(BigInt, usize)> {
     if s.len() == 0 {
         return None;
@@ -3275,6 +3281,11 @@ fn parse_import_statements(
     Ok(import_stmts)
 }
 
+/// The prose a parse error uses for a grammar rule it expected. A rule the table leaves out is
+/// written as its own name, which the reader of a Fix program has no way to look up.
+///
+/// The words of the rules expected at one position are joined with ` or `, so each reads as
+/// one alternative of `Expected ...`.
 fn rule_to_string(r: &Rule) -> String {
     fn join_by_or(tokens: &[&str]) -> String {
         tokens

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -6074,82 +6074,34 @@ pub fn test_bit_pattern_literal_below_the_types_minimum_or_past_its_width_is_rep
     );
 }
 
+/// Verifies that an integer literal naming a value its type cannot hold is reported, at each of the
+/// two ends the rules have: a decimal or octal literal stops at the maximum of its type, and a
+/// hexadecimal or binary one at the largest value the type's width holds.
 #[test]
-pub fn test_integer_string_literal_error0() {
-    let source = r##"
+pub fn test_integer_literal_past_what_its_type_holds_is_reported() {
+    // The literal, the type it is written with, and the report it draws. A literal written without
+    // a suffix is an `I64`.
+    let cases = [
+        ("0xffffffffffffffffff", "", "does not fit in the width"),
+        ("0xffffffffffffffffff", "_U64", "does not fit in the width"),
+        ("256", "_I8", "out of range"),
+        ("256", "_U8", "out of range"),
+        ("0o377", "_I8", "out of range"),
+    ];
+    for (literal, ty_suffix, report) in cases {
+        let source = format!(
+            r#"
     module Main;
-        
     main : IO ();
     main = (
-        assert_eq(|_|"", 0xffffffffffffffffff, -1);; // out of range of `I64`
+        assert_eq(|_|"", {}{}, 0{});;
         pure()
     );
-    "##;
-    test_source_fail(
-        &source,
-        Configuration::develop_mode(),
-        "does not fit in the width",
-    );
-}
-
-#[test]
-pub fn test_integer_string_literal_error1() {
-    let source = r##"
-    module Main;
-        
-    main : IO ();
-    main = (
-        assert_eq(|_|"", 0xffffffffffffffffff_U64, -1);; // out of range of `U64`
-        pure()
-    );
-    "##;
-    test_source_fail(
-        &source,
-        Configuration::develop_mode(),
-        "does not fit in the width",
-    );
-}
-
-#[test]
-pub fn test_integer_string_literal_error2() {
-    let source = r##"
-    module Main;
-        
-    main : IO ();
-    main = (
-        assert_eq(|_|"", 256_I8, -1);; // out of range of `I8`
-        pure()
-    );
-    "##;
-    test_source_fail(&source, Configuration::develop_mode(), "out of range");
-}
-
-#[test]
-pub fn test_integer_string_literal_error3() {
-    let source = r##"
-    module Main;
-        
-    main : IO ();
-    main = (
-        assert_eq(|_|"", 256_U8, -1);; // out of range of `I8`
-        pure()
-    );
-    "##;
-    test_source_fail(&source, Configuration::develop_mode(), "out of range");
-}
-
-#[test]
-pub fn test_integer_string_literal_error4() {
-    let source = r##"
-    module Main;
-        
-    main : IO ();
-    main = (
-        assert_eq(|_|"", 0o377_I8, -1);; // out of range of `I8`
-        pure()
-    );
-    "##;
-    test_source_fail(&source, Configuration::develop_mode(), "out of range");
+    "#,
+            literal, ty_suffix, ty_suffix
+        );
+        test_source_fail(&source, Configuration::develop_mode(), report);
+    }
 }
 
 /// Verifies that a decimal literal below the minimum of its type is reported, as one above its


### PR DESCRIPTION
Refs #573

#585 (負のリテラルを、その型の範囲で検査する) のレビューが、差分の外に見つけた掃除をまとめたもの。#585 の差分に混ざらないよう別のブランチにしてあり、いま #585 は main に入っているので base は `main` である。

振る舞いは変わらない。`cargo test --release` は 1,673 + 183 本すべて通る (テストの本数が減っているのは、下に述べる 5 本を 1 本にまとめたため)。

## 1. リテラルの範囲の検査が読む群に doc を書く

#585 が足した `integral_ty_range_with_bit_patterns` は `integral_ty_range` を土台にしているが、その `integral_ty_range` 自身に doc コメントが無かった。隣り合う 4 つも、名前を言い換えるだけの `//` を持っていた。

- [`integral_ty_range`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/fixstd/builtin.rs#L578-L598) — その名前の整数型が保持する最小と最大。整数型でない名前では panic すること、`("I8")` が `(-128, 127)` であることを書いた。
- [`make_integral_ty`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/fixstd/builtin.rs#L550-L570) — 8 つの整数型のどれでもない名前で `None`。
- [`make_floating_ty`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/fixstd/builtin.rs#L620-L628) — `F32` でも `F64` でもない名前で `None`。
- [`make_numeric_ty`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/fixstd/builtin.rs#L636-L644) — 返り値の組の 2 つ目が読み取りにくかった。型が `None` のときも旗は「その名前が浮動小数の型だったか」を答えるので、リテラルの形と突き合わせる呼び手 (`parse_expr_number_lit`) はそこで `false` を読む。その意味を `# Returns` に書いた。
- [`make_string_tycon`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/fixstd/builtin.rs#L544-L546) — `//` を `///` へ。

## 2. パーサの 2 つに doc を書く

- [`parse_integer_literal_string`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/parse/parser.rs#L2762-L2815) — `//` の 1 行を `///` に上げ、`e` の扱い (10 進の指数で掛け、負の指数は整数を与えないので `None`) と例を足した。
- [`rule_to_string`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/parse/parser.rs#L3289-L3332) — 何を返すかと、**表に無い規則はその規則名がそのままユーザに出る**こと (Fix のプログラムを読む人には引きようがない)、そして 1 つの位置で期待される複数の規則の語が ` or ` で連結されることを書いた。#585 が `string_char` の項を足したのはこの経路である。

## 3. 番号で並んでいたテストを 1 本にする

`test_integer_string_literal_error0` から `error4` までの 5 本が、同じ雛形のプログラムを写して 1 例ずつ検査していた。名前は何を押さえるかを述べておらず、`error3` のコメントは `I8` と書きながら `256_U8` を見ていた。

[`test_integer_literal_past_what_its_type_holds_is_reported`](https://github.com/tttmmmyyyy/fixlang/blob/ce4677cffa123b21e1ef4b33105375e605410326/src/tests/test_basic.rs#L6081-L6105) が 5 例を表で持つ。並べると、規則の 2 つの端がそのまま読める。

```
("0xffffffffffffffffff", "",     "does not fit in the width"),
("0xffffffffffffffffff", "_U64", "does not fit in the width"),
("256",                  "_I8",  "out of range"),
("256",                  "_U8",  "out of range"),
("0o377",                "_I8",  "out of range"),
```

範囲の検査を無効にする変異 (`if !(min <= val && val <= max)` を `if false` に) で、このテストは赤くなる。

## 残した所見

レビューが挙げたもののうち、振る舞いに関わるのでこの掃除に入れなかったもの。

- **`parse_integer_literal_string` が基数を引き直している。** 文法は基数を規則の名前で持っている (`number_lit_body_hex` / `_oct` / `_bin` / `_dec`) のに、パーサはその pair を捨てて `as_str()` を取り、接頭辞の照合でほぼ同形の分岐 6 本を書いている。`parse_expr_number_lit` が `raw.contains(".")` で浮動小数かを引き直しているのも同じ形で、内側の規則を読めば両方消える。
- **`Span::empty()` は `start = usize::MAX`** なので、`part` / `to_head_character` / `after_head_character` はその上で溢れる。今日そこへ至る経路は無い (#585 が `part` に入れた assert が発火する側)。
- **`rule_to_string` の総括アーム**が、表に無い規則名をそのままユーザに出す経路は #542 が主題にしている。この PR はその存在を doc に書くだけで、塞いではいない。
