### PR TITLE
レビューの所見のうち、スイートが判定できる 4 件を直す

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -628,44 +628,146 @@ pub fn make_floating_ty(name: &str) -> Option<Arc<TypeNode>> {
 }
 
 /// The value the floating point literal `raw` takes when it is written with the type of that
-/// name, read at the width of that type and widened to `f64`.
+/// name, read at the width of that type and widened to `f64`. Gives the report to make where the
+/// type holds no finite value that large.
 ///
 /// A decimal rounded to `F64` and then to `F32` can land one step away from the same decimal
 /// rounded to `F32`, so an `F32` literal is read as an `f32`. Widening it back to `f64` is exact,
 /// so the value carries the `F32` literal without loss.
 ///
-/// A literal larger than the widest finite value of its type reads as an infinity.
-///
-/// Panics where `name` is neither `F32` nor `F64`, or where `raw` does not read as a floating
-/// point number.
+/// Panics where `name` is neither `F32` nor `F64`.
 ///
 /// # Examples
-/// `floating_literal_value(F32_NAME, "0.1")` is `0.10000000149011612`, and
-/// `floating_literal_value(F64_NAME, "0.1")` is `0.1`.
-pub fn floating_literal_value(name: &str, raw: &str) -> f64 {
-    if name == F32_NAME {
+/// `floating_literal_value(F32_NAME, "0.1")` is `Ok(0.10000000149011612)`, and
+/// `floating_literal_value(F32_NAME, "3.5e38")` is an `Err`.
+pub fn floating_literal_value(name: &str, raw: &str) -> Result<f64, String> {
+    // `number_lit_body_dec` admits digits, one decimal point and an optional exponent, which read
+    // as a floating point number at either width.
+    let val = if name == F32_NAME {
         raw.parse::<f32>().unwrap() as f64
     } else if name == F64_NAME {
         raw.parse::<f64>().unwrap()
     } else {
         panic!("Not a floating point type: {}", name);
+    };
+    // A literal larger than the widest finite value of its type rounds to an infinity. Every value
+    // a literal spells is finite, so such a literal is out of range.
+    if !val.is_finite() {
+        return Err(format!(
+            "The value of a floating point literal `{}` is out of range of `{}`.",
+            raw, name
+        ));
     }
+    Ok(val)
+}
+
+/// The value the integer literal `raw` takes when it is written with the integral type of that
+/// name, as the bits of that type widened to a `u64`. Gives the report to make where `raw` names
+/// no integer, or names one the type does not hold.
+///
+/// Panics where `name` is not an integral type.
+///
+/// # Examples
+/// `integral_literal_value(I8_NAME, "12")` is `Ok(12)`, and `integral_literal_value(I8_NAME,
+/// "256")` is an `Err`.
+pub fn integral_literal_value(name: &str, raw: &str) -> Result<u64, String> {
+    let Some((val, radix)) = parse_integer_literal_string(raw) else {
+        return Err(format!(
+            "A literal string `{}` cannot be parsed as an integer.",
+            raw
+        ));
+    };
+    // A hexadecimal or binary literal writes a bit pattern, so it reaches the largest value the
+    // width of its type holds. At the low end every literal stops at the minimum of its type.
+    let writes_a_bit_pattern = radix == 16 || radix == 2;
+    let (min, max) = if writes_a_bit_pattern {
+        integral_ty_range_with_bit_patterns(name)
+    } else {
+        integral_ty_range(name)
+    };
+    if !(min <= val && val <= max) {
+        let reason = if writes_a_bit_pattern && val > max {
+            "does not fit in the width of"
+        } else {
+            "is out of range of"
+        };
+        return Err(format!(
+            "The value of an integer literal `{}` {} `{}`.",
+            raw, reason, name
+        ));
+    }
+    Ok(i128::try_from(&val).unwrap() as u64)
+}
+
+/// Read an integer literal, written in any of the four bases with an optional sign, and return
+/// its value and the base it is written in. The `e` of a decimal literal multiplies it by that
+/// power of ten, and a negative exponent leaves no integer, so it gives `None`.
+///
+/// # Examples
+/// `parse_integer_literal_string("-0xff")` is `Some((-255, 16))`, and `"123e4"` is
+/// `Some((1230000, 10))`.
+fn parse_integer_literal_string(raw: &str) -> Option<(BigInt, usize)> {
+    if raw.len() == 0 {
+        return None;
+    }
+    for (prefix, radix) in [("0x", 16), ("0o", 8), ("0b", 2)] {
+        if let Some((digits, is_negative)) = strip_sign_and_radix_prefix(raw, prefix) {
+            let val = BigInt::parse_bytes(digits.as_bytes(), radix as u32)?;
+            return Some((if is_negative { -val } else { val }, radix));
+        }
+    }
+    let num_and_exp = raw.split('e').collect::<Vec<_>>();
+    if num_and_exp.len() > 2 {
+        return None;
+    }
+    if num_and_exp.len() == 1 {
+        // 'e' is not contained.
+        return BigInt::parse_bytes(raw.as_bytes(), 10).map(|x| (x, 10));
+    }
+    assert_eq!(num_and_exp.len(), 2);
+    let num = BigInt::parse_bytes(num_and_exp[0].as_bytes(), 10)?;
+    let exp = BigInt::parse_bytes(num_and_exp[1].as_bytes(), 10)?;
+    if exp < BigInt::from(0 as i32) {
+        // Negative exponent is not allowed in integral literal.
+        return None;
+    }
+    // Return num * 10^exp.
+    let mut val = num;
+    let mut i = BigInt::from(0);
+    while i < exp {
+        val *= 10;
+        i += 1;
+    }
+    Some((val, 10))
+}
+
+/// The digits `raw` writes behind `prefix`, which a minus sign may precede, and whether that sign
+/// is there. Gives `None` where `raw` carries another prefix.
+///
+/// # Examples
+/// `strip_sign_and_radix_prefix("-0xff", "0x")` is `Some(("ff", true))`, and
+/// `strip_sign_and_radix_prefix("12", "0x")` is `None`.
+fn strip_sign_and_radix_prefix<'a>(raw: &'a str, prefix: &str) -> Option<(&'a str, bool)> {
+    if let Some(digits) = raw.strip_prefix(prefix) {
+        return Some((digits, false));
+    }
+    raw.strip_prefix('-')
+        .and_then(|after_sign| after_sign.strip_prefix(prefix))
+        .map(|digits| (digits, true))
 }
 
 /// The numeric type of that name, and whether it is a floating point type.
 ///
-/// # Returns
-/// The type is `None` where the name is not a numeric type; the flag then says whether the name
-/// would have been a floating point one, so a caller comparing it against the form of a literal
-/// reads `false`.
-pub fn make_numeric_ty(name: &str) -> (Option<Arc<TypeNode>>, bool) {
-    let integral_ty = make_integral_ty(name);
-    if integral_ty.is_some() {
+/// Panics where the name is not one of the eight integral types or the two floating point ones.
+pub fn make_numeric_ty(name: &str) -> (Arc<TypeNode>, bool) {
+    if let Some(integral_ty) = make_integral_ty(name) {
         return (integral_ty, false);
     }
     let floating_ty = make_floating_ty(name);
-    assert!(floating_ty.is_some(), "Not a numeric type: {}", name);
-    (floating_ty, true)
+    match floating_ty {
+        Some(floating_ty) => (floating_ty, true),
+        None => panic!("Not a numeric type: {}", name),
+    }
 }
 
 /// The type `Std::#DynamicObject`, the boxed object a closure holds its captured values in.

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -39,19 +39,17 @@ use crate::constants::{
 use crate::error::Errors;
 use crate::fixstd::builtin::{
     expr_bool_lit, expr_float_lit, expr_int_lit, expr_nullptr_lit, floating_literal_value,
-    integral_ty_range, integral_ty_range_with_bit_patterns, make_f64_ty, make_i64_ty,
-    make_io_tycon, make_numeric_ty, make_string_lit, make_tuple_name_abs, make_u8_ty,
-    ADD_TRAIT_ADD_NAME, ADD_TRAIT_NAME, DIVIDE_TRAIT_DIVIDE_NAME, DIVIDE_TRAIT_NAME,
-    EQ_TRAIT_EQ_NAME, EQ_TRAIT_NAME, LESS_THAN_OR_EQUAL_TO_TRAIT_NAME,
-    LESS_THAN_OR_EQUAL_TO_TRAIT_OP_NAME, LESS_THAN_TRAIT_LT_NAME, LESS_THAN_TRAIT_NAME,
-    MULTIPLY_TRAIT_MULTIPLY_NAME, MULTIPLY_TRAIT_NAME, NEGATE_TRAIT_NAME, NEGATE_TRAIT_NEGATE_NAME,
-    NOT_TRAIT_NAME, NOT_TRAIT_OP_NAME, REMAINDER_TRAIT_NAME, REMAINDER_TRAIT_REMAINDER_NAME,
-    SUBTRACT_TRAIT_NAME, SUBTRACT_TRAIT_SUBTRACT_NAME,
+    integral_literal_value, make_f64_ty, make_i64_ty, make_io_tycon, make_numeric_ty,
+    make_string_lit, make_tuple_name_abs, make_u8_ty, ADD_TRAIT_ADD_NAME, ADD_TRAIT_NAME,
+    DIVIDE_TRAIT_DIVIDE_NAME, DIVIDE_TRAIT_NAME, EQ_TRAIT_EQ_NAME, EQ_TRAIT_NAME,
+    LESS_THAN_OR_EQUAL_TO_TRAIT_NAME, LESS_THAN_OR_EQUAL_TO_TRAIT_OP_NAME, LESS_THAN_TRAIT_LT_NAME,
+    LESS_THAN_TRAIT_NAME, MULTIPLY_TRAIT_MULTIPLY_NAME, MULTIPLY_TRAIT_NAME, NEGATE_TRAIT_NAME,
+    NEGATE_TRAIT_NEGATE_NAME, NOT_TRAIT_NAME, NOT_TRAIT_OP_NAME, REMAINDER_TRAIT_NAME,
+    REMAINDER_TRAIT_REMAINDER_NAME, SUBTRACT_TRAIT_NAME, SUBTRACT_TRAIT_SUBTRACT_NAME,
 };
 use crate::misc::{make_map, save_temporary_source, to_absolute_path, Map};
 use crate::parse::sourcefile::{SourceFile, Span};
 use either::Either;
-use num_bigint::BigInt;
 use pest::error::{Error, ErrorVariant, InputLocation};
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
@@ -1123,7 +1121,7 @@ fn parse_export_statement(pair: Pair<Rule>, ctx: &mut ParseContext) -> ExportSta
     let fix_value_name = relative_path.join_under(&ctx.namespace);
     let c_function_name = pairs.next().unwrap().as_str().to_string();
     let mut stmt = ExportStatement::new(fix_value_name, c_function_name, Some(span));
-    stmt.value_name_src = name_span;
+    stmt.value_name_src = Some(name_span);
     stmt
 }
 
@@ -1146,7 +1144,7 @@ fn parse_deprecated_statement(
     let (message, _) = parse_string_lit_content(pairs.next().unwrap(), ctx)?;
     Ok(DeprecationStatement {
         target_path,
-        target_name_src: name_span,
+        target_name_src: Some(name_span),
         origin_namespace: ctx.namespace.clone(),
         message,
         src: Some(span),
@@ -2281,18 +2279,12 @@ fn parse_expr_var(pair: Pair<Rule>, ctx: &mut ParseContext) -> Arc<ExprNode> {
 /// Parses a `fullname` rule into the full name it writes, together with the span of its trailing
 /// `name` token alone, which covers the bare name and leaves the namespace prefix outside it. That
 /// span is what a rename or a find-references over such a name works with.
-fn parse_fullname(pair: Pair<Rule>, ctx: &mut ParseContext) -> (FullName, Option<Span>) {
+fn parse_fullname(pair: Pair<Rule>, ctx: &mut ParseContext) -> (FullName, Span) {
     assert_eq!(pair.as_rule(), Rule::fullname);
-    let name_span = pair
-        .clone()
-        .into_inner()
-        .last()
-        .and_then(|last| match last.as_rule() {
-            Rule::name | Rule::capital_name | Rule::number_name => {
-                Some(Span::from_pair(&ctx.source, &last))
-            }
-            _ => None,
-        });
+    // The rule `fullname` ends with its `name`, so the last inner pair is that name.
+    let name_pair = pair.clone().into_inner().last().unwrap();
+    assert_eq!(name_pair.as_rule(), Rule::name);
+    let name_span = Span::from_pair(&ctx.source, &name_pair);
     (parse_fullname_or_capital_fullname(pair, ctx), name_span)
 }
 
@@ -2346,7 +2338,11 @@ fn parse_fullname_or_capital_fullname(pair: Pair<Rule>, ctx: &mut ParseContext) 
         }
     }
     if fullname.is_absolute() && !fullname.namespace.names.is_empty() {
-        debug_assert_eq!(path_spans.len(), fullname.namespace.names.len() + 1);
+        assert_eq!(
+            path_spans.len(),
+            fullname.namespace.names.len() + 1,
+            "an absolute name carries one span per namespace it names and one for the name itself"
+        );
         ctx.abs_path_uses.push((fullname.clone(), path_spans));
     }
     fullname
@@ -2699,11 +2695,9 @@ fn parse_ffi_param_tys(
 }
 
 /// Parses a number literal. A `_`-suffix such as `_U8` gives the literal's type; without one, a
-/// literal containing a decimal point is `F64` and a literal without one is `I64`. A decimal or
-/// octal integer literal must lie in the range of that type; a hexadecimal or binary one may fill
-/// its bit width, so `0b11111111_I8` is `-1`. A floating point literal must lie in the range of
-/// its type as well, and takes the value of that type nearest to what is written, so
-/// `1.0e-50_F32` is `0.0_F32`.
+/// literal containing a decimal point is `F64` and a literal without one is `I64`. The value the
+/// literal takes at that type, and the report where the type does not hold it, come from
+/// `integral_literal_value` and `floating_literal_value`.
 fn parse_expr_number_lit(
     pair: Pair<Rule>,
     ctx: &mut ParseContext,
@@ -2727,7 +2721,7 @@ fn parse_expr_number_lit(
                     &[&Some(span)],
                 ));
             }
-            (ty.unwrap(), ty_name)
+            (ty, ty_name)
         }
         None => {
             // Type of literal is implicit.
@@ -2739,124 +2733,12 @@ fn parse_expr_number_lit(
         }
     };
     let ty = ty.set_source(Some(span.clone()));
-    if is_float {
-        // `number_lit_body_dec` admits digits, one decimal point and an optional exponent, which
-        // read as a floating point number at either width.
-        let val = floating_literal_value(ty_name, raw);
-        // A literal larger than the widest finite value of its type rounds to an infinity. Every
-        // value a literal spells is finite, so such a literal is out of range.
-        if !val.is_finite() {
-            return Err(Errors::from_msg_srcs(
-                format!(
-                    "The value of a floating point literal `{}` is out of range of `{}`.",
-                    raw, ty_name
-                ),
-                &[&Some(span)],
-            ));
-        }
-        Ok(expr_float_lit(val, ty, Some(span)))
+    let expr = if is_float {
+        floating_literal_value(ty_name, raw).map(|val| expr_float_lit(val, ty, Some(span.clone())))
     } else {
-        // Integral literal
-        let opt_val_radix = parse_integer_literal_string(raw);
-        if opt_val_radix.is_none() {
-            return Err(Errors::from_msg_srcs(
-                format!("A literal string `{}` cannot be parsed as an integer.", raw),
-                &[&Some(span)],
-            ));
-        }
-        let (val, radix) = opt_val_radix.unwrap();
-
-        // Check size.
-        // A hexadecimal or binary literal writes a bit pattern, so it reaches the largest value the
-        // width of its type holds. At the low end every literal stops at the minimum of its type.
-        let writes_a_bit_pattern = radix == 16 || radix == 2;
-        let (min, max) = if writes_a_bit_pattern {
-            integral_ty_range_with_bit_patterns(ty_name)
-        } else {
-            integral_ty_range(ty_name)
-        };
-        if !(min <= val && val <= max) {
-            let reason = if writes_a_bit_pattern && val > max {
-                "does not fit in the width of"
-            } else {
-                "is out of range of"
-            };
-            return Err(Errors::from_msg_srcs(
-                format!(
-                    "The value of an integer literal `{}` {} `{}`.",
-                    raw, reason, ty_name
-                ),
-                &[&Some(span)],
-            ));
-        }
-        let val = i128::try_from(&val).unwrap();
-        Ok(expr_int_lit(val as u64, ty, Some(span)))
-    }
-}
-
-/// Read an integer literal, written in any of the four bases with an optional sign, and return
-/// its value and the base it is written in. The `e` of a decimal literal multiplies it by that
-/// power of ten, and a negative exponent leaves no integer, so it gives `None`.
-///
-/// # Examples
-/// `parse_integer_literal_string("-0xff")` is `Some((-255, 16))`, and `"123e4"` is
-/// `Some((1230000, 10))`.
-fn parse_integer_literal_string(raw: &str) -> Option<(BigInt, usize)> {
-    if raw.len() == 0 {
-        return None;
-    }
-    for (prefix, radix) in [("0x", 16), ("0o", 8), ("0b", 2)] {
-        if let Some((digits, is_negative)) = strip_sign_and_radix_prefix(raw, prefix) {
-            let val = BigInt::parse_bytes(digits.as_bytes(), radix as u32)?;
-            return Some((if is_negative { -val } else { val }, radix));
-        }
-    }
-    let num_and_exp = raw.split('e').collect::<Vec<_>>();
-    if num_and_exp.len() > 2 {
-        return None;
-    }
-    if num_and_exp.len() == 1 {
-        // 'e' is not contained.
-        return BigInt::parse_bytes(raw.as_bytes(), 10).map(|x| (x, 10));
-    }
-    assert_eq!(num_and_exp.len(), 2);
-    let num = BigInt::parse_bytes(num_and_exp[0].as_bytes(), 10);
-    if num.is_none() {
-        return None;
-    }
-    let num = num.unwrap();
-    let exp = BigInt::parse_bytes(num_and_exp[1].as_bytes(), 10);
-    if exp.is_none() {
-        return None;
-    }
-    let exp = exp.unwrap();
-    if exp < BigInt::from(0 as i32) {
-        // Negative exponent is not allowed in integral literal.
-        return None;
-    }
-    // Return num * 10^exp.
-    let mut val = num;
-    let mut i = BigInt::from(0);
-    while i < exp {
-        val *= 10;
-        i += 1;
-    }
-    Some((val, 10))
-}
-
-/// The digits `raw` writes behind `prefix`, which a minus sign may precede, and whether that sign
-/// is there. Gives `None` where `raw` carries another prefix.
-///
-/// # Examples
-/// `strip_sign_and_radix_prefix("-0xff", "0x")` is `Some(("ff", true))`, and `strip_sign_and_radix_prefix("12", "0x")`
-/// is `None`.
-fn strip_sign_and_radix_prefix<'a>(raw: &'a str, prefix: &str) -> Option<(&'a str, bool)> {
-    if let Some(digits) = raw.strip_prefix(prefix) {
-        return Some((digits, false));
-    }
-    raw.strip_prefix('-')
-        .and_then(|after_sign| after_sign.strip_prefix(prefix))
-        .map(|digits| (digits, true))
+        integral_literal_value(ty_name, raw).map(|val| expr_int_lit(val, ty, Some(span.clone())))
+    };
+    expr.map_err(|msg| Errors::from_msg_srcs(msg, &[&Some(span)]))
 }
 
 fn parse_expr_nullptr_lit(pair: Pair<Rule>, ctx: &mut ParseContext) -> Arc<ExprNode> {


### PR DESCRIPTION
Refs #587, #588

#594 のレビューが差分の外に見つけた所見のうち、**プロジェクトのスイートが判定できる 4 件**を直したもの。清掃 PR #595 に入れるつもりで書いたが、#595 が merge された直後になったので別の PR にしてある。

レビューの radius 規則は、差分の外でインターフェースや振る舞いを変える編集を finding にする。1 つの規約しか見ていないサブエージェントがそれを判断できないからで、規則としては正しい。ただしその判断は、全体を見てスイート (1,679 + 183 本) を回せる側でなら下せる。この 4 件はどれも「壊していないか」だけが問題で、フルスイートがそれに答える。

フルスイートは通る。

## 1. `parse_fullname` が、文法が作れない形に備えていた

**役割**: `fullname` の pair — 値の名前で、名前空間のパスと先頭の `::` が前に付きうる — を受け取り、書かれた名前と、**その名前だけの span** (パスを含まない) を返す。この span は rename と find-references が使う。

**変更前**: 名前の span を `match` で取り、3 つの規則を受けて残りを `None` に落としていた。

```rust
    let name_span = pair
        .clone()
        .into_inner()
        .last()
        .and_then(|last| match last.as_rule() {
            Rule::name | Rule::capital_name | Rule::number_name => {
                Some(Span::from_pair(&ctx.source, &last))
            }
            _ => None,
        });
```

文法は `fullname = { double_colon? ~ (namespace_item ~ double_colon)* ~ name }` で、関数の冒頭は `assert_eq!(pair.as_rule(), Rule::fullname)` である。よって最後の内側 pair は必ず `Rule::name` で、`capital_name` と `number_name` の腕も `_ => None` も到達しない。`None` が万一返れば、その名前の span が黙って消え、rename と find-references が位置を失う。

**変更後**: それを表明にし、返り値を `Option<Span>` から `Span` にした。

```rust
    // The rule `fullname` ends with its `name`, so the last inner pair is that name.
    let name_pair = pair.clone().into_inner().last().unwrap();
    assert_eq!(name_pair.as_rule(), Rule::name);
    let name_span = Span::from_pair(&ctx.source, &name_pair);
```

呼び手 2 か所 (`parse_export_statement`、`parse_deprecated_statement`) は、常に `Some` だった値を `Some(...)` で包むようになる。どちらも `Option<Span>` のフィールドへ入れるが、そのフィールドが `Option` なのは合成された文が span を持たないためで、`parse_fullname` の返り値が `Option` である理由ではない。

**表明が到達することの確認**: `Rule::name` を `Rule::capital_name` に変えると、`main = println $ "x";` だけのプログラムでもこの行で panic する。

## 2. 絶対パスの span の個数が、release では検査されていなかった

**役割**: `parse_fullname_or_capital_fullname` は名前を組み立て、絶対パスのときはパスの部分ごとの span を集めて `ctx.abs_path_uses` に積む。この span 列は、合成する暗黙の import 文の各要素 (モジュール名・中間の名前空間・葉) に配られるので、個数が名前の部分の個数と一致していなければならない。

**変更前**: `debug_assert_eq!(path_spans.len(), fullname.namespace.names.len() + 1);`

このプロジェクトはテストを release で走らせる (`cargo test --release`)。`debug_assert!` は release で消えるので、**この不変条件はどこでも検査されていなかった**。

**変更後**: `assert_eq!` にし、何を数えているかをメッセージに書いた。

```rust
        assert_eq!(
            path_spans.len(),
            fullname.namespace.names.len() + 1,
            "an absolute name carries one span per namespace it names and one for the name itself"
        );
```

**表明が到達することの確認**: 右辺を `+ 1` から `+ 2` に変えてフルスイートを回すと **20 本が赤くなる**。

```
test_abs_path_dep_hash::integration_tests::{abs_path_no_import_propagates_lib_type_change,
  missing_module_via_absolute_path_reports_at_module_token,
  value_typo_via_absolute_path_reports_unknown_name_with_span,
  with_import_propagates_lib_type_change}
test_basic::{test_absolute_namespace_trait, test_absolute_namespace_trait_alias,
  test_absolute_namespace_type, test_absolute_namespace_value}
test_import::{test_absolute_path_reaches_every_value_name_shape_without_an_import,
  test_absolute_path_to_an_undefined_type_of_another_module_is_reported_as_an_entity,
  test_absolute_path_to_an_undefined_value_of_another_module_is_reported_as_a_value}
test_dependencies, test_deprecation (2), test_explicit_import, test_index_syntax,
test_lsp::test_rename, test_lsp::test_semantic_tokens (3)
```

つまり、この 20 本は表明を 1 度も実行しないまま緑になっていた。テストを足す必要はない。

## 3. `make_numeric_ty` の `Option` が決して `None` にならない

**役割**: 数値型の名前から、その型と「浮動小数点型かどうか」を返す。

**変更前**: `(Option<Arc<TypeNode>>, bool)` を返し、doc の `# Returns` は「数値型でない名前では型は `None`」と述べていた。だが本体の `assert!(floating_ty.is_some(), "Not a numeric type: {}", name)` がその場合にそのまま panic するので、`None` は返らない。唯一の呼び手 (`parse_expr_number_lit`) は `.unwrap()` していた。

**変更後**: `(Arc<TypeNode>, bool)` にし、doc を panic の条件で書き直した。呼び手の `.unwrap()` が消える。

## 4. 整数リテラルの読み取りを、浮動小数と同じ場所へ出す

**役割**: `parse_expr_number_lit` は数値リテラルの pair を受け取り、書かれた型を決め、その型で値を読み、値がその型に収まることを検査して式を返す。

**変更前**: 浮動小数側は `floating_literal_value` の 1 呼び出しになっていたが、整数側はリテラルの読み取り・基数の選択・2 つの範囲関数・理由の文字列・エラーの組み立ての約 30 行を抱えたままだった。「対になる整数版を出せるが、報告に `Span` が要るので素直な移動にならない」と #595 に書いたのがこれである。

**変更後**: `integral_literal_value` を `builtin.rs` の `floating_literal_value` の隣に置き、あわせて `floating_literal_value` にも範囲の検査を持たせた。どちらも報告の**文**を `Result<_, String>` の `Err` で返し、**span は呼び手が付ける**。`Span` の問題は `map_err` 1 つで解ける。

```rust
    let expr = if is_float {
        floating_literal_value(ty_name, raw).map(|val| expr_float_lit(val, ty, Some(span.clone())))
    } else {
        integral_literal_value(ty_name, raw).map(|val| expr_int_lit(val, ty, Some(span.clone())))
    };
    expr.map_err(|msg| Errors::from_msg_srcs(msg, &[&Some(span)]))
```

`parse_expr_number_lit` は「型を決め、その型でリテラルを読み、返ってきた報告に span を付ける」だけになる。`parse_integer_literal_string` と `strip_sign_and_radix_prefix` も一緒に `builtin.rs` へ移り、`parser.rs` から `num_bigint::BigInt` の import が消えた。数値型の名前から性質を引く問いが 1 つのモジュールに揃う。

診断の文言は変わらない。

## テスト

新しいテストは足していない。4 件のうち 2 件は表明で、その表明に届くテストが既に在ること (2 は 20 本、1 はすべてのプログラム) を変異で測った。残る 2 件は振る舞いを変えないので、リテラルのテスト 34 本がそのまま持ち主である。

## 残した所見

- **数値型の名前の列挙が 3 モジュールに散っている** (`grammer.pest` の `number_lit_type`、`constants.rs` の名前定数、`builtin.rs` の 6 関数)。数値型を 1 つ足すとこの全部を触ることになり、どれか 1 つを忘れても静かに通る。1 か所から導く形にするのは設計の判断なので、方向を決めてもらう必要がある。
