### PR TITLE
レビュー清掃 (#605): コメントアウトされたコードを消し、導出とテストの主題を書く

### DIFF
--- a/src/fixstd/runtime.c
+++ b/src/fixstd/runtime.c
@@ -327,12 +327,6 @@ __attribute__((noreturn)) void fixruntime_array_size_overflow(int64_t size)
     fixruntime_abort();
 }
 
-// void fixruntime_union_variant_mismatch(uint8_t expected, uint8_t actual)
-// {
-//     fprintf(stderr, "Union variant mismatch: expected=%" PRIu8 ", actual=%" PRIu8 "\n", expected, actual);
-//     fixruntime_abort();
-// }
-
 #if defined(BACKTRACE)
 #if defined(__linux__)
 #include <backtrace.h>

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -3829,7 +3829,7 @@ namespace Ptr {
 
 impl Ptr : ToString {
     to_string = |v| (
-        let data = Array::empty(17);
+        let data = Array::empty(17); // len(ffffffffffffffff) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_ptr_to_str(Ptr, Ptr), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -3903,7 +3903,7 @@ impl U32 : FromBytes {
 }
 impl U32 : ToString {
     to_string = |v| (
-        let data = Array::empty(11);
+        let data = Array::empty(11); // len(4294967295) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_u32_to_str(Ptr, U32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -3929,7 +3929,7 @@ impl U64 : FromBytes {
 }
 impl U64 : ToString {
     to_string = |v| (
-        let data = Array::empty(21);
+        let data = Array::empty(21); // len(18446744073709551615) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_u64_to_str(Ptr, U64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4016,7 +4016,7 @@ impl I32 : FromBytes {
 }
 impl I32 : ToString {
     to_string = |v| (
-        let data = Array::empty(12);
+        let data = Array::empty(12); // len(-2147483648) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_i32_to_str(Ptr, I32), ptr, v]);
         String::_unsafe_from_c_str(data)
     );
@@ -4042,7 +4042,7 @@ impl I64 : FromBytes {
 }
 impl I64 : ToString {
     to_string = |v| (
-        let data = Array::empty(21);
+        let data = Array::empty(21); // len(-9223372036854775808) + 1
         let (data, _) = data.mutate_elements(|ptr| FFI_CALL_IO[() fixruntime_i64_to_str(Ptr, I64), ptr, v]);
         String::_unsafe_from_c_str(data)
     );

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -5510,6 +5510,8 @@ pub fn test_consumed_time_fast() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Verifies that `abs` carries a negative value to its magnitude and leaves a positive one
+/// alone, at each of the signed integer types.
 #[test]
 pub fn test_signed_integral_abs() {
     let source = r#"
@@ -5566,6 +5568,8 @@ pub fn test_float_to_string() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the text `to_string_precision` writes at precision 0, at 255, and for the widest `F32`
+/// and `F64`, whose whole part is the widest either type reaches.
 #[test]
 pub fn test_float_to_string_precision() {
     let source = r#"
@@ -5608,6 +5612,8 @@ pub fn test_float_to_string_precision() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the exponential text `to_string_exp` writes: the six places the format gives by default,
+/// and the widest exponent each type reaches -- two digits for `F32` and three for `F64`.
 #[test]
 pub fn test_float_to_string_exp() {
     let source = r#"
@@ -5638,6 +5644,8 @@ pub fn test_float_to_string_exp() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the exponential text `to_string_exp_precision` writes at precision 0, at 255, and for the
+/// widest `F32` and `F64`, whose exponent is the widest either type reaches.
 #[test]
 pub fn test_float_to_string_exp_precision() {
     let source = r#"
@@ -5880,6 +5888,8 @@ pub fn test_tarai_fast() {
     test_source(&source, Configuration::develop_mode());
 }
 
+/// Pins the text `to_string` writes for the infinities and the quiet NaN of each float type, and
+/// the bytes each type's quiet NaN carries.
 #[test]
 pub fn test_float_inf_nan() {
     let source = r##"
@@ -10972,8 +10982,9 @@ namespace Pipe {
     write = undefined("program running!");
 }
 
+// The regression needs this implementation to name its type variables `a` and `b`, the names
+// `Pipe`'s definition gives its parameters.
 impl Pipe a b: Monad {
-//impl Pipe x y: Monad {        // Ok if this line is used instead of the above line.
     pure = undefined("program running!");
     bind = undefined("program running!");
 }

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -4996,13 +4996,6 @@ pub fn test_trait_alias() {
             ))
         );
 
-        // Error (cannot implement trait alias directly)
-        // impl [a : Additive] Vector2 a : Additive {}
-
-        // Error (circular aliasing)
-        // trait MyTraitA = MyTraitB + ToString;
-        // trait MyTraitB = MyTraitA + Eq;
-
         main : IO ();
         main = (
             let sum_vec = [Vector2{x : 1, y : 2}, Vector2{x : 3, y : 4}].to_iter.sum;
@@ -7792,8 +7785,6 @@ pub fn test_range_step_1() {
     main : IO ();
     main = (
         assert_eq(|_|"A-2", Iterator::range_step(0, 10, -1).get_size, 0);;
-        // assert_eq(|_|"A-1", Iterator::range_step(0, 10, 0).take(100).get_size, 100);;
-        // assert_eq(|_|"A0", Iterator::range_step(0, 10, 0).take(100).get_size, 100);;
         assert_eq(|_|"A1", Iterator::range_step(0, 10, 1).to_array, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);;
         assert_eq(|_|"A2", Iterator::range_step(0, 10, 2).to_array, [0, 2, 4, 6, 8]);;
         assert_eq(|_|"A3", Iterator::range_step(0, 10, 3).to_array, [0, 3, 6, 9]);;
@@ -7821,8 +7812,6 @@ pub fn test_range_step_2() {
     main = (
 
         assert_eq(|_|"B2", Iterator::range_step(10, 0, 2).get_size, 0);;
-        // assert_eq(|_|"B1", Iterator::range_step(10, 0, 1).take(100).get_size, 100);;
-        // assert_eq(|_|"B0", Iterator::range_step(10, 0, 0).take(100).get_size, 100);;
         assert_eq(|_|"B-1", Iterator::range_step(10, 0, -1).to_array, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);;
         assert_eq(|_|"B-2", Iterator::range_step(10, 0, -2).to_array, [10, 8, 6, 4, 2]);;
         assert_eq(|_|"B-3", Iterator::range_step(10, 0, -3).to_array, [10, 7, 4, 1]);;
@@ -7836,7 +7825,6 @@ pub fn test_range_step_2() {
         assert_eq(|_|"B-11", Iterator::range_step(10, 0, -11).to_array, [10]);;
 
         assert_eq(|_|"C1", Iterator::range_step(0, 0, 1).get_size, 0);;
-        // assert_eq(|_|"C0", Iterator::range_step(0, 0, 0).get_size, 0);;
         assert_eq(|_|"C-1", Iterator::range_step(0, 0, -1).get_size, 0);;
 
         pure()
@@ -11023,7 +11011,7 @@ namespace Main {
 
 main: IO ();
 main = (
-    // assert_eq(|_|"", Main::x, 0);; // ambiguous
+    // `Main::x` names both of these values, so each is written out to say which one it is.
     assert_eq(|_|"", ::Main::x, 0);; // top-level `x`
     assert_eq(|_|"", Main::Main::x, 1);; // `Main::x` in `Main` namespace
     assert_eq(|_|"", ::Main::Main::x, 1);; // `Main::x` in `Main` namespace
@@ -11077,7 +11065,7 @@ namespace Main {
 
 main: IO ();
 main = (
-    // assert_eq(|_|"", 0 : X, 0);; // ambiguous
+    // `Main::X` names both of these types, so each is written out to say which one it is.
     assert_eq(|_|"", 0 : ::Main::X, 0);; // top-level `X`
     assert_eq(|_|"", 0 : Main::Main::X, 0);; // `Main::X` in `Main` namespace
     assert_eq(|_|"", 0 : ::Main::Main::X, 0);; // `Main::X` in `Main` namespace
@@ -11132,7 +11120,7 @@ namespace Main {
     }
 }
 
-// impl I64 : Foo { ... } // ambiguous
+// `Main::Foo` names both of these traits, so each implementation writes out which one it is.
 impl I64 : ::Main::Foo { // top-level `Foo`
     foo = |n| n + 1;
 }
@@ -11207,6 +11195,7 @@ namespace Main {
     trait Foo = Std::ToString;
 }
 
+// `Main::Foo` names the trait and the alias both, so each use writes out which one it is.
 impl I64 : ::Main::Foo { // top-level `Foo`
     foo = |n| n + 1;
 }
@@ -12257,7 +12246,6 @@ main = (
     let cma: ContT String IOFail String = do {
         let jmpbuf = *setjmp(0);
         let i = jmpbuf.@arg;
-        //eval *eprintln("i=" + i.to_string).lift.lift_t;
         if i < 5 { jmpbuf.longjmp(i + 1) };
         pure(i.to_string)
     };


### PR DESCRIPTION
`f64-to-string-precision` のコードレビューが、その変更の外側で見つけたものを直す。すべて散文の追加とコメントアウトされたコードの削除で、プログラムが計算するものは変わらない。base はレビュー対象のブランチなので、そちらが読まれてから取り込める。

## コメントアウトされたコードを消した

**`src/fixstd/runtime.c`**: `fixruntime_union_variant_mismatch` が関数まるごとコメントアウトされたまま残っていた。

**`src/tests/test_basic.rs`**: 6 か所。

- `test_trait_alias` の、トレイトエイリアスを直接実装する誤りと循環エイリアスの例 2 つ。どちらも専用のテストがあり、診断の文言を含めて押さえている (`A trait alias cannot be implemented directly.` と `Circular aliasing detected in trait alias` を検査するもの)。
- `test_range_step_1` / `test_range_step_2` の、刻み幅 0 に対する表明 5 つ。いまの `range_step` は刻み幅 0 で `undefined` に落ちる。
- `test_setjmp` のデバッグ出力 1 行。

### 消さずに散文へ書き換えたもの

3 か所は、コメントアウトされた行がそのテストの主題を述べる唯一の記述だった。消すと、テストの名前が指すものが本文のどこにも書かれていない状態になる。

- `test_ambiguous_namespace_value` / `_type` / `_trait`: `// assert_eq(|_|"", Main::x, 0);; // ambiguous` の類。これらのテストは短い形が 2 つのものを指すことを主題にしているのに、本文には**曖昧でない形の表明しか無い**。「`Main::x` はこの 2 つの値のどちらも指すので、どちらであるかを言うために書き下してある」という一文にした。
- `test_regression_issue_54`: `//impl Pipe x y: Monad { // Ok if this line is used instead of the above line.` が、この回帰テストが型変数を `a` `b` と名づけたままにしなければならないことを述べる唯一の記述だった。「この回帰は、この実装が型変数を `a` と `b` — `Pipe` の定義がその引数に与える名前 — と名づけていることを要する」という一文にした。

## バッファの大きさの導出を書き足した

`src/fixstd/std.fix` の整数とポインタの `to_string` は、どれも「最も長い表記 + 終端」ちょうどのバッファを取る。`U8` / `U16` / `I8` / `I16` には `// len(255) + 1` の形の導出が書かれていたが、`Ptr` / `U32` / `U64` / `I32` / `I64` には無かった。同じ形で書き足した。

```diff
-        let data = Array::empty(21);
+        let data = Array::empty(21); // len(-9223372036854775808) + 1
```

幅はすべて検算した — Ptr 17、U8 4、U16 6、U32 11、U64 21、I8 5、I16 7、I32 12、I64 21。どれも正しく、短いものは無い。

## テストが何を押さえているかを書き足した

`src/tests/test_basic.rs` の 5 つに `///` を付けた。

- `test_float_to_string_precision`、`test_float_to_string_exp`、`test_float_to_string_exp_precision` — 変更が本文に触れたもの。
- `test_float_inf_nan`、`test_signed_integral_abs` — その隣にあるもの。

## 残した指摘

- `src/tests/test_basic.rs` の 503 個の `#[test]` のうち 344 個にはまだ `///` が無い。この変更の近傍をはるかに超えるので、それ自体を 1 つの作業にするのが筋である。
- `src/fixstd/std.fix` の doc コメントは `std_doc/Std.md` を生成する元なので、そこに書き足すと生成物が古くなる。コメントだけの pass で作ってよい結合ではないので、`F32::abs` / `F64::abs` など doc コメントの無い公開値には手を付けていない。
- `src/fixstd/runtime.c` の整数の `to_str` 群の上にある `// NOTE: Maybe should we define following functions by LLVM to better optimization opportunity?` は、コードを説明するのでなく設計の問いを立てている。残すかどうかは作者の判断。

レビューはこのほかに、利用者に届く既存の欠陥を 1 件見つけた。清掃ではないので #604 に分けてある。
