### PR TITLE
浮動小数の文字列化バッファを、その書式が書きうる幅ちょうどにする

### DIFF
--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -127,16 +127,12 @@ void fixruntime_f32_to_str_exp(char *buf, float v)
 
 void fixruntime_f32_to_str_exp_precision(char *buf, float v, uint8_t precision)
 {
-    char specifier[7]; // len(%.255e) + 1
-    sprintf(specifier, "%%.%" PRIu8 "e", precision);
-    sprintf(buf, specifier, v);
+    sprintf(buf, "%.*e", (int)precision, v);
 }
 
 void fixruntime_f32_to_str_precision(char *buf, float v, uint8_t precision)
 {
-    char specifier[7]; // len(%.255f) + 1
-    sprintf(specifier, "%%.%" PRIu8 "f", precision);
-    sprintf(buf, specifier, v);
+    sprintf(buf, "%.*f", (int)precision, v);
 }
 
 void fixruntime_f64_to_str(char *buf, double v)
@@ -151,16 +147,12 @@ void fixruntime_f64_to_str_exp(char *buf, double v)
 
 void fixruntime_f64_to_str_exp_precision(char *buf, double v, uint8_t precision)
 {
-    char specifier[8]; // len(%.255le) + 1
-    sprintf(specifier, "%%.%" PRIu8 "le", precision);
-    sprintf(buf, specifier, v);
+    sprintf(buf, "%.*le", (int)precision, v);
 }
 
 void fixruntime_f64_to_str_precision(char *buf, double v, uint8_t precision)
 {
-    char specifier[8]; // len(%.255lf) + 1
-    sprintf(specifier, "%%.%" PRIu8 "lf", precision);
-    sprintf(buf, specifier, v);
+    sprintf(buf, "%.*lf", (int)precision, v);
 }
 
 int64_t fixruntime_strtoll_10(const char *str)

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -115,32 +115,28 @@ void fixruntime_i64_to_str(char *buf, int64_t v)
     sprintf(buf, "%" PRId64, v);
 }
 
-// Stops the program when a number's text did not fit the buffer it was written into.
+// Stops the program unless the text `snprintf` reported fits `size`.
 //
 // The caller in `src/fixstd/std.fix` derives that buffer's size from the widest text the format
 // can write, so a text that does not fit means the derivation is wrong. Stopping here names the
 // two sizes, where letting the write run on would leave the heap damaged and the program going.
 //
 // # Arguments
-// * `needed` - The bytes the whole text and its null take.
-// * `size` - The bytes the buffer holds.
-__attribute__((noreturn)) static void fixruntime_float_text_too_wide(int64_t needed, int64_t size)
-{
-    fprintf(stderr, "A number's text takes %" PRId64 " bytes and its buffer holds %" PRId64 "\n",
-            needed, size);
-    fixruntime_abort();
-}
-
-// Stops the program unless the text `snprintf` reported fits `size`.
-//
-// # Arguments
-// * `written` - What `snprintf` answered: the length of the text, without its null.
+// * `written` - What `snprintf` answered: the length of the text, without its null, or a negative
+//   number where it could not write the text at all.
 // * `size` - The bytes the buffer holds.
 static void fixruntime_check_float_text(int written, int64_t size)
 {
-    if (written < 0 || (int64_t)written + 1 > size)
+    if (written < 0)
     {
-        fixruntime_float_text_too_wide((int64_t)written + 1, size);
+        fprintf(stderr, "Writing a number as text failed\n");
+        fixruntime_abort();
+    }
+    if ((int64_t)written + 1 > size)
+    {
+        fprintf(stderr, "A number's text takes %" PRId64 " bytes and its buffer holds %" PRId64 "\n",
+                (int64_t)written + 1, size);
+        fixruntime_abort();
     }
 }
 

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -125,11 +125,13 @@ void fixruntime_f32_to_str_exp(char *buf, float v)
     sprintf(buf, "%e", v);
 }
 
+// `F32::to_string_exp_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
 void fixruntime_f32_to_str_exp_precision(char *buf, float v, uint8_t precision)
 {
     sprintf(buf, "%.*e", (int)precision, v);
 }
 
+// `F32::to_string_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
 void fixruntime_f32_to_str_precision(char *buf, float v, uint8_t precision)
 {
     sprintf(buf, "%.*f", (int)precision, v);
@@ -145,11 +147,13 @@ void fixruntime_f64_to_str_exp(char *buf, double v)
     sprintf(buf, "%le", v);
 }
 
+// `F64::to_string_exp_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
 void fixruntime_f64_to_str_exp_precision(char *buf, double v, uint8_t precision)
 {
     sprintf(buf, "%.*le", (int)precision, v);
 }
 
+// `F64::to_string_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
 void fixruntime_f64_to_str_precision(char *buf, double v, uint8_t precision)
 {
     sprintf(buf, "%.*lf", (int)precision, v);

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -327,12 +327,6 @@ __attribute__((noreturn)) void fixruntime_array_size_overflow(int64_t size)
     fixruntime_abort();
 }
 
-// void fixruntime_union_variant_mismatch(uint8_t expected, uint8_t actual)
-// {
-//     fprintf(stderr, "Union variant mismatch: expected=%" PRIu8 ", actual=%" PRIu8 "\n", expected, actual);
-//     fixruntime_abort();
-// }
-
 #if defined(BACKTRACE)
 #if defined(__linux__)
 #include <backtrace.h>

--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -115,48 +115,53 @@ void fixruntime_i64_to_str(char *buf, int64_t v)
     sprintf(buf, "%" PRId64, v);
 }
 
