### PR TITLE
モナドを通るループが反復ごとにクロージャを確保するのをやめる

### DIFF
--- a/src/optimization/application_inlining.rs
+++ b/src/optimization/application_inlining.rs
@@ -51,10 +51,17 @@ use crate::ast::{
         AppSourceCodeOrderType, Expr, ExprNode,
     },
     pattern::PatternNode,
-    program::Symbol,
+    program::{Program, Symbol},
     traverse::{EndVisitResult, ExprVisitor, StartVisitResult, VisitState},
 };
 use std::sync::Arc;
+
+/// Optimizes every symbol of `prg` in place.
+pub fn run(prg: &mut Program) {
+    for (_name, sym) in &mut prg.symbols {
+        run_on_symbol(sym);
+    }
+}
 
 /// Optimizes the expression of a symbol in place. The symbol has to be one that already has an
 /// expression.
@@ -155,12 +162,16 @@ impl ExprVisitor for AppInliner {
         match &*func.expr {
             Expr::Lam(params, body) => {
                 // The expression is of the form `(|x| {expr})({a})`.
-                // Replace it with `let x = {a} in {expr}`. A lambda uncurrying has rewritten takes
-                // its parameters together, and the call to it takes them together as well, so it
-                // does not reach here with one argument.
-                if params.len() != 1 {
-                    return EndVisitResult::unchanged(expr);
-                }
+                // Replace it with `let x = {a} in {expr}`. A lambda of many parameters is built by
+                // uncurrying alone, as the body of a `#funptr` symbol, and every call uncurrying
+                // rewrites onto one names it outright, so it does not reach an application of one
+                // argument.
+                assert_eq!(
+                    params.len(),
+                    1,
+                    "a lambda of {} parameters reached application inlining",
+                    params.len()
+                );
                 let param = &params[0];
                 let pat = PatternNode::make_var(param.clone(), None)
                     .set_type(arg.type_.as_ref().unwrap().clone());

--- a/src/optimization/application_inlining.rs
+++ b/src/optimization/application_inlining.rs
@@ -142,15 +142,12 @@ impl ExprVisitor for AppInliner {
     /// moves inward is rewritten in turn.
     fn end_visit_app(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         // Get the argument of the application. An application carries one argument until uncurrying
-        // rewrites call sites onto function pointers, which happens after every pass that runs this
-        // one.
+        // rewrites the call onto a function pointer, and a call it has rewritten names the function
+        // outright, so there is nothing to move an argument into.
         let args = expr.get_app_args();
-        assert_eq!(
-            args.len(),
-            1,
-            "an application of {} arguments reached application inlining",
-            args.len()
-        );
+        if args.len() != 1 {
+            return EndVisitResult::unchanged(expr);
+        }
         let arg = args[0].clone();
 
         // Get the function applied to the argument.
@@ -158,13 +155,12 @@ impl ExprVisitor for AppInliner {
         match &*func.expr {
             Expr::Lam(params, body) => {
                 // The expression is of the form `(|x| {expr})({a})`.
-                // Replace it with `let x = {a} in {expr}`.
-                assert_eq!(
-                    params.len(),
-                    1,
-                    "a lambda of {} parameters reached application inlining",
-                    params.len()
-                );
+                // Replace it with `let x = {a} in {expr}`. A lambda uncurrying has rewritten takes
+                // its parameters together, and the call to it takes them together as well, so it
+                // does not reach here with one argument.
+                if params.len() != 1 {
+                    return EndVisitResult::unchanged(expr);
+                }
                 let param = &params[0];
                 let pat = PatternNode::make_var(param.clone(), None)
                     .set_type(arg.type_.as_ref().unwrap().clone());

--- a/src/optimization/mod.rs
+++ b/src/optimization/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod application_inlining;
+mod application_inlining;
 mod capture_struct;
 mod closure_specialization;
 mod collapse_constructions;

--- a/src/optimization/mod.rs
+++ b/src/optimization/mod.rs
@@ -1,4 +1,4 @@
-mod application_inlining;
+pub(crate) mod application_inlining;
 mod capture_struct;
 mod closure_specialization;
 mod collapse_constructions;

--- a/src/optimization/optimization.rs
+++ b/src/optimization/optimization.rs
@@ -140,18 +140,18 @@ pub fn run(prg: &mut Program, config: &Configuration) {
     // Push an application into the branches of what produces the function. Specializing a closure
     // puts the body of the function a caller passed into the caller, so a body answering with a
     // lambda leaves an application whose function is an `if`, and the lambda of the branch taken is
-    // built at run time. The pass that flattens that shape runs inside inlining, which is above
-    // specialization, so it has to be run again here.
+    // built at run time.
+    //
+    // It runs below uncurrying because that is what brings the application and the `if` into one
+    // scope: above it, the application sits inside a lambda the `if` is outside of, and the pass
+    // finds nothing to move. Uncurrying's eta expansion is what closes that gap, by binding the
+    // action to a name and folding the name into its one use.
     run_pass(
         prg,
         config,
-        config.enable_closure_specialization(),
+        config.enable_closure_specialization() && config.enable_uncurry_optimization(),
         "application_inlining",
-        |prg| {
-            for sym in prg.symbols.values_mut() {
-                application_inlining::run_on_symbol(sym);
-            }
-        },
+        application_inlining::run,
     );
 
     run_pass(

--- a/src/optimization/optimization.rs
+++ b/src/optimization/optimization.rs
@@ -1,7 +1,7 @@
 use super::{
-    closure_specialization, collapse_constructions, dead_symbol_elimination, defunctionalize_fix,
-    inline, inline_local, optimize_act, remove_tyanno, simplify_symbol_names, skip_eval,
-    split_struct_args, uncurry, unwrap_newtype,
+    application_inlining, closure_specialization, collapse_constructions, dead_symbol_elimination,
+    defunctionalize_fix, inline, inline_local, optimize_act, remove_tyanno, simplify_symbol_names,
+    skip_eval, split_struct_args, uncurry, unwrap_newtype,
 };
 use crate::{ast::program::Program, configuration::Configuration, tool::stopwatch::StopWatch};
 
@@ -135,6 +135,23 @@ pub fn run(prg: &mut Program, config: &Configuration) {
         config.enable_uncurry_optimization(),
         "uncurry",
         uncurry::run,
+    );
+
+    // Push an application into the branches of what produces the function. Specializing a closure
+    // puts the body of the function a caller passed into the caller, so a body answering with a
+    // lambda leaves an application whose function is an `if`, and the lambda of the branch taken is
+    // built at run time. The pass that flattens that shape runs inside inlining, which is above
+    // specialization, so it has to be run again here.
+    run_pass(
+        prg,
+        config,
+        config.enable_closure_specialization(),
+        "application_inlining",
+        |prg| {
+            for sym in prg.symbols.values_mut() {
+                application_inlining::run_on_symbol(sym);
+            }
+        },
     );
 
     run_pass(

--- a/src/optimization/optimization.rs
+++ b/src/optimization/optimization.rs
@@ -137,6 +137,14 @@ pub fn run(prg: &mut Program, config: &Configuration) {
         uncurry::run,
     );
 
+    run_pass(
+        prg,
+        config,
+        config.enable_dead_symbol_elimination(),
+        "dead_symbol_elimination",
+        dead_symbol_elimination::run,
+    );
+
     // Push an application into the branches of what produces the function. Specializing a closure
     // puts the body of the function a caller passed into the caller, so a body answering with a
     // lambda leaves an application whose function is an `if`, and the lambda of the branch taken is
@@ -152,14 +160,6 @@ pub fn run(prg: &mut Program, config: &Configuration) {
         config.enable_closure_specialization() && config.enable_uncurry_optimization(),
         "application_inlining",
         application_inlining::run,
-    );
-
-    run_pass(
-        prg,
-        config,
-        config.enable_dead_symbol_elimination(),
-        "dead_symbol_elimination",
-        dead_symbol_elimination::run,
     );
 
     if config.emit_symbols {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -69,6 +69,7 @@ mod test_shared_boxed_swap;
 mod test_signal;
 mod test_simplify;
 mod test_skip_eval;
+mod test_split_struct_args;
 mod test_string;
 mod test_struct_destructure;
 mod test_struct_literal;

--- a/src/tests/test_application_inlining.rs
+++ b/src/tests/test_application_inlining.rs
@@ -7,7 +7,9 @@
 #[cfg(test)]
 mod tests {
     use crate::configuration::Configuration;
-    use crate::tests::test_util::{build_within_and_run, test_source, test_source_fail};
+    use crate::tests::test_util::{
+        build_run_and_read_rc_ir, build_within_and_run, test_source, test_source_fail,
+    };
     use std::time::Duration;
 
     /// The argument `x` of `(let x = ..; ..)(x)` denotes the outer `x` after the application is
@@ -673,6 +675,93 @@ mod tests {
             source,
             Configuration::develop_mode(),
             "Array storage is not unique",
+        );
+    }
+
+    /// A state monad whose `bind` threads a counter, looped over with `Std::loop_m`.
+    ///
+    /// `loop_m` answers with an action of the monad it loops in, so each round of it hands `bind`
+    /// the action the body produced. Specializing the closure the body is puts that body into
+    /// `loop_m`, where it answers with a lambda under each arm of an `if`, and the application of
+    /// that lambda to the state is what has to reach the arms.
+    const MONADIC_LOOP: &str = r#"
+        module Main;
+
+        type St a = unbox struct { _run : I64 -> (a, I64) };
+
+        namespace St {
+            run : I64 -> St a -> (a, I64);
+            run = |s, m| (m.@_run)(s);
+        }
+
+        impl St : Functor {
+            map = |f, m| St { _run : |s| let (v, s) = m.run(s); (f(v), s) };
+        }
+
+        impl St : Monad {
+            pure = |v| St { _run : |s| (v, s) };
+            bind = |f, m| St { _run : |s| let (v, s) = m.run(s); f(v).run(s) };
+        }
+
+        _tick : St I64;
+        _tick = St { _run : |s| (s, s + 1) };
+
+        main : IO () = (
+            let counting = loop_m((0, 0), |(i, total)|
+                if i == 100 { break_m $ total };
+                let v = *_tick;
+                continue_m $ (i + 1, total + v)
+            );
+            let (total, _) = counting.St::run(0);
+            println(total.to_string)
+        );
+    "#;
+
+    /// What `MONADIC_LOOP` prints: the sum of `0..99`.
+    const MONADIC_LOOP_OUTPUT: &str = "4950";
+
+    /// The body of the function in `dump` whose name carries `name_part`, from its signature to
+    /// the line before the next function's.
+    fn function_body<'a>(dump: &'a str, name_part: &str) -> &'a str {
+        let start = dump
+            .match_indices(
+                "
+fn ",
+            )
+            .find(|(at, _)| dump[at + 1..].lines().next().unwrap().contains(name_part))
+            .map(|(at, _)| at + 1)
+            .unwrap_or_else(|| panic!("the dump names no function carrying `{}`", name_part));
+        let rest = &dump[start..];
+        let end = rest[1..]
+            .find(
+                "
+fn ",
+            )
+            .map(|at| at + 1)
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    /// A loop through a monad builds no closure: `loop_m` hands the state to the action its body
+    /// answered with, and that application reaches the arms of the `if` the body ends in, so the
+    /// lambda of the arm taken is never built. Left unreached, it is one heap allocation per round
+    /// of the loop.
+    ///
+    /// The dump is what this asserts against because the program cannot observe it: the loop
+    /// answers the same either way.
+    #[test]
+    fn test_a_loop_through_a_monad_builds_no_closure() {
+        let dump = build_run_and_read_rc_ir(
+            MONADIC_LOOP,
+            "max",
+            MONADIC_LOOP_OUTPUT,
+            "a state monad looped over with `loop_m`",
+        );
+        let body = function_body(&dump, "Std::loop_m");
+        assert!(
+            !body.contains("= closure "),
+            "the loop should build no closure, but its body is:\n{}",
+            body
         );
     }
 }

--- a/src/tests/test_application_inlining.rs
+++ b/src/tests/test_application_inlining.rs
@@ -8,7 +8,8 @@
 mod tests {
     use crate::configuration::Configuration;
     use crate::tests::test_util::{
-        build_run_and_read_rc_ir, build_within_and_run, test_source, test_source_fail,
+        build_run_and_read_rc_ir, build_within_and_run, rc_ir_function_bodies, test_source,
+        test_source_fail,
     };
     use std::time::Duration;
 
@@ -720,26 +721,34 @@ mod tests {
     /// What `MONADIC_LOOP` prints: the sum of `0..99`.
     const MONADIC_LOOP_OUTPUT: &str = "4950";
 
-    /// The body of the function in `dump` whose name carries `name_part`, from its signature to
-    /// the line before the next function's.
-    fn function_body<'a>(dump: &'a str, name_part: &str) -> &'a str {
-        let start = dump
-            .match_indices(
-                "
-fn ",
-            )
-            .find(|(at, _)| dump[at + 1..].lines().next().unwrap().contains(name_part))
-            .map(|(at, _)| at + 1)
-            .unwrap_or_else(|| panic!("the dump names no function carrying `{}`", name_part));
-        let rest = &dump[start..];
-        let end = rest[1..]
-            .find(
-                "
-fn ",
-            )
-            .map(|at| at + 1)
-            .unwrap_or(rest.len());
-        &rest[..end]
+    /// Asserts that `dump` holds the loop of `Std::loop_m`, and that no copy of it builds a
+    /// closure.
+    ///
+    /// The call the loop makes to itself is asserted alongside the closure's absence, so that a
+    /// build where the loop no longer lives in `Std::loop_m` fails here rather than reading a
+    /// function that has nothing left to build.
+    fn assert_loop_m_builds_no_closure(dump: &str) {
+        let bodies = rc_ir_function_bodies(dump, "Std::loop_m");
+        assert!(
+            !bodies.is_empty(),
+            "the dump names no `Std::loop_m`:\n{}",
+            dump
+        );
+        assert!(
+            bodies.iter().any(|body| body
+                .lines()
+                .skip(1)
+                .any(|line| line.contains("Std::loop_m"))),
+            "no `Std::loop_m` calls itself, so the loop this pins is not in the dump:\n{}",
+            bodies.join("\n")
+        );
+        for body in &bodies {
+            assert!(
+                !body.contains("= closure "),
+                "the loop should build no closure, but its body is:\n{}",
+                body
+            );
+        }
     }
 
     /// A loop through a monad builds no closure: `loop_m` hands the state to the action its body
@@ -757,11 +766,61 @@ fn ",
             MONADIC_LOOP_OUTPUT,
             "a state monad looped over with `loop_m`",
         );
-        let body = function_body(&dump, "Std::loop_m");
-        assert!(
-            !body.contains("= closure "),
-            "the loop should build no closure, but its body is:\n{}",
-            body
+        assert_loop_m_builds_no_closure(&dump);
+    }
+
+    /// A loop in `IO`, performing an action each round, written the way `Std::loop_m` documents
+    /// itself.
+    ///
+    /// `IO` reaches the shape by a route of its own: `IO a` is a one-field unboxed struct over
+    /// `IOState -> (IOState, a)`, which unwrapping opens into that function type, and the loop
+    /// threads the `IOState` through each round.
+    const IO_LOOP: &str = r#"
+        module Main;
+
+        main : IO () = (
+            let total = *loop_m((0, 0), |(i, total)|
+                if i == 3 { break_m $ total };
+                println("round " + i.to_string);;
+                continue_m $ (i + 1, total + i)
+            );
+            println(total.to_string)
         );
+    "#;
+
+    /// What `IO_LOOP` prints: a line per round, then the sum of `0..2`.
+    const IO_LOOP_OUTPUT: &str = "round 0\nround 1\nround 2\n3";
+
+    /// A loop in `IO` builds no closure either, which is what `Std` itself pays: `read_string` and
+    /// `get_args` both loop this way.
+    #[test]
+    fn test_a_loop_in_io_builds_no_closure() {
+        let dump = build_run_and_read_rc_ir(
+            IO_LOOP,
+            "max",
+            IO_LOOP_OUTPUT,
+            "an `IO` action looped over with `loop_m`",
+        );
+        assert_loop_m_builds_no_closure(&dump);
+    }
+
+    /// The answer of a loop through a monad does not depend on the optimization level. The pass
+    /// that flattens the application into the arms runs at `-O max` alone, so the levels below it
+    /// are what says the flattening leaves the answer where it was.
+    #[test]
+    fn test_a_loop_through_a_monad_answers_the_same_at_every_level() {
+        for opt_level in ["none", "basic", "max"] {
+            assert_eq!(
+                build_within_and_run(
+                    MONADIC_LOOP,
+                    opt_level,
+                    Duration::from_secs(600),
+                    "a state monad looped over with `loop_m`",
+                ),
+                MONADIC_LOOP_OUTPUT,
+                "the loop should answer the same at -O {}",
+                opt_level
+            );
+        }
     }
 }

--- a/src/tests/test_split_struct_args.rs
+++ b/src/tests/test_split_struct_args.rs
@@ -1,0 +1,77 @@
+// A global whose struct argument is split into its fields hands those fields over under the names
+// the destructuring pattern gave them. Where a recursive call passes one of those names as another
+// argument, that argument has to reach the call holding the value it had before the new struct was
+// taken apart; where the body reads the struct itself, the twin has to rebuild it. Every function
+// below is self-recursive, so `inline` leaves it in place and the split stands in the program that
+// runs.
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::Configuration;
+    use crate::tests::test_util::test_source;
+
+    /// Verifies that splitting a struct argument leaves every value where it was, over the shapes
+    /// that make a field arrive under a name the body binds elsewhere.
+    #[test]
+    fn test_split_struct_argument_computes_the_same_values() {
+        let source = r#"
+module Main;
+
+type P = struct { x : I64, y : I64 };
+type Q = struct { u : I64, v : Array I64 };
+type Deep = struct { inner : P, z : I64 };
+
+// A recursive call handing over an argument named exactly as one of the field binders.
+f : I64 -> P -> I64 -> I64;
+f = |n, p, acc| (
+    let P { x : x, y : y } = p;
+    if n <= 0 { x * 1000 + y * 10 + acc };
+    f(n - 1, P { x : x + 1, y : y * 2 }, x)
+);
+
+// The struct argument first, and two other arguments naming field binders.
+g : P -> I64 -> I64 -> I64 -> I64;
+g = |p, n, a, b| (
+    let P { x : x, y : y } = p;
+    if n <= 0 { x * 100 + y * 10 + a + b };
+    g(P { x : y, y : x + 1 }, n - 1, y, x)
+);
+
+// A field holding a boxed value, so that a field handed over at the wrong index shows as a wrong
+// element too.
+k : Q -> I64 -> I64 -> I64;
+k = |q, n, prev| (
+    let Q { u : u, v : v } = q;
+    if n <= 0 { u * 100 + v.@(0) * 10 + prev };
+    k(Q { u : u + 1, v : v.set(0, u) }, n - 1, u)
+);
+
+// A struct whose field is a struct, which one round of splitting flattens and the next splits again.
+d : Deep -> I64 -> I64 -> I64;
+d = |s, n, carry| (
+    let Deep { inner : inner, z : z } = s;
+    let P { x : x, y : y } = inner;
+    if n <= 0 { x * 1000 + y * 100 + z * 10 + carry };
+    d(Deep { inner : P { x : y, y : x + 1 }, z : z + 1 }, n - 1, x)
+);
+
+// An argument that is an expression naming a field binder rather than a bare name.
+e : I64 -> P -> I64 -> I64;
+e = |n, p, acc| (
+    let P { x : x, y : y } = p;
+    if n <= 0 { x + y * 10 + acc * 100 };
+    e(n - 1, P { x : y, y : x }, acc + x * y)
+);
+
+main : IO () = (
+    assert_eq(|_|"f", f(4, P { x : 5, y : 1 }, 0), 9168);;
+    assert_eq(|_|"g", g(P { x : 1, y : 3 }, 4, 0, 0), 357);;
+    assert_eq(|_|"k", k(Q { u : 2, v : [7, 8] }, 3, 0), 544);;
+    assert_eq(|_|"d", d(Deep { inner : P { x : 1, y : 2 }, z : 0 }, 3, 0), 3332);;
+    assert_eq(|_|"e", e(4, P { x : 1, y : 2 }, 0), 821);;
+    pure()
+);
+"#;
+        test_source(source, Configuration::develop_mode());
+    }
+}

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -177,6 +177,27 @@ fn build_program(
 /// # Arguments
 /// * `description` — what is being compiled, as a phrase that reads after "compiling": it is what
 ///   a failure names, e.g. "a chain of 2400 `let`s".
+pub fn build_within_and_run(
+    source: &str,
+    opt_level: &str,
+    timeout: Duration,
+    description: &str,
+) -> String {
+    let (_temp_dir, program_path) =
+        build_program(source, opt_level, &[], Some(timeout), description);
+
+    let output = Command::new(&program_path)
+        .output()
+        .expect("Failed to run the compiled program");
+    assert!(
+        output.status.success(),
+        "the program compiled from {} exited with {}",
+        description,
+        output.status
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 /// Builds `source` at `opt_level` with the RC IR dumped, runs the program, and returns the RC IR of
 /// every module.
 ///
@@ -185,7 +206,7 @@ fn build_program(
 ///
 /// # Arguments
 /// * `opt_level` - the level to build at, which decides which optimizations the dump shows.
-/// * `expected_output` - what the program prints on stdout, with the trailing newline dropped.
+/// * `expected_output` - what the program prints on stdout, with the surrounding whitespace removed.
 /// * `description` - what is being compiled, as a phrase that reads after "compiling".
 pub fn build_run_and_read_rc_ir(
     source: &str,
@@ -218,30 +239,39 @@ pub fn build_run_and_read_rc_ir(
         opt_level
     );
 
-    let dump_path = temp_dir.path().join(".fixlang/rc_ir.post.txt");
+    read_rc_ir_dump(temp_dir.path())
+}
+
+/// The RC IR of every module, read out of the dump a build with `--emit-rc-ir all` left in `dir`.
+pub fn read_rc_ir_dump(dir: &Path) -> String {
+    let dump_path = dir.join(".fixlang/rc_ir.post.txt");
     fs::read_to_string(&dump_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", dump_path.display(), e))
 }
 
-pub fn build_within_and_run(
-    source: &str,
-    opt_level: &str,
-    timeout: Duration,
-    description: &str,
-) -> String {
-    let (_temp_dir, program_path) =
-        build_program(source, opt_level, &[], Some(timeout), description);
-
-    let output = Command::new(&program_path)
-        .output()
-        .expect("Failed to run the compiled program");
-    assert!(
-        output.status.success(),
-        "the program compiled from {} exited with {}",
-        description,
-        output.status
-    );
-    String::from_utf8_lossy(&output.stdout).trim().to_string()
+/// Every function of an RC IR dump whose signature line names `name_part`: that line and the lines
+/// under it, up to the line that opens the next function or global.
+///
+/// A dump names a function with `fn ` and a global with `global `, and the last function of a dump
+/// is followed by the globals, so both open a new item and both end the one before.
+pub fn rc_ir_function_bodies(dump: &str, name_part: &str) -> Vec<String> {
+    let mut bodies = vec![];
+    let mut current_body: Option<Vec<&str>> = None;
+    for line in dump.lines() {
+        if line.starts_with("fn ") || line.starts_with("global ") {
+            if let Some(body) = current_body.take() {
+                bodies.push(body.join("\n"));
+            }
+            current_body = (line.starts_with("fn ") && line.contains(name_part)).then(Vec::new);
+        }
+        if let Some(body) = current_body.as_mut() {
+            body.push(line);
+        }
+    }
+    if let Some(body) = current_body {
+        bodies.push(body.join("\n"));
+    }
+    bodies
 }
 
 /// Builds `source` at `opt_level` with `build_args` on the build command, runs the program it

--- a/src/tests/test_util.rs
+++ b/src/tests/test_util.rs
@@ -177,6 +177,52 @@ fn build_program(
 /// # Arguments
 /// * `description` — what is being compiled, as a phrase that reads after "compiling": it is what
 ///   a failure names, e.g. "a chain of 2400 `let`s".
+/// Builds `source` at `opt_level` with the RC IR dumped, runs the program, and returns the RC IR of
+/// every module.
+///
+/// Running the program is what keeps the dump honest: what a test asserts on then comes off a build
+/// that is known to answer correctly.
+///
+/// # Arguments
+/// * `opt_level` - the level to build at, which decides which optimizations the dump shows.
+/// * `expected_output` - what the program prints on stdout, with the trailing newline dropped.
+/// * `description` - what is being compiled, as a phrase that reads after "compiling".
+pub fn build_run_and_read_rc_ir(
+    source: &str,
+    opt_level: &str,
+    expected_output: &str,
+    description: &str,
+) -> String {
+    let (temp_dir, program_path) = build_program(
+        source,
+        opt_level,
+        &["--emit-rc-ir", "all"],
+        Some(Duration::from_secs(600)),
+        description,
+    );
+
+    let output = Command::new(&program_path)
+        .output()
+        .expect("Failed to run the compiled program");
+    assert!(
+        output.status.success(),
+        "the program compiled from {} exited with {}",
+        description,
+        output.status
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        expected_output,
+        "the program compiled from {} should answer the same at -O {}",
+        description,
+        opt_level
+    );
+
+    let dump_path = temp_dir.path().join(".fixlang/rc_ir.post.txt");
+    fs::read_to_string(&dump_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", dump_path.display(), e))
+}
+
 pub fn build_within_and_run(
     source: &str,
     opt_level: &str,


### PR DESCRIPTION
Closes #607

モナドを通るループは、**1 反復につきヒープの確保を 1 回**払っていた。モナドの種類によらず、`Std` 自身が `IO` で回すループもである。

```
自作の state モナドを loop_m で 10,000,000 反復   malloc 10,000,012 -> 11
IO を loop_m で 3,000,000 反復                   malloc  3,000,012 -> 11
```

確保していたのはクロージャで、それが作られる形はこうだった。

```
let (v, s) = ( if int_eq(n, i) { |#v4| ... } else { |#v5| ... } )(#v2);
```

`if` が返したラムダを直後に適用している。どちらの枝も値を捕捉するので、走った枝のラムダが実行時に組み立てられる。

## この形を潰すパスは既に在った

`src/optimization/application_inlining.rs` の冒頭がそのものを述べている。

```
(if c {expr0} else {expr1})({expr2})
→ let v = {expr2} in if c { {expr0}(v) } else { {expr1}(v) }
```

**走る場所が足りなかった。** このパスは `inline` と `inline_local` と `eta_expansion` の中からしか呼ばれず、どれも `closure_specialization` より上にある。そして `(if …)(引数)` の形を**作るのは `closure_specialization`** である — 呼び出し側が渡した関数の本体を呼び出し側へ埋めるので、ラムダで答える本体は `if` の各枝の下にラムダを残す。作られた後にこのパスは一度も走らない。

そこで、パイプラインの下の方でもう一度走らせる。

## なぜ `uncurry` の後なのか

`closure_specialization` の直後に置いても確保は消えない。その時点の形はこうで、

```
|#v0| (
    let #v1 = (if … { λ } else { λ });
    |#v2| ( let (v, s) = #v1(#v2); … )
)
```

適用 `#v1(#v2)` は**別のラムダ `|#v2|` の内側**にあり、`let #v1 = if …` は外側にある。押し込むには束縛をそのラムダの中へ沈める必要があるが、それは**クロージャが捕捉するものを入れ替える** — 束縛式の*結果*でなく、束縛式が*読むもの*を捕捉するようになる — うえ、束縛式がラムダの呼び出しごとに再評価される。GHC の let-floating が「ラムダを跨いで内側へ float するのはそのラムダが高々 1 回しか呼ばれないと分かっているときだけ」としているのと同じ理由で、Fix に one-shot の解析はない。

`uncurry` が両者を同じ scope へ持ってくる。`|#param| |#v0| … |#v2|` が 1 つの多引数関数に畳まれ、その中で `uncurry` の eta 展開が最後に走らせる `let_elimination` が `let #v1 = …` を唯一の使用箇所へ畳む。そこで初めて `(if …)(#v2)` が現れ、既存のパスがそのまま効く。押し込みは**ラムダを 1 つも跨がず**、走るのは片方の枝だけなので評価回数も変わらず、`#v2` は変数なので複製されるのは変数参照だけである。

## 代償

`-O max` で 35 ファイルのプロジェクトを建てたときのコンパイラの命令数が **+0.72%** (303.45G -> 305.63G)。走らせる位置を `dead_symbol_elimination` の**後ろ**にしてある。`uncurry` はグローバルごとに arity 分の双子を作り、呼ばれるのはふつう 1 つなので、前に置くと走査したシンボルの大半を次の段が捨てる — 下の最小の再現例では、パスに届く 32 個のうち生き残るのは 8 個である。

後ろへ動かしても結果は変わらない。このパスはシンボルへの参照を増やしも減らしもしないので、`dead_symbol_elimination` が到達できる集合はこのパスの前後どちらでも同じである。上の 35 ファイルのプロジェクトで測ると 0.11% 安い (306.02G -> 305.68G)。

## 生成コードの速さ

基準は枝の分岐点 `3a80159c`。同じ木で枝と基準を順に建て、**二値が実際に違うことを先に確かめた** — 同じモナドのループの RC IR で `= closure ` が 9 個から 7 個に減る。

### speedtest 56 ケース (`-O experimental`)

```
命令数   56 ケースの変化がどれも 0.005% 以内
         合計 15,816,536,974 -> 15,816,536,439   -0.0000% (差 535 命令)
サイクル 56 ケースすべてが埋まった (混雑による欠測なし)
```

**このゼロが言っているのは「このコーパスが変更に届いていない」である。** `iter_filter_map` と `option_plumbing` と `sort_stable` について RC IR を正規化して突き合わせると**完全に一致する**。生成された二値はこの 3 ケースを含む 5 ケースで比べたときどれも異なるが、記号名に単位ハッシュ (コンパイラのビルド時刻を含む) が乗るためで、コードの違いではない。

サイクル欄は `iter_filter` の -4.18% から `iter_filter_map` の +2.74% まで散る。**命令数が 1 つも動いていないケースがその幅で振れている**ので、読めるのはこの環境の雑音の大きさだけである。

### LangArena 50 本 (`-O max`)

```
Json::ParseMapping   命令 -16.886%   サイクル -12.276%
Json::ParseDom       命令  +0.613%   サイクル  +1.314%
残る 48 本           命令の変化はどれも 0.01% 未満
合計                 命令  -0.333%
```

サイクルは 1 本につき 7 回測った最小である。3 回では雑音に埋もれる — 命令数が動かない `Brainfuck::Array` が 3 回の最小で +28.8% に出た。

### `Json::ParseDom` の +0.613%

5 回測って 200 命令の範囲で再現する (26,794,578,5xx -> 26,958,903,5xx)。

**増えているのは `Std` の側である。** RC IR を突き合わせると、差分 1,165 行のうち消えた関数は `loop_m` と `fold_m` の特殊化のクロージャだけで、**追加された関数は 1 つもない**。JSON のベンチマーク自身のコードは 1 行も変わらない。残りの差分は `Std::loop` と `HashMap::insert` などが持つ RC 状態の注釈 (`@local` / `@deeplocal`) の移動である。

profile の内訳 (単位は 100 万命令):

```
+480  Std::loop の特殊化の借用版      (基準では 1 サンプルも実行されない)
+184  __strlen_evex
+135  別の Std::loop の特殊化の借用版 (同上)
+395  malloc / realloc / memmove / free の合計
-278  strtod
-214  JsonRead::_value
-211  HashMap::_find_slot と HashMap::insert
```

クロージャが消えたことで借用化が別の判断をし、**どちらの借用版を呼ぶかが呼び出し側で変わっている**。押し込み自体が仕事を増やしているのではない — 押し込みは走る枝を 1 つに保ち、複製するのは変数参照だけである。

引き金がどの腕 (`Lam` / `Let` / `If` / `Match` / `Eval`) かは特定していない。腕を 1 つずつ有効にしたコンパイラを 5 つ建てて `Json::ParseDom` を測れば分かる。

## 各項目の説明

差分が触れる項目ごとの説明は、この pull request のコメントに置いた。

## テスト

### `test_a_loop_through_a_monad_builds_no_closure` (`src/tests/test_application_inlining.rs`、新規)

自作の state モナドを `loop_m` で回すプログラムを建てて走らせ、`--emit-rc-ir` が出した dump に対して、`Std::loop_m` の本体が `= closure ` を持たないことと、**ループが自分を呼んでいること**を表明する。

**この変更が無いときの振る舞い**: 赤くなる。本体の 2 つの枝がそれぞれ `= closure ` で終わる。

dump に対して測るのは、**プログラムからは観測できない**ためである。ループの答えはどちらでも同じで、`test_closure_specialization.rs` が同じ理由で採っている形に倣った。自己呼び出しの表明を対にしてあるのは、ループが `Std::loop_m` の外へ移った版が「何も測らずに緑」にならないようにするためである。

### `test_a_loop_in_io_builds_no_closure` (同、新規)

`IO` は別の経路でこの形に届く。`IO a` は `IOState -> (IOState, a)` を 1 つ持つ unboxed struct で、`unwrap_newtype` がそれを開き、ループは `IOState` を回す。`Std` 自身が `IOHandle::read_string` と `get_args` でこの形を使っている。

**この変更が無いときの振る舞い**: 赤くなる。

### `test_a_loop_through_a_monad_answers_the_same_at_every_level` (同、新規)

同じループを `-O none` / `-O basic` / `-O max` で建てて、答えが同じであることを表明する。押し込みが走るのは `-O max` だけなので、下の水準が「押し込みが答えを動かしていない」ことを言う。

**この変更が無いときの振る舞い**: 通る。押さえているのは、この変更が答えを変えないことである。

### `test_split_struct_argument_computes_the_same_values` (`src/tests/test_split_struct_args.rs`、新規)

この変更とは独立で、バグハントが見つけた穴を埋める。構造体の引数を分割すると、そのフィールドは分解パターンが与えた名前で渡され、その名前は**本体の続きでなく本体全体**を覆う。再帰呼び出しの引数がその名前を名指すとき、その引数は新しい構造体が分解される前の値を持ったまま呼び出しに届かなければならない。

**この変更が無いときの振る舞い**: 通る。押さえているのは `split_struct_args` の振る舞いである。`twin_call` の `stands_for_itself` から「パターンの束縛子でないこと」を外すと赤くなり、**その変異で他のテストは 1 本も赤くならない**。これは以前の周が見つけて直した誤コンパイルの軸そのもので、直したときに回帰テストが入っていなかった。

## 確かめたこと

- **全テスト 1,686 本が緑**
- **素通しにした多引数の適用 18,525 件の関数位置がすべて `Expr::Var` だった** (下の付録)
- **LangArena 50 本すべてが `OK`** (checksum 一致)
- **project_euler の Fix 解法 109 件のうち 105 件が完全一致**。残りは元から失敗する 3 件 (`150-sub-triangle-sums` と `153-investigating-gaussian-integers` は #608、`54-poker-hands` は標準入力を要する) と、末尾に実行時間を出力する 1 件
- 上の malloc の数は `malloc` と `free` を数える `LD_PRELOAD` の共有ライブラリで取った

## 付録

### RC IR の姿

修正前、特殊化された `loop_m` の本体:

```
let if#… : Std::I64 -> (…) [{.1=fresh}] = match v#… {
    case 1(…):
        let closure#… = closure closure#0[v#…]
        ret closure#…
    case 0(…):
        let closure#… = closure closure#1[i#…, total#…]
        ret closure#…
}
let app#… = if#…(#v2#…)
```

修正後、同じ関数:

```
let if#… : (Std::LoopState (Std::I64, Std::I64) Std::I64, Std::I64) [unboxed] = match v#… {
    case 1(…):
        let v#… = union_make_1(total#…)
        let struct#… = struct_make(v#…, #v4#…)
        ret struct#…
    case 0(…):
        …
        let struct#… = struct_make(v#…, v#…)
        ret struct#…
}
```

`closure` が 1 つも無く、値はすべて unboxed で、末尾は自分自身への直接呼び出しになる。

### 止まった停止条件

`uncurry` の後に走らせると、パスが持っていた 2 つのアサーションのうち 1 つが落ちる。

```
assertion `left == right` failed: an application of 3 arguments reached application inlining
```

`uncurry` が書き換えた呼び出しは関数を名前で指すので、引数を押し込む先が無い。そちらは素通しにした。もう 1 つ — 多引数のラムダが 1 引数の適用の関数位置に立つ — は到達しないので、アサーションのまま残してある。多引数のラムダを作るのは `uncurry` だけで、それは `#funptr` 記号の本体になり、`uncurry` が書き換える呼び出しはその記号を名前で指す。

**素通しが書き換えの機会を捨てていないことを数えて確かめた。** パスに検出器を入れ、素通しした適用の関数位置を種類ごとに数える。

```
LangArena を -O max で建てる        Var = 1,886    ほかの種類 = 0
コンパイラの全テスト (107 プロセス)  Var = 16,639   ほかの種類 = 0
合計                                Var = 18,525   ほかの種類 = 0
```

押し込める形 (`Lam` / `Let` / `If` / `Match` / `Eval`) は 1 件も立たない。検出器が黙っているだけでないことは注入で示した — 記録を全適用に広げると同じプログラムで `App=352 Lam=261 Let=162` が出る。

読みも同じことを言う。production で多引数の適用を作るのは [`uncurry::replace_closure_call_to_funptr_call`](https://github.com/tttmmmyyyy/fixlang/blob/f00187f133c8e07d109fb430b3d45d11efa76cef/src/optimization/uncurry.rs#L235-L256) の 1 か所だけで、そこは関数位置に `expr_var` を置く。

**このパスで適用の形を読む操作は、すべて `end_visit_app` の中に在る。** `get_app_args` / `get_app_func` / `set_app_func` / `set_app_args` / `app_order` / `Expr::Lam(params, _)` の 16 個の出現がどれもこの関数の中で、ほかの 23 個の visitor メソッドは子を訪ねるか `unchanged` を返すかのどちらかである。

### ケースごとの数字

speedtest 56 ケースと LangArena 50 本の全行は、この pull request のコメントに置いた。

### 残した指摘

- **`build_run_and_read_rc_ir` の写しが `test_closure_specialization.rs` と `test_collapse_constructions.rs` に在る**。本体はバイト単位で同一で、違うのは「何を建てるか」だけ。この pull request は 3 つ目を書かずに `test_util.rs` へ置いたが、既存の 2 つを寄せるのは触れていないファイルの変更なので分けてある。
- **`eta_expansion::run_on_expr` が `application_inlining` -> `let_elimination` の順に呼んで、後者が作った形に前者を再適用していない。** 不動点まで回せば、飽和呼び出しの分はその場で直るかもしれない。上の +0.72% が問題になったときの対抗案として。未検証。