-void fixruntime_f32_to_str(char *buf, float v)
+// Stops the program when a number's text did not fit the buffer it was written into.
+//
+// The caller in `src/fixstd/std.fix` derives that buffer's size from the widest text the format
+// can write, so a text that does not fit means the derivation is wrong. Stopping here names the
+// two sizes, where letting the write run on would leave the heap damaged and the program going.
+//
+// # Arguments
+// * `needed` - The bytes the whole text and its null take.
+// * `size` - The bytes the buffer holds.
+__attribute__((noreturn)) static void fixruntime_float_text_too_wide(int64_t needed, int64_t size)
 {
-    sprintf(buf, "%f", v);
+    fprintf(stderr, "A number's text takes %" PRId64 " bytes and its buffer holds %" PRId64 "\n",
+            needed, size);
+    fixruntime_abort();
 }
 
-void fixruntime_f32_to_str_exp(char *buf, float v)
+// Stops the program unless the text `snprintf` reported fits `size`.
+//
+// # Arguments
+// * `written` - What `snprintf` answered: the length of the text, without its null.
+// * `size` - The bytes the buffer holds.
+static void fixruntime_check_float_text(int written, int64_t size)
 {
-    sprintf(buf, "%e", v);
+    if (written < 0 || (int64_t)written + 1 > size)
+    {
+        fixruntime_float_text_too_wide((int64_t)written + 1, size);
+    }
 }
 
-// `F32::to_string_exp_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
-void fixruntime_f32_to_str_exp_precision(char *buf, float v, uint8_t precision)
+void fixruntime_f32_to_str_exp_precision(char *buf, int64_t size, float v, uint8_t precision)
 {
-    sprintf(buf, "%.*e", (int)precision, v);
+    fixruntime_check_float_text(snprintf(buf, (size_t)size, "%.*e", (int)precision, v), size);
 }
 
-// `F32::to_string_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
-void fixruntime_f32_to_str_precision(char *buf, float v, uint8_t precision)
+void fixruntime_f32_to_str_precision(char *buf, int64_t size, float v, uint8_t precision)
 {
-    sprintf(buf, "%.*f", (int)precision, v);
+    fixruntime_check_float_text(snprintf(buf, (size_t)size, "%.*f", (int)precision, v), size);
 }
 
-void fixruntime_f64_to_str(char *buf, double v)
+void fixruntime_f64_to_str_exp_precision(char *buf, int64_t size, double v, uint8_t precision)
 {
-    sprintf(buf, "%lf", v);
+    fixruntime_check_float_text(snprintf(buf, (size_t)size, "%.*le", (int)precision, v), size);
 }
 
-void fixruntime_f64_to_str_exp(char *buf, double v)
+void fixruntime_f64_to_str_precision(char *buf, int64_t size, double v, uint8_t precision)
 {
-    sprintf(buf, "%le", v);
-}
-
-// `F64::to_string_exp_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
-void fixruntime_f64_to_str_exp_precision(char *buf, double v, uint8_t precision)
-{
-    sprintf(buf, "%.*le", (int)precision, v);
-}
-
-// `F64::to_string_precision` in src/fixstd/std.fix sizes `buf` from the widest text this format writes.
-void fixruntime_f64_to_str_precision(char *buf, double v, uint8_t precision)
-{
-    sprintf(buf, "%.*lf", (int)precision, v);
+    fixruntime_check_float_text(snprintf(buf, (size_t)size, "%.*lf", (int)precision, v), size);
 }
 
 int64_t fixruntime_strtoll_10(const char *str)

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -4077,7 +4077,9 @@ impl F32 : FromBytes {
 }
 impl F32 : ToString {
     to_string = |v| (
-        let data = Array::empty(50);
+        // A sign, the 39 digits the greatest `F32` takes in its whole part, a point, the 6
+        // places `%f` writes by default and a null.
+        let data = Array::empty(48);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str(Ptr, F32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4089,7 +4091,9 @@ namespace F32 {
     // * `v` - The floating number to be converted to a string.
     to_string_exp : F32 -> String;
     to_string_exp = |v| (
-        let data = Array::empty(50);
+        // A sign, a digit, a point, the 6 places `%e` writes by default, `e`, the exponent's
+        // sign, the 2 digits a `F32` exponent reaches and a null.
+        let data = Array::empty(14);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_exp(Ptr, F32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4101,7 +4105,9 @@ namespace F32 {
     // * `v` - The floating number to be converted to a string.
     to_string_exp_precision : U8 -> F32 -> String;
     to_string_exp_precision = |prec, v| (
-        let data = Array::empty(50 + prec.i64);
+        // A sign, a digit, a point, `prec` digits, `e`, the exponent's sign, the 2 digits a
+        // `F32` exponent reaches and a null.
+        let data = Array::empty(8 + prec.i64);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_exp_precision(Ptr, F32, U8), ptr, v, prec]);
         String::_unsafe_from_c_str(data)
     );
@@ -4113,7 +4119,9 @@ namespace F32 {
     // * `v` - The floating number to be converted to a string.
     to_string_precision : U8 -> F32 -> String;
     to_string_precision = |prec, v| (
-        let data = Array::empty(50 + prec.i64);
+        // A sign, the 39 digits the greatest `F32` takes in its whole part, a point, `prec`
+        // digits and a null.
+        let data = Array::empty(42 + prec.i64);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_precision(Ptr, F32, U8), ptr, v, prec]);
         String::_unsafe_from_c_str(data)
     );
@@ -4148,7 +4156,9 @@ impl F64 : FromBytes {
 }
 impl F64 : ToString {
     to_string = |v| (
-        let data = Array::empty(500);
+        // A sign, the 309 digits the greatest `F64` takes in its whole part, a point, the 6
+        // places `%f` writes by default and a null.
+        let data = Array::empty(318);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str(Ptr, F64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4160,7 +4170,9 @@ namespace F64 {
     // * `v` - The floating number to be converted to a string.
     to_string_exp : F64 -> String;
     to_string_exp = |v| (
-        let data = Array::empty(500);
+        // A sign, a digit, a point, the 6 places `%e` writes by default, `e`, the exponent's
+        // sign, the 3 digits a `F64` exponent reaches and a null.
+        let data = Array::empty(15);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_exp(Ptr, F64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4172,7 +4184,9 @@ namespace F64 {
     // * `v` - The floating number to be converted to a string.
     to_string_exp_precision : U8 -> F64 -> String;
     to_string_exp_precision = |prec, v| (
-        let data = Array::empty(500 + prec.i64);
+        // A sign, a digit, a point, `prec` digits, `e`, the exponent's sign, the 3 digits a
+        // `F64` exponent reaches and a null.
+        let data = Array::empty(9 + prec.i64);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_exp_precision(Ptr, F64, U8), ptr, v, prec]);
         String::_unsafe_from_c_str(data)
     );
@@ -4184,7 +4198,9 @@ namespace F64 {
     // * `v` - The floating number to be converted to a string.
     to_string_precision : U8 -> F64 -> String;
     to_string_precision = |prec, v| (
-        let data = Array::empty(500 + prec.i64);
+        // A sign, the 309 digits the greatest `F64` takes in its whole part, a point, `prec`
+        // digits and a null.
+        let data = Array::empty(312 + prec.i64);
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_precision(Ptr, F64, U8), ptr, v, prec]);
         String::_unsafe_from_c_str(data)
     );

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -4076,13 +4076,7 @@ impl F32 : FromBytes {
     );
 }
 impl F32 : ToString {
-    to_string = |v| (
-        // A sign, the 39 digits the greatest `F32` takes in its whole part, a point, the 6
-        // places `%f` writes by default and a null.
-        let data = Array::empty(48);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str(Ptr, F32), ptr, v]);
-        String::_unsafe_from_c_str(data)
-    );
+    to_string = |v| v.to_string_precision(6_U8);
 }
 namespace F32 {
     // Converts a floating number to a string of exponential form.
@@ -4090,13 +4084,7 @@ namespace F32 {
     // # Parameters
     // * `v` - The floating number to be converted to a string.
     to_string_exp : F32 -> String;
-    to_string_exp = |v| (
-        // A sign, a digit, a point, the 6 places `%e` writes by default, `e`, the exponent's
-        // sign, the 2 digits a `F32` exponent reaches and a null.
-        let data = Array::empty(14);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_exp(Ptr, F32), ptr, v]);
-        String::_unsafe_from_c_str(data)
-    );
+    to_string_exp = |v| v.to_string_exp_precision(6_U8);
 
     // Converts a floating number to a string of exponential form with specified precision (i.e., number of digits after the decimal point).
     // 
@@ -4107,8 +4095,9 @@ namespace F32 {
     to_string_exp_precision = |prec, v| (
         // A sign, a digit, a point, `prec` digits, `e`, the exponent's sign, the 2 digits a
         // `F32` exponent reaches and a null.
-        let data = Array::empty(8 + prec.i64);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_exp_precision(Ptr, F32, U8), ptr, v, prec]);
+        let size = 8 + prec.i64;
+        let data = Array::empty(size);
+        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_exp_precision(Ptr, I64, F32, U8), ptr, size, v, prec]);
         String::_unsafe_from_c_str(data)
     );
 
@@ -4121,8 +4110,9 @@ namespace F32 {
     to_string_precision = |prec, v| (
         // A sign, the 39 digits the greatest `F32` takes in its whole part, a point, `prec`
         // digits and a null.
-        let data = Array::empty(42 + prec.i64);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_precision(Ptr, F32, U8), ptr, v, prec]);
+        let size = 42 + prec.i64;
+        let data = Array::empty(size);
+        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f32_to_str_precision(Ptr, I64, F32, U8), ptr, size, v, prec]);
         String::_unsafe_from_c_str(data)
     );
 }
@@ -4155,13 +4145,7 @@ impl F64 : FromBytes {
     );
 }
 impl F64 : ToString {
-    to_string = |v| (
-        // A sign, the 309 digits the greatest `F64` takes in its whole part, a point, the 6
-        // places `%f` writes by default and a null.
-        let data = Array::empty(318);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str(Ptr, F64), ptr, v]);
-        String::_unsafe_from_c_str(data)
-    );
+    to_string = |v| v.to_string_precision(6_U8);
 }
 namespace F64 {
     // Converts a floating number to a string of exponential form.
@@ -4169,13 +4153,7 @@ namespace F64 {
     // # Parameters
     // * `v` - The floating number to be converted to a string.
     to_string_exp : F64 -> String;
-    to_string_exp = |v| (
-        // A sign, a digit, a point, the 6 places `%e` writes by default, `e`, the exponent's
-        // sign, the 3 digits a `F64` exponent reaches and a null.
-        let data = Array::empty(15);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_exp(Ptr, F64), ptr, v]);
-        String::_unsafe_from_c_str(data)
-    );
+    to_string_exp = |v| v.to_string_exp_precision(6_U8);
 
     // Converts a floating number to a string of exponential form with specified precision (i.e., number of digits after the decimal point).
     //
@@ -4186,8 +4164,9 @@ namespace F64 {
     to_string_exp_precision = |prec, v| (
         // A sign, a digit, a point, `prec` digits, `e`, the exponent's sign, the 3 digits a
         // `F64` exponent reaches and a null.
-        let data = Array::empty(9 + prec.i64);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_exp_precision(Ptr, F64, U8), ptr, v, prec]);
+        let size = 9 + prec.i64;
+        let data = Array::empty(size);
+        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_exp_precision(Ptr, I64, F64, U8), ptr, size, v, prec]);
         String::_unsafe_from_c_str(data)
     );
 
@@ -4200,8 +4179,9 @@ namespace F64 {
     to_string_precision = |prec, v| (
         // A sign, the 309 digits the greatest `F64` takes in its whole part, a point, `prec`
         // digits and a null.
-        let data = Array::empty(312 + prec.i64);
-        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_precision(Ptr, F64, U8), ptr, v, prec]);
+        let size = 312 + prec.i64;
+        let data = Array::empty(size);
+        let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_f64_to_str_precision(Ptr, I64, F64, U8), ptr, size, v, prec]);
         String::_unsafe_from_c_str(data)
     );
 }

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -3829,7 +3829,7 @@ namespace Ptr {
 
 impl Ptr : ToString {
     to_string = |v| (
-        let data = Array::empty(17);
+        let data = Array::empty(17); // len(ffffffffffffffff) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_ptr_to_str(Ptr, Ptr), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -3903,7 +3903,7 @@ impl U32 : FromBytes {
 }
 impl U32 : ToString {
     to_string = |v| (
-        let data = Array::empty(11);
+        let data = Array::empty(11); // len(4294967295) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_u32_to_str(Ptr, U32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -3929,7 +3929,7 @@ impl U64 : FromBytes {
 }
 impl U64 : ToString {
     to_string = |v| (
-        let data = Array::empty(21);
+        let data = Array::empty(21); // len(18446744073709551615) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_u64_to_str(Ptr, U64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4016,7 +4016,7 @@ impl I32 : FromBytes {
 }
 impl I32 : ToString {
     to_string = |v| (
-        let data = Array::empty(12);
+        let data = Array::empty(12); // len(-2147483648) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_i32_to_str(Ptr, I32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4042,7 +4042,7 @@ impl I64 : FromBytes {
 }
 impl I64 : ToString {
     to_string = |v| (
-        let data = Array::empty(21);
+        let data = Array::empty(21); // len(-9223372036854775808) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_i64_to_str(Ptr, I64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -33,6 +33,7 @@ mod test_explicit_import;
 mod test_external_projects;
 mod test_ffi;
 mod test_file_io;
+mod test_float_text_buffer;
 mod test_get_args;
 mod test_git_ref;
 mod test_global_accessor;

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5555,6 +5555,28 @@ pub fn test_float_to_string_precision() {
             assert_eq(|_|"case to_string_precision F64 0", x.to_string_precision(0_U8), "-3");;
             assert_eq(|_|"case to_string_precision F64 255", x.to_string_precision(255_U8), "-3.140000000000000124344978758017532527446746826171875000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");;
 
+            // The widest text this writes for a `F32`: the least one, whose whole part takes
+            // 39 digits, with a sign before it and 255 places behind the point.
+            let widest = -3.4028235e38_F32;
+            let text = widest.to_string_precision(255_U8);
+            assert_eq(|_|"the widest F32 text is a sign, 39 digits, a point and 255 places",
+                      text.@size, 1 + 39 + 1 + 255);;
+            assert_eq(|_|"the widest F32 text opens with the digits of the least F32",
+                      text.get_sub(0, 20), "-3402823466385288598");;
+            assert_eq(|_|"the widest F32 text ends in the places behind its point",
+                      text.get_sub(text.@size - 6, text.@size), "000000");;
+
+            // The widest text this writes for a `F64`: the least one, whose whole part takes
+            // 309 digits, with a sign before it and 255 places behind the point.
+            let widest = -1.7976931348623157e308;
+            let text = widest.to_string_precision(255_U8);
+            assert_eq(|_|"the widest F64 text is a sign, 309 digits, a point and 255 places",
+                      text.@size, 1 + 309 + 1 + 255);;
+            assert_eq(|_|"the widest F64 text opens with the digits of the least F64",
+                      text.get_sub(0, 20), "-1797693134862315708");;
+            assert_eq(|_|"the widest F64 text ends in the places behind its point",
+                      text.get_sub(text.@size - 6, text.@size), "000000");;
+
             pure()
         );
     "#;
@@ -5592,7 +5614,29 @@ pub fn test_float_to_string_exp_precision() {
             let x = -123.45_F64;
             assert_eq(|_|"", x.to_string_exp_precision(0_U8), "-1e+02");;
             assert_eq(|_|"", x.to_string_exp_precision(255_U8), "-1.234500000000000028421709430404007434844970703125000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e+02");;
-        
+
+            // The widest text this writes for a `F32`: the least one, with a sign before it,
+            // 255 places behind the point and a two-digit exponent.
+            let widest = -3.4028235e38_F32;
+            let text = widest.to_string_exp_precision(255_U8);
+            assert_eq(|_|"the widest F32 text is a sign, a digit, a point, 255 places and `e+38`",
+                      text.@size, 1 + 1 + 1 + 255 + 4);;
+            assert_eq(|_|"the widest F32 text opens with the digits of the least F32",
+                      text.get_sub(0, 20), "-3.40282346638528859");;
+            assert_eq(|_|"the widest F32 text ends in its exponent",
+                      text.get_sub(text.@size - 6, text.@size), "00e+38");;
+
+            // The widest text this writes for a `F64`: the least one, with a sign before it,
+            // 255 places behind the point and a three-digit exponent.
+            let widest = -1.7976931348623157e308;
+            let text = widest.to_string_exp_precision(255_U8);
+            assert_eq(|_|"the widest F64 text is a sign, a digit, a point, 255 places and `e+308`",
+                      text.@size, 1 + 1 + 1 + 255 + 5);;
+            assert_eq(|_|"the widest F64 text opens with the digits of the least F64",
+                      text.get_sub(0, 20), "-1.79769313486231570");;
+            assert_eq(|_|"the widest F64 text ends in its exponent",
+                      text.get_sub(text.@size - 6, text.@size), "8e+308");;
+
             pure()
         );
     "#;

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5541,6 +5541,9 @@ pub fn test_signed_integral_abs() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the text `to_string` writes for the widest `F32` and `F64`: the digits of the whole part
+/// and the places the format gives by default, which together are the width the buffer is sized
+/// for.
 #[test]
 pub fn test_float_to_string() {
     let source = r#"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5510,6 +5510,8 @@ pub fn test_consumed_time_fast() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Verifies that `abs` carries a negative value to its magnitude and leaves a positive one
+/// alone, at each of the signed integer types.
 #[test]
 pub fn test_signed_integral_abs() {
     let source = r#"
@@ -5566,6 +5568,8 @@ pub fn test_float_to_string() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the text `to_string_precision` writes at precision 0, at 255, and for the widest `F32`
+/// and `F64`, whose whole part is the widest either type reaches.
 #[test]
 pub fn test_float_to_string_precision() {
     let source = r#"
@@ -5608,6 +5612,8 @@ pub fn test_float_to_string_precision() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the exponential text `to_string_exp` writes: the six places the format gives by default,
+/// and the widest exponent each type reaches -- two digits for `F32` and three for `F64`.
 #[test]
 pub fn test_float_to_string_exp() {
     let source = r#"
@@ -5638,6 +5644,8 @@ pub fn test_float_to_string_exp() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the exponential text `to_string_exp_precision` writes at precision 0, at 255, and for the
+/// widest `F32` and `F64`, whose exponent is the widest either type reaches.
 #[test]
 pub fn test_float_to_string_exp_precision() {
     let source = r#"
@@ -5880,6 +5888,8 @@ pub fn test_tarai_fast() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the text `to_string` writes for the infinities and the quiet NaN of each float type, and
+/// the bytes each type's quiet NaN carries.
 #[test]
 pub fn test_float_inf_nan() {
     let source = r##"
@@ -10972,8 +10982,9 @@ namespace Pipe {
     write = undefined("program running!");
 }
 
+// The regression needs this implementation to name its type variables `a` and `b`, the names
+// `Pipe`'s definition gives its parameters.
 impl Pipe a b: Monad {
-//impl Pipe x y: Monad {        // Ok if this line is used instead of the above line.
     pure = undefined("program running!");
     bind = undefined("program running!");
 }

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -4996,13 +4996,6 @@ pub fn test_trait_alias() {
             ))
         );
 
-        // Error (cannot implement trait alias directly)
-        // impl [a : Additive] Vector2 a : Additive {}
-
-        // Error (circular aliasing)
-        // trait MyTraitA = MyTraitB + ToString;
-        // trait MyTraitB = MyTraitA + Eq;
-
         main : IO ();
         main = (
             let sum_vec = [Vector2{x : 1, y : 2}, Vector2{x : 3, y : 4}].to_iter.sum;
@@ -7792,8 +7785,6 @@ pub fn test_range_step_1() {
     main : IO ();
     main = (
         assert_eq(|_|"A-2", Iterator::range_step(0, 10, -1).get_size, 0);;
-        // assert_eq(|_|"A-1", Iterator::range_step(0, 10, 0).take(100).get_size, 100);;
-        // assert_eq(|_|"A0", Iterator::range_step(0, 10, 0).take(100).get_size, 100);;
         assert_eq(|_|"A1", Iterator::range_step(0, 10, 1).to_array, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);;
         assert_eq(|_|"A2", Iterator::range_step(0, 10, 2).to_array, [0, 2, 4, 6, 8]);;
         assert_eq(|_|"A3", Iterator::range_step(0, 10, 3).to_array, [0, 3, 6, 9]);;
@@ -7821,8 +7812,6 @@ pub fn test_range_step_2() {
     main = (
 
         assert_eq(|_|"B2", Iterator::range_step(10, 0, 2).get_size, 0);;
-        // assert_eq(|_|"B1", Iterator::range_step(10, 0, 1).take(100).get_size, 100);;
-        // assert_eq(|_|"B0", Iterator::range_step(10, 0, 0).take(100).get_size, 100);;
         assert_eq(|_|"B-1", Iterator::range_step(10, 0, -1).to_array, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);;
         assert_eq(|_|"B-2", Iterator::range_step(10, 0, -2).to_array, [10, 8, 6, 4, 2]);;
         assert_eq(|_|"B-3", Iterator::range_step(10, 0, -3).to_array, [10, 7, 4, 1]);;
@@ -7836,7 +7825,6 @@ pub fn test_range_step_2() {
         assert_eq(|_|"B-11", Iterator::range_step(10, 0, -11).to_array, [10]);;
 
         assert_eq(|_|"C1", Iterator::range_step(0, 0, 1).get_size, 0);;
-        // assert_eq(|_|"C0", Iterator::range_step(0, 0, 0).get_size, 0);;
         assert_eq(|_|"C-1", Iterator::range_step(0, 0, -1).get_size, 0);;
 
         pure()
@@ -11023,7 +11011,7 @@ namespace Main {
 
 main: IO ();
 main = (
-    // assert_eq(|_|"", Main::x, 0);; // ambiguous
+    // `Main::x` names both of these values, so each is written out to say which one it is.
     assert_eq(|_|"", ::Main::x, 0);; // top-level `x`
     assert_eq(|_|"", Main::Main::x, 1);; // `Main::x` in `Main` namespace
     assert_eq(|_|"", ::Main::Main::x, 1);; // `Main::x` in `Main` namespace
@@ -11077,7 +11065,7 @@ namespace Main {
 
 main: IO ();
 main = (
-    // assert_eq(|_|"", 0 : X, 0);; // ambiguous
+    // `Main::X` names both of these types, so each is written out to say which one it is.
     assert_eq(|_|"", 0 : ::Main::X, 0);; // top-level `X`
     assert_eq(|_|"", 0 : Main::Main::X, 0);; // `Main::X` in `Main` namespace
     assert_eq(|_|"", 0 : ::Main::Main::X, 0);; // `Main::X` in `Main` namespace
@@ -11132,7 +11120,7 @@ namespace Main {
     }
 }
 
-// impl I64 : Foo { ... } // ambiguous
+// `Main::Foo` names both of these traits, so each implementation writes out which one it is.
 impl I64 : ::Main::Foo { // top-level `Foo`
     foo = |n| n + 1;
 }
@@ -11207,6 +11195,7 @@ namespace Main {
     trait Foo = Std::ToString;
 }
 
+// `Main::Foo` names the trait and the alias both, so each use writes out which one it is.
 impl I64 : ::Main::Foo { // top-level `Foo`
     foo = |n| n + 1;
 }
@@ -12257,7 +12246,6 @@ main = (
     let cma: ContT String IOFail String = do {
         let jmpbuf = *setjmp(0);
         let i = jmpbuf.@arg;
-        //eval *eprintln("i=" + i.to_string).lift.lift_t;
         if i < 5 { jmpbuf.longjmp(i + 1) };
         pure(i.to_string)
     };

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5542,6 +5542,35 @@ pub fn test_signed_integral_abs() {
 }
 
 #[test]
+pub fn test_float_to_string() {
+    let source = r#"
+        module Main;
+        main : IO ();
+        main = (
+            // The widest text this writes for a `F32`: the least one, whose whole part takes
+            // 39 digits, with a sign before it and the 6 places `%f` writes by default.
+            let widest = -3.4028235e38_F32;
+            assert_eq(|_|"the widest F32 text is a sign, 39 digits, a point and 6 places",
+                      widest.to_string, "-340282346638528859811704183484516925440.000000");;
+
+            // The widest text this writes for a `F64`: the least one, whose whole part takes
+            // 309 digits, with a sign before it and the 6 places `%f` writes by default.
+            let widest = -1.7976931348623157e308;
+            let text = widest.to_string;
+            assert_eq(|_|"the widest F64 text is a sign, 309 digits, a point and 6 places",
+                      text.@size, 1 + 309 + 1 + 6);;
+            assert_eq(|_|"the widest F64 text opens with the digits of the least F64",
+                      text.get_sub(0, 20), "-1797693134862315708");;
+            assert_eq(|_|"the widest F64 text ends in the places behind its point",
+                      text.get_sub(text.@size - 10, text.@size), "368.000000");;
+
+            pure()
+        );
+    "#;
+    test_source(&source, Configuration::develop_mode());
+}
+
+#[test]
 pub fn test_float_to_string_precision() {
     let source = r#"
         module Main; 
@@ -5594,7 +5623,19 @@ pub fn test_float_to_string_exp() {
 
             let x = -123.45_F64;
             assert_eq(|_|"case to_string_exp F64", x.to_string_exp, "-1.234500e+02");;
-        
+
+            // The widest text this writes for a `F32`: the least one, with a sign before it,
+            // the 6 places `%e` writes by default and a two-digit exponent.
+            let widest = -3.4028235e38_F32;
+            assert_eq(|_|"the widest F32 text is a sign, a digit, a point, 6 places and `e+38`",
+                      widest.to_string_exp, "-3.402823e+38");;
+
+            // The widest text this writes for a `F64`: the least one, with a sign before it,
+            // the 6 places `%e` writes by default and a three-digit exponent.
+            let widest = -1.7976931348623157e308;
+            assert_eq(|_|"the widest F64 text is a sign, a digit, a point, 6 places and `e+308`",
+                      widest.to_string_exp, "-1.797693e+308");;
+
             pure()
         );
     "#;

--- a/src/tests/test_float_text_buffer.rs
+++ b/src/tests/test_float_text_buffer.rs
@@ -1,0 +1,61 @@
+// The eight values that write a `F32` or a `F64` as text hand a buffer to the C runtime, which
+// writes into it with no length to stop at. Each buffer's size is derived from the widest text its
+// format can produce, and the derivation holds only if the widest whole part, the widest exponent
+// and the null terminator were all counted. A buffer short by even one byte writes past its
+// allocation, which the program itself cannot see: the overflowing bytes are readable afterwards,
+// so the text still comes back whole. Valgrind is what sees it.
+//
+// How far the check reaches depends on the size of the buffer. A storage of
+// `ARRAY_ALIGNED_ALLOC_THRESHOLD` bytes or more is allocated with `ARRAY_STORAGE_ALLOC_SLACK` bytes
+// of room to slide the object onto the buffer alignment, and a write a byte past such a buffer
+// lands in that room. `F64::to_string` and `F64::to_string_precision` always allocate more than the
+// threshold, so an error of a byte in their bounds passes here and one of `ARRAY_BUF_ALIGNMENT`
+// bytes or more is caught; for the other six, a byte is enough.
+
+#[cfg(test)]
+mod float_text_buffer_tests {
+    use crate::{
+        configuration::{Configuration, ValgrindTool},
+        misc::{function_name, platform_valgrind_supported},
+        tests::test_util::test_source,
+    };
+
+    #[test]
+    pub fn test_widest_text_fits_its_buffer() {
+        if !platform_valgrind_supported() {
+            eprintln!(
+                "Skipping {}: Valgrind not available on this platform.",
+                function_name!()
+            );
+            return;
+        }
+        let source = r#"
+module Main;
+
+main : IO () = (
+    // The least value of each type, whose whole part and exponent are the widest either type
+    // reaches, written to every precision the functions accept. Each buffer is therefore filled
+    // to the width its size was derived for.
+    let widest_f32 = -3.4028235e38_F32;
+    let widest_f64 = -1.7976931348623157e308;
+    let total = range(0, 256).fold(0, |p, total|
+        let prec = p.u8;
+        total + widest_f32.to_string_precision(prec).@size
+              + widest_f32.to_string_exp_precision(prec).@size
+              + widest_f64.to_string_precision(prec).@size
+              + widest_f64.to_string_exp_precision(prec).@size
+    );
+    // The four that take no precision write the 6 places their format gives by default.
+    let total = total + widest_f32.to_string.@size
+                      + widest_f32.to_string_exp.@size
+                      + widest_f64.to_string.@size
+                      + widest_f64.to_string_exp.@size;
+    assert_eq(|_|"the texts of every precision come to their known total", total, 224899);;
+    pure()
+);
+"#;
+        let mut config = Configuration::develop_mode();
+        config.set_valgrind(ValgrindTool::MemCheck);
+        test_source(source, config);
+    }
+}

--- a/src/tests/test_float_text_buffer.rs
+++ b/src/tests/test_float_text_buffer.rs
@@ -10,7 +10,12 @@
 // of room to slide the object onto the buffer alignment, and a write a byte past such a buffer
 // lands in that room. `F64::to_string` and `F64::to_string_precision` always allocate more than the
 // threshold, so an error of a byte in their bounds passes here and one of `ARRAY_BUF_ALIGNMENT`
-// bytes or more is caught; for the other six, a byte is enough.
+// bytes or more is caught. `F32::to_string`, `F32::to_string_exp` and `F64::to_string_exp` always
+// allocate less than the threshold, so a byte is enough for them. The remaining three,
+// `F32::to_string_precision`, `F32::to_string_exp_precision` and `F64::to_string_exp_precision`,
+// cross the threshold at the higher precisions, where a byte again lands in the slack; a byte in
+// their bounds is caught at the lower precisions, where the same size constant is exercised with
+// the storage under the threshold.
 
 #[cfg(test)]
 mod float_text_buffer_tests {
@@ -20,6 +25,9 @@ mod float_text_buffer_tests {
         tests::test_util::test_source,
     };
 
+    /// Writes the widest text each of the eight functions can produce -- the least value of each
+    /// type, at every precision they accept -- under Valgrind, so that a buffer sized short of
+    /// that text shows up as a write past its allocation.
     #[test]
     pub fn test_widest_text_fits_its_buffer() {
         if !platform_valgrind_supported() {


### PR DESCRIPTION
Refs #602

浮動小数を文字列にする 8 つの値は、C ランタイムに渡すバッファを自分で確保する。その大きさは根拠のない定数だった — `F64` はどれも 500、精度を取るものは 500 + 精度である。`%f` が `F64` に対して書きうる最も広いテキストは「符号 1 + 整数部 309 桁 + 小数点 1 + 精度の桁数 + 終端 1」なので、8 つとも、その書式が書きうる幅ちょうどに変えた。導出は定数のとなりに書いてある。

数値を多く書くプログラムはこの確保を数値 1 つにつき 1 回払う。LangArena の `Json::Generate` — 10,000 個の座標を持つ文書を 100 回書き、1 回につき約 40,000 個の数値を書く — で **3.194 秒から 2.787 秒 (-12.8%)** になる。

## 書式文字列を組み立てるのをやめた

精度を取る 4 つは、呼び出しごとに `sprintf` で書式文字列を作ってから、それでもう一度 `sprintf` していた。

```c
char specifier[8]; // len(%.255lf) + 1
sprintf(specifier, "%%.%" PRIu8 "lf", precision);
sprintf(buf, specifier, v);
```

C には精度を引数で渡す `%.*lf` があるので、`sprintf` は 1 回で済む。

## 書き込みをバッファの大きさで境界づけた

幅ちょうどに詰めると、導出が 1 バイトでも狂ったときに逃げ場が無くなる。`sprintf` は上限を取らないので確保の外へ書き、しかも**書いた先はそのまま読み戻せる**ので、プログラムは正しいテキストと壊れたヒープを持って動き続ける。

そこで 4 つのランタイム関数はバッファの大きさを受け取り、`snprintf` で書いて、収まらなければ止まる。利用者が見る文言は 2 つある。

```
A number's text takes 567 bytes and its buffer holds 566
```

```
Writing a number as text failed
```

前者は導出が足りなかったとき、後者は `snprintf` が負を返したとき — テキストを書けなかったとき — に出る。どちらも `Std` の実装の誤りを述べるもので、利用者のプログラムが引き起こせるものではない。

この境界検査の代償は、`Json::Generate` で命令数 +0.55%、サイクル +1.56% である。バッファを詰めた分の利得 -14.2% のうち 1.6% を戻して -12.8% になる勘定になる。

## 既定の精度で書く 4 つを、精度を取る 4 つの上に置いた

C は `%f` と `%e` の既定の精度を 6 と定めるので、`%lf` と精度 6 の `%.*lf` は同じ呼び出しである。既定で書く 4 つは、それぞれの相手を 6 で呼ぶだけになった。

```fix
impl F64 : ToString {
    to_string = |v| v.to_string_precision(6_U8);
}
```

これでランタイム関数が 8 本から 4 本になり、`309` と `39` という桁数がそれぞれ 2 か所に書かれていたのが 1 か所になる。出力はバイト単位で同じで、`test_float_inf_nan` を含む既存のテストがそれを押さえている。

## 各項目の説明

差分が触れる項目ごとの説明は、この pull request のコメントに置いた。

## テスト

### `test_widest_text_fits_its_buffer` (`src/tests/test_float_text_buffer.rs`、新規)

8 つの値それぞれに、その型の最小の値を、受け付ける精度すべて (0 から 255) で書かせる。各バッファがその大きさの導出どおりの幅で埋まる。

**この変更が無いときの振る舞い**: 変更前のバッファには 188 バイトの余裕があったので、このテストは何も測らない。**変更後にどれかのバッファを 1 バイト縮めると赤くなる** — 4 つとも、`A number's text takes N bytes and its buffer holds N-1` を出してプログラムが止まる。

この「4 つとも」は境界検査が入って初めて成り立つ。検査が無く valgrind に頼っていたときは、`F64::to_string_precision` の 1 バイトの誤りは**原理的に見えなかった**。`ARRAY_ALIGNED_ALLOC_THRESHOLD` (256 バイト) 以上の記憶域は `ARRAY_STORAGE_ALLOC_SLACK` (31 バイト) の余地を持つ確保になり、このバッファは常に 312 バイト以上なので、1 バイトのはみ出しがその余地に収まってしまう。

### `test_float_to_string` (`src/tests/test_basic.rs`、新規)

`to_string` が最小の `F32` と `F64` に対して書くテキストの幅を固定する。`F32` は符号 + 39 桁 + 小数点 + 6 桁 = 47 文字、`F64` は 317 文字。

**この変更が無いときの振る舞い**: 通る。この 2 つの幅は変更前も同じである。押さえているのは、バッファの大きさがその上に立っている 2 つの事実 — 整数部の桁数と、書式の既定の精度が 6 であること。**`runtime.c` の `%f` を `%.7f` に変えると赤くなる。**

### `test_float_to_string_precision` / `test_float_to_string_exp_precision` (`src/tests/test_basic.rs`、既存に追加)

最小の値を精度 255 で書いたテキストの幅と、その先頭 20 文字・末尾 6 文字を固定する。`F64` の固定小数は 566 文字、指数形式は 263 文字。

**この変更が無いときの振る舞い**: 通る。上と同じく、押さえているのは幅の導出であってバッファではない。

### `test_float_to_string_exp` (`src/tests/test_basic.rs`、既存に追加)

`to_string_exp` が最小の値に対して書くテキストを固定する。`F32` は `-3.402823e+38`、`F64` は `-1.797693e+308`。指数の桁数 (`F32` は 2、`F64` は 3) がバッファの根拠なので、そこを押さえる。

**この変更が無いときの振る舞い**: 通る。**`%e` を `%.7e` に変えると赤くなる。**

## 確かめたこと

- 全テスト 1,682 本が緑
- 8 つの上限を C で走査 — 精度 0..255 の全域、`±DBL_MAX`、`±DBL_MIN`、非正規化数、無限大、NaN。溢れゼロ、8 つとも余裕ゼロ (付録)
- 停止の文言を実際に出させた (付録)

## 付録

### 上限の走査

glibc に対し、8 つの書式それぞれを極値 × 精度 0..255 で走らせ、`strlen + 1` を上限と突き合わせた。

```
f64 fixed        len=566   bound=567   spare=0
f64 exp          len=263   bound=264   spare=0
f32 fixed        len=296   bound=297   spare=0
f32 exp          len=262   bound=264   spare=1
f32 to_string        widest text 47   bound 48   spare 0
f32 to_string_exp    widest text 13   bound 14   spare 0
f64 to_string        widest text 317  bound 318  spare 0
f64 to_string_exp    widest text 14   bound 15   spare 0
over = 0
```

`F32` の指数形式だけ 1 バイト余るのは、その指数が 2 桁 (最小の非正規化数で `1e-45`) までだからである。`F64` は 3 桁 (`5e-324`) まで届く。

### 停止の文言

`F64::to_string_precision` のバッファを 1 バイト縮めて、最小の `F64` を精度 255 で書かせた。

```
$ ./q
A number's text takes 567 bytes and its buffer holds 566
Aborted (core dumped)
```

### 測定

同じ機械で、`before` (main) と `after` を交互に 5 回ずつ走らせた中央値。

| | main | 詰めただけ | この pull request |
|---|---|---|---|
| `Json::Generate` 時間 | 3.194s | 2.742s | **2.787s** |
| 命令数 | 48.119G | 42.107G | 42.338G |
| サイクル | 17.275G | 14.481G | 14.707G |
| `Json::ParseDom` 時間 | 2.229s | 2.178s | 2.218s |
| `Json::ParseMapping` 時間 | 5.774s | 5.865s | 5.833s |

`Json::ParseMapping` の +1.0% は、命令数が -0.03% でサイクルが +1.1% なので、仕事ではなくヒープの配置である。`to_string_precision(8)` の確保が 508 バイトから 320 バイトになって malloc の size class が変わり、その後の読み込みが使うヒープの並びが動く。同じ読み込みコードを使う `Json::ParseDom` が -0.5% と逆向きに出るのも同じ理由である。

### 残した指摘

- **整数とポインタの `to_string` にも同じ境界検査を広げるか。** 9 つのバッファが同じ形 (幅ちょうど + `sprintf`) で、幅はすべて検算済みで正しい。広げるかどうかは費用の問題で、`I64::to_string` は浮動小数より呼ばれる回数がずっと多い。上の +1.56% がその見積もりの材料になる。
- **`F32` と `F64` のランタイム関数を 1 本ずつにするか。** `%.*e` と `%.*le` は同じ呼び出しで (`l` は `e`/`f`/`g` に効かず、`float` は可変引数で `double` に昇格する)、4 本を 2 本にできる。型付きの FFI 宣言が Fix 側の型と一致している利点と引き換えになる。
