### PR TITLE
LSP のテストを、時計でなくサーバが送るものを待つ形にする

### DIFF
--- a/src/commands/lsp/server.rs
+++ b/src/commands/lsp/server.rs
@@ -240,7 +240,10 @@ pub fn launch_language_server() {
         VecDeque::new();
 
     loop {
-        // Take in whatever the diagnostics thread has finished, keeping the newest result.
+        // Take in whatever the diagnostics thread has finished, keeping the newest result. This
+        // sits above the read below, so a result finished while the loop was blocked reading
+        // arrives only after one more message has been handled. `save_and_wait_for_the_program`
+        // of the test client waits that message out, and must stay in step with this placement.
         let mut diagnostics_updated = false;
         while let Ok(diagnostics_result) = diag_res_recv.try_recv() {
             last_diag = Some(diagnostics_result);

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -33,7 +33,7 @@ mod bench {
     const TIMEOUT: Duration = Duration::from_secs(60);
     /// How long the wait for one response sits between two looks. It bounds how coarse the
     /// latency this benchmark reports can be.
-    const LOOK_INTERVAL: Duration = Duration::from_millis(1);
+    const POLL_INTERVAL: Duration = Duration::from_millis(1);
 
     /// Absolute path to the directory holding the LSP test-case projects.
     fn get_test_cases_dir() -> PathBuf {
@@ -71,7 +71,7 @@ mod bench {
                 }),
             )
             .expect("send completion");
-        let resp = poll_every(LOOK_INTERVAL, TIMEOUT, || client.get_response(id))
+        let resp = poll_every(POLL_INTERVAL, TIMEOUT, || client.get_response(id))
             .unwrap_or_else(|| panic!("completion did not respond within {:?}", TIMEOUT));
         let elapsed = start.elapsed();
         (elapsed, completion_items(&resp).len())

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,6 +17,7 @@
 
 #[cfg(test)]
 mod bench {
+    use super::super::completion_harness::completion_items;
     use super::super::lsp_client::{poll_every, LspClient};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
@@ -73,17 +74,7 @@ mod bench {
         let resp = poll_every(LOOK_INTERVAL, TIMEOUT, || client.get_response(id))
             .unwrap_or_else(|| panic!("completion did not respond within {:?}", TIMEOUT));
         let elapsed = start.elapsed();
-        let result = resp.get("result").expect("response has result");
-        let n = if result.is_array() {
-            result.as_array().unwrap().len()
-        } else {
-            result
-                .get("items")
-                .and_then(|v| v.as_array())
-                .map(|a| a.len())
-                .unwrap_or(0)
-        };
-        (elapsed, n)
+        (elapsed, completion_items(&resp).len())
     }
 
     /// Convert a `Duration` to fractional milliseconds.

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -171,7 +171,7 @@ mod bench {
         // Warm the typecheck cache / snapshot by running diagnostics once
         // and waiting for it to settle. The user considers this initial
         // cost acceptable; we measure what happens *after* this.
-        client.trigger_and_wait_for_diagnostics(main_rel);
+        client.save_and_wait_for_the_program(main_rel);
 
         let uri = format!("file://{}", project_dir.join(main_rel).display());
 

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -1,19 +1,19 @@
 // Opt-in benchmark for warm-state `textDocument/completion` latency.
 //
-// This is NOT a correctness test: it measures the round-trip latency the
-// editor experiences for a completion request *after* the initial
-// diagnostics run has settled (the cache is warm). It is gated behind the
-// `FIX_LSP_BENCH` environment variable so it returns immediately during
-// normal `cargo test` runs and only does work when explicitly requested:
+// It measures, and asserts nothing about, the round-trip latency the editor
+// experiences for a completion request once the initial diagnostics run has
+// settled (the cache is warm). It is gated behind the `FIX_LSP_BENCH`
+// environment variable, so it returns immediately during a normal
+// `cargo test` run and does its work when asked for:
 //
 //   FIX_LSP_BENCH=1 cargo test --release \
 //     --  tests::test_lsp::bench_completion --nocapture
 //
 // The reported numbers are end-to-end (send request -> receive response),
-// so they include the client-side JSON parse of the response in this test
-// harness. For the non-dot case that returns the full candidate list,
-// that parse is non-trivial; treat the absolute numbers as an upper bound
-// and use the before/after delta as the signal when optimizing.
+// so they include this harness's own JSON parse of the response. That parse
+// costs something for the non-dot case, which returns the full candidate
+// list; read the absolute numbers as an upper bound and the before/after
+// delta as the signal when optimizing.
 
 #[cfg(test)]
 mod bench {
@@ -104,9 +104,7 @@ mod bench {
     }
 
     /// Locate the cursor `(line, col)` at the end of the first occurrence
-    /// of `needle` (used for a non-dot context where `needle` is a
-    /// lowercase identifier, yielding an empty namespace filter -> the
-    /// full candidate list).
+    /// of `needle`.
     fn pos_after(text: &str, needle: &str) -> (u32, u32) {
         for (i, line) in text.lines().enumerate() {
             if let Some(start) = line.find(needle) {
@@ -138,9 +136,8 @@ mod bench {
             .expect("initialize LSP");
         client.open_document(main_rel).expect("open main.fix");
 
-        // Warm the typecheck cache / snapshot by running diagnostics once
-        // and waiting for it to settle. The user considers this initial
-        // cost acceptable; we measure what happens *after* this.
+        // Warm the typecheck cache / snapshot by running diagnostics once and
+        // waiting for it to settle, so that what follows is measured warm.
         client.save_and_wait_for_the_program(main_rel);
 
         let uri = client.file_uri(main_rel);

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,13 +17,11 @@
 
 #[cfg(test)]
 mod bench {
-    use super::super::completion_harness::completion_items;
+    use super::super::completion_harness::{completion_items, setup_test_env};
     use super::super::lsp_client::{poll_every, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::time::{Duration, Instant};
-    use tempfile::TempDir;
 
     /// Number of measured completion requests per benchmark point.
     const ITERS: usize = 15;
@@ -34,24 +32,6 @@ mod bench {
     /// How long the wait for one response sits between two looks. It bounds how coarse the
     /// latency this benchmark reports can be.
     const POLL_INTERVAL: Duration = Duration::from_millis(1);
-
-    /// Absolute path to the directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy a test-case project into a fresh temp directory and return the
-    /// temp dir (kept alive for cleanup) and the canonicalized project path.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let src = get_test_cases_dir().join(project_name);
-        let dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&src, &dst).expect("Failed to copy test case");
-        let dst = dst.canonicalize().expect("canonicalize");
-        (temp_dir, dst)
-    }
 
     /// Send one completion request and finely poll for the response,
     /// returning the round-trip duration and the number of items.
@@ -161,7 +141,7 @@ mod bench {
         // cost acceptable; we measure what happens *after* this.
         client.save_and_wait_for_the_program(main_rel);
 
-        let uri = format!("file://{}", project_dir.join(main_rel).display());
+        let uri = client.file_uri(main_rel);
 
         // Non-dot, full candidate list (empty namespace filter).
         let (l, c) = pos_after(&text, "let _ = sz");

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -51,20 +51,20 @@ mod bench {
                 }),
             )
             .expect("send completion");
-        let resp = poll_every(POLL_INTERVAL, TIMEOUT, || client.get_response(id))
+        let resp = poll_every(POLL_INTERVAL, TIMEOUT, || client.take_response(id))
             .unwrap_or_else(|| panic!("completion did not respond within {:?}", TIMEOUT));
         let elapsed = start.elapsed();
         (elapsed, completion_items(&resp).len())
     }
 
     /// Convert a `Duration` to fractional milliseconds.
-    fn millis(d: Duration) -> f64 {
-        d.as_secs_f64() * 1000.0
+    fn millis(duration: Duration) -> f64 {
+        duration.as_secs_f64() * 1000.0
     }
 
     /// Run `ITERS` measured completions at `(line, col)` after `WARMUP`
     /// discarded warm-up calls, and print min / median / mean / max.
-    fn bench_one(client: &mut LspClient, uri: &str, line: u32, col: u32, label: &str) {
+    fn bench_position(client: &mut LspClient, uri: &str, line: u32, col: u32, label: &str) {
         let (cold, n_items) = timed_completion(client, uri, line, col);
         for _ in 1..WARMUP {
             timed_completion(client, uri, line, col);
@@ -145,19 +145,21 @@ mod bench {
 
         // Non-dot, full candidate list (empty namespace filter).
         let (l, c) = pos_after(&text, "let _ = sz");
-        bench_one(&mut client, &uri, l, c, "non-dot/full");
+        bench_position(&mut client, &uri, l, c, "non-dot/full");
 
         // Dot on an `Array I64` receiver.
         let (l, c) = pos_after_dot(&text, "arr.get_size");
-        bench_one(&mut client, &uri, l, c, "dot/array");
+        bench_position(&mut client, &uri, l, c, "dot/array");
 
         // Dot on an `I64` receiver.
         let (l, c) = pos_after_dot(&text, "42.compute");
-        bench_one(&mut client, &uri, l, c, "dot/i64");
+        bench_position(&mut client, &uri, l, c, "dot/i64");
 
         client
             .shutdown(Duration::from_millis(500))
             .expect("shutdown LSP");
-        client.finish().expect("reader thread clean");
+        client
+            .verify_no_protocol_error()
+            .expect("reader thread clean");
     }
 }

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -20,6 +20,8 @@ mod bench {
     use super::super::completion_harness::{completion_items, setup_test_env};
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
+    use std::env;
+    use std::fs;
     use std::path::Path;
     use std::time::{Duration, Instant};
 
@@ -119,7 +121,7 @@ mod bench {
     /// receivers); opt-in via `FIX_LSP_BENCH`, otherwise a no-op.
     #[test]
     fn bench_completion_warm() {
-        if std::env::var("FIX_LSP_BENCH").is_err() {
+        if env::var("FIX_LSP_BENCH").is_err() {
             eprintln!(
                 "[bench] skipped (set FIX_LSP_BENCH=1 to run the completion latency benchmark)"
             );
@@ -128,7 +130,7 @@ mod bench {
 
         let (_temp_dir, project_dir) = setup_test_env("completion-bench");
         let main_rel = Path::new("main.fix");
-        let text = std::fs::read_to_string(project_dir.join(main_rel)).expect("read main.fix");
+        let text = fs::read_to_string(project_dir.join(main_rel)).expect("read main.fix");
 
         let mut client = LspClient::new(&project_dir).expect("start LSP");
         client

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,7 +17,7 @@
 
 #[cfg(test)]
 mod bench {
-    use super::super::lsp_client::LspClient;
+    use super::super::lsp_client::{poll_every, LspClient};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -30,6 +30,9 @@ mod bench {
     const WARMUP: usize = 2;
     /// Per-request deadline before the benchmark gives up and panics.
     const TIMEOUT: Duration = Duration::from_secs(60);
+    /// How long the wait for one response sits between two looks. It bounds how coarse the
+    /// latency this benchmark reports can be.
+    const LOOK_INTERVAL: Duration = Duration::from_millis(1);
 
     /// Absolute path to the directory holding the LSP test-case projects.
     fn get_test_cases_dir() -> PathBuf {
@@ -67,26 +70,20 @@ mod bench {
                 }),
             )
             .expect("send completion");
-        loop {
-            if let Some(resp) = client.get_response(id) {
-                let elapsed = start.elapsed();
-                let result = resp.get("result").expect("response has result");
-                let n = if result.is_array() {
-                    result.as_array().unwrap().len()
-                } else {
-                    result
-                        .get("items")
-                        .and_then(|v| v.as_array())
-                        .map(|a| a.len())
-                        .unwrap_or(0)
-                };
-                return (elapsed, n);
-            }
-            if start.elapsed() > TIMEOUT {
-                panic!("completion did not respond within {:?}", TIMEOUT);
-            }
-            std::thread::sleep(Duration::from_millis(1));
-        }
+        let resp = poll_every(LOOK_INTERVAL, TIMEOUT, || client.get_response(id))
+            .unwrap_or_else(|| panic!("completion did not respond within {:?}", TIMEOUT));
+        let elapsed = start.elapsed();
+        let result = resp.get("result").expect("response has result");
+        let n = if result.is_array() {
+            result.as_array().unwrap().len()
+        } else {
+            result
+                .get("items")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0)
+        };
+        (elapsed, n)
     }
 
     /// Convert a `Duration` to fractional milliseconds.

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,7 +17,8 @@
 
 #[cfg(test)]
 mod bench {
-    use super::super::completion_harness::{completion_items, setup_test_env};
+    use super::super::case_project::setup_test_env;
+    use super::super::completion_harness::completion_items;
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::env;
@@ -154,9 +155,7 @@ mod bench {
         let (l, c) = pos_after_dot(&text, "42.compute");
         bench_position(&mut client, &uri, l, c, "dot/i64");
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("shutdown LSP");
+        client.shutdown().expect("shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("reader thread clean");

--- a/src/tests/test_lsp/case_project.rs
+++ b/src/tests/test_lsp/case_project.rs
@@ -1,0 +1,33 @@
+//! The copy of a test project a session runs over.
+
+use crate::tests::test_util::copy_dir_recursive;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// The directory holding the LSP test projects, one subdirectory per
+/// project, named as the tests name it.
+fn get_test_cases_dir() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/tests/test_lsp/cases");
+    path
+}
+
+/// Copy the test project `project_name` into a temporary directory of its
+/// own, so tests that build and edit it can run in parallel.
+///
+/// # Returns
+/// The guard whose drop deletes the copy, and the canonicalized path of
+/// the copied project. Canonicalizing resolves the symlinks a temporary
+/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
+/// matches the root URI the server is initialized with and the URIs it
+/// publishes under.
+pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let test_case_src = get_test_cases_dir().join(project_name);
+    let test_case_dst = temp_dir.path().join(project_name);
+    copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
+    let test_case_dst = test_case_dst
+        .canonicalize()
+        .expect("Failed to canonicalize test case path");
+    (temp_dir, test_case_dst)
+}

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -171,7 +171,7 @@ impl LspCompletionCtx {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         self.client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -2,42 +2,14 @@
 // over a private copy of a test project and sends completion /
 // resolve requests against it.
 
+use super::case_project::setup_test_env;
 use super::lsp_client::LspClient;
-use crate::tests::test_util::copy_dir_recursive;
 use serde_json::{json, Value};
 use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
 use tempfile::TempDir;
-
-/// The directory holding the LSP test projects, one subdirectory per
-/// project, named as the tests name it.
-fn get_test_cases_dir() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src/tests/test_lsp/cases");
-    path
-}
-
-/// Copy the test project `project_name` into a temporary directory of its
-/// own, so tests that build and edit it can run in parallel.
-///
-/// # Returns
-/// The guard whose drop deletes the copy, and the canonicalized path of
-/// the copied project. Canonicalizing resolves the symlinks a temporary
-/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
-/// matches the root URI the server is initialized with and the URIs it
-/// publishes under.
-pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-    let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let test_case_src = get_test_cases_dir().join(project_name);
-    let test_case_dst = temp_dir.path().join(project_name);
-    copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-    let test_case_dst = test_case_dst
-        .canonicalize()
-        .expect("Failed to canonicalize test case path");
-    (temp_dir, test_case_dst)
-}
 
 /// Look up the `sortText` of the completion item whose `label` is `label`.
 pub fn find_sort_text(items: &[Value], label: &str) -> Option<String> {
@@ -101,7 +73,7 @@ impl LspCompletionCtx {
         for f in files {
             client
                 .open_document(Path::new(f))
-                .expect(&format!("Failed to open {}", f));
+                .unwrap_or_else(|_| panic!("Failed to open {}", f));
         }
         let trigger_file = files.last().unwrap();
         client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -165,9 +137,7 @@ impl LspCompletionCtx {
 
     /// Shut the server down and assert its reader thread saw no errors.
     pub fn shutdown(mut self) {
-        self.client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        self.client.shutdown().expect("Failed to shutdown LSP");
         self.client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -100,7 +100,7 @@ impl LspCompletionCtx {
                 .expect(&format!("Failed to open {}", f));
         }
         let trigger_file = files.last().unwrap();
-        client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+        client.save_and_wait_for_the_program(Path::new(trigger_file));
         Self {
             client,
             project_dir,
@@ -154,7 +154,7 @@ impl LspCompletionCtx {
             .expect("Failed to send resolve request");
         let response = self
             .client
-            .wait_for_response(id, Duration::from_secs(5))
+            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
             .expect("Should receive a resolve response");
         response
             .get("result")

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -24,7 +24,10 @@ fn get_test_cases_dir() -> PathBuf {
 ///
 /// # Returns
 /// The guard whose drop deletes the copy, and the canonicalized path of
-/// the copied project.
+/// the copied project. Canonicalizing resolves the symlinks a temporary
+/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
+/// matches the root URI the server is initialized with and the URIs it
+/// publishes under.
 pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let test_case_src = get_test_cases_dir().join(project_name);
@@ -114,7 +117,7 @@ impl LspCompletionCtx {
     /// The `file://` URI the server knows `file` by, `file` being a path
     /// relative to the project root.
     pub fn file_uri(&self, file: &str) -> String {
-        format!("file://{}", self.project_dir.join(file).display())
+        self.client.file_uri(Path::new(file))
     }
 
     /// Send textDocument/completion and return the result items,

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -7,7 +7,7 @@ use crate::tests::test_util::copy_dir_recursive;
 use serde_json::{json, Value};
 use std::{
     path::{Path, PathBuf},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tempfile::TempDir;
 
@@ -57,26 +57,18 @@ pub fn collect_completion_items(
     request_id: u32,
     timeout: Duration,
 ) -> Option<Vec<Value>> {
-    let start = Instant::now();
-    loop {
-        client.wait_for_server(Duration::from_millis(500));
-        if let Some(response) = client.get_response(request_id) {
-            let result = response.get("result").expect("response has result");
-            let items = if result.is_array() {
-                result.as_array().unwrap().clone()
-            } else {
-                result
-                    .get("items")
-                    .and_then(|v| v.as_array())
-                    .cloned()
-                    .unwrap_or_default()
-            };
-            return Some(items);
-        }
-        if start.elapsed() > timeout {
-            return None;
-        }
-    }
+    let response = client.wait_for_response(request_id, timeout)?;
+    let result = response.get("result").expect("response has result");
+    let items = if result.is_array() {
+        result.as_array().unwrap().clone()
+    } else {
+        result
+            .get("items")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    };
+    Some(items)
 }
 
 /// A language server running over a private copy of one test project,
@@ -160,10 +152,9 @@ impl LspCompletionCtx {
             .client
             .send_request("completionItem/resolve", item)
             .expect("Failed to send resolve request");
-        self.client.wait_for_server(Duration::from_secs(5));
         let response = self
             .client
-            .get_response(id)
+            .wait_for_response(id, Duration::from_secs(5))
             .expect("Should receive a resolve response");
         response
             .get("result")

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -65,7 +65,7 @@ pub fn completion_items(response: &Value) -> Vec<Value> {
 /// server replies or `timeout` elapses. Returns the completion items;
 /// returns `None` when the timeout expires so the caller can format
 /// its own diagnostic.
-pub fn collect_completion_items(
+pub fn wait_for_completion_items(
     client: &mut LspClient,
     request_id: u32,
     timeout: Duration,
@@ -145,7 +145,7 @@ impl LspCompletionCtx {
                 }),
             )
             .expect("Failed to send completion request");
-        collect_completion_items(&mut self.client, id, timeout)
+        wait_for_completion_items(&mut self.client, id, timeout)
             .unwrap_or_else(|| panic!("completion did not respond within {:?}", timeout))
     }
 
@@ -155,7 +155,7 @@ impl LspCompletionCtx {
             .client
             .send_request("completionItem/resolve", item)
             .expect("Failed to send resolve request");
-        let response = self.client.response_of(id);
+        let response = self.client.expect_response(id);
         response
             .get("result")
             .cloned()

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -46,29 +46,32 @@ pub fn find_sort_text(items: &[Value], label: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// The completion items a `textDocument/completion` response carries. Its `result` is either
+/// the array of items or a `CompletionList` holding them, and a server offering nothing answers
+/// `null`, which carries no item.
+pub fn completion_items(response: &Value) -> Vec<Value> {
+    let result = response.get("result").expect("response has result");
+    if let Some(items) = result.as_array() {
+        return items.clone();
+    }
+    result
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+}
+
 /// Poll an in-flight `textDocument/completion` request until the
-/// server replies or `timeout` elapses. Returns the completion items
-/// (the response's `result` may be either an array or a
-/// `CompletionList` — both shapes are unwrapped); returns `None`
-/// when the timeout expires so the caller can format its own
-/// diagnostic.
+/// server replies or `timeout` elapses. Returns the completion items;
+/// returns `None` when the timeout expires so the caller can format
+/// its own diagnostic.
 pub fn collect_completion_items(
     client: &mut LspClient,
     request_id: u32,
     timeout: Duration,
 ) -> Option<Vec<Value>> {
     let response = client.wait_for_response(request_id, timeout)?;
-    let result = response.get("result").expect("response has result");
-    let items = if result.is_array() {
-        result.as_array().unwrap().clone()
-    } else {
-        result
-            .get("items")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default()
-    };
-    Some(items)
+    Some(completion_items(&response))
 }
 
 /// A language server running over a private copy of one test project,

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -64,10 +64,8 @@ pub fn completion_items(response: &Value) -> Vec<Value> {
         .unwrap_or_default()
 }
 
-/// Poll an in-flight `textDocument/completion` request until the
-/// server replies or `timeout` elapses. Returns the completion items;
-/// returns `None` when the timeout expires so the caller can format
-/// its own diagnostic.
+/// The completion items the answer to the request `request_id` carries, waited for until it
+/// arrives or `timeout` runs out. `None` says the wait ran out.
 pub fn wait_for_completion_items(
     client: &mut LspClient,
     request_id: u32,
@@ -126,10 +124,10 @@ impl LspCompletionCtx {
         self.complete_with_timeout(file, line, col, Duration::from_secs(5))
     }
 
-    /// Send textDocument/completion and poll for the response with
-    /// the given timeout. Use this in dot-completion tests where
-    /// the server's first-time re-elaborate can take longer than
-    /// `complete`'s 5-second wait on a cold cache.
+    /// Send `textDocument/completion` and return the result items, waiting up
+    /// to `timeout` for the response. A request the server answers only after
+    /// re-elaborating the project takes longer than `complete` waits on a cold
+    /// cache, and `timeout` is what such a request is given.
     pub fn complete_with_timeout(
         &mut self,
         file: &str,

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -152,10 +152,7 @@ impl LspCompletionCtx {
             .client
             .send_request("completionItem/resolve", item)
             .expect("Failed to send resolve request");
-        let response = self
-            .client
-            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-            .expect("Should receive a resolve response");
+        let response = self.client.response_of(id);
         response
             .get("result")
             .cloned()

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -168,6 +168,15 @@ fn process_message(message: Value, shared: &SharedState) {
 }
 
 impl LspClient {
+    /// How long a request is given to be answered.
+    pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// How long a diagnostics pass is given to end.
+    pub const PASS_TIMEOUT: Duration = Duration::from_secs(180);
+
+    /// How long the server is given to exit once it has been told to.
+    pub const EXIT_TIMEOUT: Duration = Duration::from_millis(500);
+
     /// Run `fix language-server` in `working_dir`, which is the project root the paths a test
     /// passes are taken as relative to, and read what it sends on a thread of its own.
     /// `working_dir` itself may be relative to the directory the test runs in.
@@ -313,25 +322,25 @@ impl LspClient {
     }
 
     /// The oldest message the server sent that the queue still holds, taken out of it.
-    pub fn pop_message(&mut self) -> Option<Value> {
+    pub fn pop_message(&self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
     }
 
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
-    pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
+    pub fn wait_for_response(&self, id: u32, timeout: Duration) -> Option<Value> {
         poll(timeout, || self.take_response(id))
     }
 
     /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
-    pub fn expect_response(&mut self, id: u32) -> Value {
+    pub fn expect_response(&self, id: u32) -> Value {
         self.wait_for_response(id, Self::RESPONSE_TIMEOUT)
             .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
     }
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
     /// once. `None` says the response is yet to arrive.
-    pub fn take_response(&mut self, id: u32) -> Option<Value> {
+    pub fn take_response(&self, id: u32) -> Option<Value> {
         self.shared.responses.lock().unwrap().remove(&id)
     }
 
@@ -360,12 +369,6 @@ impl LspClient {
             )
         })
     }
-
-    /// How long a request is given to be answered.
-    pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-
-    /// How long a diagnostics pass is given to end.
-    pub const PASS_TIMEOUT: Duration = Duration::from_secs(180);
 
     /// Run `trigger`, which asks the server for a diagnostics pass, and return once one more pass
     /// has ended than had ended before it ran, so that the reports that pass publishes have
@@ -580,16 +583,16 @@ impl LspClient {
         )
     }
 
-    /// Ask the server to shut down and exit, and wait up to `exit_timeout` for its process to end
+    /// Ask the server to shut down and exit, and wait up to `EXIT_TIMEOUT` for its process to end
     /// once the `exit` notification has been sent.
-    pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
+    pub fn shutdown(&mut self) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
         let _ = self.wait_for_response(id, Self::RESPONSE_TIMEOUT);
 
         self.send_notification("exit", json!(null))?;
 
         // A process still running when `exit_timeout` runs out is an error; `Drop` kills it.
-        match poll(exit_timeout, || match self.process.try_wait() {
+        match poll(Self::EXIT_TIMEOUT, || match self.process.try_wait() {
             Ok(Some(_status)) => Some(Ok(())),
             Ok(None) => None,
             Err(e) => Some(Err(format!("Failed to check process status: {:?}", e))),

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -10,6 +10,9 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+/// How long a wait for something the server sends sits between two looks at what has arrived.
+pub(super) const POLL_INTERVAL: Duration = Duration::from_millis(2);
+
 /// Shared state between `LspClient` and the background reader thread.
 /// Each field is an `Arc<Mutex<T>>` so `SharedState` can be cheaply cloned
 /// to share the same data across threads.
@@ -217,9 +220,6 @@ impl LspClient {
             }
         });
 
-        // Give the server a moment to initialize
-        thread::sleep(Duration::from_millis(100));
-
         Ok(LspClient {
             process,
             stdin,
@@ -286,15 +286,34 @@ impl LspClient {
         Ok(())
     }
 
-    /// Sleep for `duration`, giving the reader thread that long to take in whatever the server
-    /// sends meanwhile.
-    pub fn wait_for_server(&mut self, duration: Duration) {
-        thread::sleep(duration);
+    /// Look at what the server has sent every `POLL_INTERVAL` until `ready` answers `Some`, and
+    /// hand that answer back. `None` says `timeout` ran out with `ready` still answering `None`.
+    pub fn poll_until<T>(
+        &mut self,
+        timeout: Duration,
+        mut ready: impl FnMut(&mut Self) -> Option<T>,
+    ) -> Option<T> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(answer) = ready(self) {
+                return Some(answer);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            thread::sleep(POLL_INTERVAL);
+        }
     }
 
     /// Pop one message from the message queue
     pub fn pop_message(&mut self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
+    }
+
+    /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
+    /// `None` says the wait ran out.
+    pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
+        self.poll_until(timeout, |client| client.get_response(id))
     }
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
@@ -314,36 +333,28 @@ impl LspClient {
     /// This is used to detect when diagnostics have completed, since the
     /// server sends `$/progress` with `kind: "end"` after each diagnostics run.
     pub fn wait_for_progress_end_count(
-        &self,
+        &mut self,
         target_count: usize,
         timeout: Duration,
     ) -> Result<(), String> {
-        let start = Instant::now();
-        loop {
-            if self.count_progress_end_messages() >= target_count {
-                return Ok(());
-            }
-            if start.elapsed() > timeout {
-                return Err(format!(
-                    "Timeout ({:?}) waiting for progress end count to reach {}. Current: {}",
-                    timeout,
-                    target_count,
-                    self.count_progress_end_messages()
-                ));
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
+        self.poll_until(timeout, |client| {
+            (client.count_progress_end_messages() >= target_count).then_some(())
+        })
+        .ok_or_else(|| {
+            format!(
+                "Timeout ({:?}) waiting for progress end count to reach {}. Current: {}",
+                timeout,
+                target_count,
+                self.count_progress_end_messages()
+            )
+        })
     }
 
-    /// Trigger diagnostics for `file` and wait until the server has processed the results.
+    /// Trigger diagnostics for `file` and return once the server's main loop holds the result
+    /// of the pass, so that a request answered out of it sees the program this pass elaborated.
     ///
-    /// The server sends a `$/progress` notification with `kind: "end"` when diagnostics
-    /// complete, and the wait ends on that notification.
-    ///
-    /// After diagnostics complete, the result is on the internal channel
-    /// but the server's main loop must call `try_recv` to pick it up.
-    /// Sending a `$/ping` notification (unknown to the server, safely ignored)
-    /// forces the main loop to iterate, executing `try_recv`.
+    /// The server sends a `$/progress` notification with `kind: "end"` when a pass ends, and
+    /// the pass's result travels to the main loop on a channel of its own.
     pub fn trigger_and_wait_for_diagnostics(&mut self, file: &Path) {
         let count_before = self.count_progress_end_messages();
 
@@ -354,11 +365,21 @@ impl LspClient {
         self.wait_for_progress_end_count(count_before + 1, Duration::from_secs(60))
             .expect("Diagnostics did not complete in time");
 
-        // Force the server's main loop to iterate, ensuring it picks up
-        // the diagnostics result via try_recv.
-        self.send_notification("$/ping", json!(null))
-            .expect("Failed to send flush notification");
-        self.wait_for_server(Duration::from_secs(1));
+        // The main loop takes the result of a pass in at the top of an iteration, before it
+        // blocks reading the next message, so the result of the pass that just ended reaches it
+        // only once it has handled one more message. Two answered requests put it past that
+        // point: the first is what wakes the loop, the second is answered after the result is in.
+        let uri = format!("file://{}", self.working_dir.join(file).display());
+        for _ in 0..2 {
+            let id = self
+                .send_request(
+                    "textDocument/semanticTokens/full",
+                    json!({ "textDocument": { "uri": uri } }),
+                )
+                .expect("Failed to send the request that waits out the main loop");
+            self.wait_for_response(id, Duration::from_secs(10))
+                .expect("the request that waits out the main loop is expected to be answered");
+        }
     }
 
     /// The diagnostics the server last published for `file_path`, which is taken as relative to
@@ -423,9 +444,7 @@ impl LspClient {
 
         let id = self.send_request("initialize", params)?;
 
-        // Wait for response
-        self.wait_for_server(timeout);
-        if let Some(response) = self.get_response(id) {
+        if let Some(response) = self.wait_for_response(id, timeout) {
             if response.get("error").is_some() {
                 return Err(format!("Initialize failed: {:?}", response));
             }
@@ -542,33 +561,19 @@ impl LspClient {
     /// * `exit_timeout` - Maximum time to wait for the process to exit after sending exit notification
     pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
-
-        // Wait for response with 5 second timeout
-        let response_timeout = Duration::from_secs(5);
-        self.wait_for_server(response_timeout);
-        let _ = self.get_response(id);
+        let _ = self.wait_for_response(id, Duration::from_secs(5));
 
         self.send_notification("exit", json!(null))?;
 
-        // Wait for process to exit with timeout to avoid freezing tests
-        // If the process doesn't exit within the timeout, return error (Drop will kill it)
-        thread::sleep(exit_timeout);
-
-        match self.process.try_wait() {
-            Ok(Some(_status)) => {
-                // Process has already exited
-            }
-            Ok(None) => {
-                // Process is still running - return error
-                // Drop will kill the process when LspClient is dropped
-                return Err("LSP server did not exit gracefully within timeout".to_string());
-            }
-            Err(e) => {
-                return Err(format!("Failed to check process status: {:?}", e));
-            }
+        // A process still running when `exit_timeout` runs out is an error; `Drop` kills it.
+        match self.poll_until(exit_timeout, |client| match client.process.try_wait() {
+            Ok(Some(_status)) => Some(Ok(())),
+            Ok(None) => None,
+            Err(e) => Some(Err(format!("Failed to check process status: {:?}", e))),
+        }) {
+            Some(result) => result,
+            None => Err("LSP server did not exit gracefully within timeout".to_string()),
         }
-
-        Ok(())
     }
 
     /// The protocol error the reader thread met, as an `Err`. Called at the end of a test, so

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -10,8 +10,23 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-/// How long a wait for something the server sends sits between two looks at what has arrived.
-pub(super) const POLL_INTERVAL: Duration = Duration::from_millis(2);
+/// How long a wait sits between two looks at what has arrived.
+const POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+/// Look every `POLL_INTERVAL` until `ready` answers `Some`, and hand that answer back. `None`
+/// says `timeout` ran out with `ready` still answering `None`.
+pub(super) fn poll_until<T>(timeout: Duration, mut ready: impl FnMut() -> Option<T>) -> Option<T> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(answer) = ready() {
+            return Some(answer);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
 
 /// Shared state between `LspClient` and the background reader thread.
 /// Each field is an `Arc<Mutex<T>>` so `SharedState` can be cheaply cloned
@@ -286,25 +301,6 @@ impl LspClient {
         Ok(())
     }
 
-    /// Look at what the server has sent every `POLL_INTERVAL` until `ready` answers `Some`, and
-    /// hand that answer back. `None` says `timeout` ran out with `ready` still answering `None`.
-    pub fn poll_until<T>(
-        &mut self,
-        timeout: Duration,
-        mut ready: impl FnMut(&mut Self) -> Option<T>,
-    ) -> Option<T> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if let Some(answer) = ready(self) {
-                return Some(answer);
-            }
-            if Instant::now() >= deadline {
-                return None;
-            }
-            thread::sleep(POLL_INTERVAL);
-        }
-    }
-
     /// Pop one message from the message queue
     pub fn pop_message(&mut self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
@@ -313,7 +309,7 @@ impl LspClient {
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
     pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
-        self.poll_until(timeout, |client| client.get_response(id))
+        poll_until(timeout, || self.get_response(id))
     }
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
@@ -333,12 +329,12 @@ impl LspClient {
     /// This is used to detect when diagnostics have completed, since the
     /// server sends `$/progress` with `kind: "end"` after each diagnostics run.
     pub fn wait_for_progress_end_count(
-        &mut self,
+        &self,
         target_count: usize,
         timeout: Duration,
     ) -> Result<(), String> {
-        self.poll_until(timeout, |client| {
-            (client.count_progress_end_messages() >= target_count).then_some(())
+        poll_until(timeout, || {
+            (self.count_progress_end_messages() >= target_count).then_some(())
         })
         .ok_or_else(|| {
             format!(
@@ -350,36 +346,47 @@ impl LspClient {
         })
     }
 
-    /// Trigger diagnostics for `file` and return once the server's main loop holds the result
-    /// of the pass, so that a request answered out of it sees the program this pass elaborated.
-    ///
-    /// The server sends a `$/progress` notification with `kind: "end"` when a pass ends, and
-    /// the pass's result travels to the main loop on a channel of its own.
-    pub fn trigger_and_wait_for_diagnostics(&mut self, file: &Path) {
-        let count_before = self.count_progress_end_messages();
+    /// How long a request is given to be answered.
+    pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
-        // Save triggers diagnostics.
+    /// How long a diagnostics pass is given to end.
+    const PASS_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// Save `file` and return once the pass it triggers has ended, so that the reports the pass
+    /// publishes have arrived.
+    pub fn save_and_wait_for_a_pass(&mut self, file: &Path) {
+        let passes_before = self.count_progress_end_messages();
         self.save_document(file).expect("Failed to save document");
+        self.wait_for_progress_end_count(passes_before + 1, Self::PASS_TIMEOUT)
+            .expect("the pass over the saved buffer is expected to end");
+    }
 
-        // Wait for diagnostics to complete ($/progress end notification).
-        self.wait_for_progress_end_count(count_before + 1, Duration::from_secs(60))
-            .expect("Diagnostics did not complete in time");
-
-        // The main loop takes the result of a pass in at the top of an iteration, before it
-        // blocks reading the next message, so the result of the pass that just ended reaches it
-        // only once it has handled one more message. Two answered requests put it past that
-        // point: the first is what wakes the loop, the second is answered after the result is in.
+    /// Save `file` and return once the server's main loop holds what the pass it triggers
+    /// produced, so that a request answered out of the elaborated program sees this pass's
+    /// program.
+    ///
+    /// The main loop takes a pass's result in at the top of an iteration, before it blocks
+    /// reading the next message, so the result of a pass that has just ended reaches it only once
+    /// it has read one more message. The wait therefore ends the pass, sends a notification the
+    /// loop reads and ignores, and then waits out one request: the notification is what the loop
+    /// reads before it takes the result in, and the answer to the request is what says it has.
+    ///
+    /// The request is `textDocument/semanticTokens/full` because it is the one the server answers
+    /// whether or not it holds a program — which is what a project whose source fails to
+    /// elaborate needs.
+    pub fn save_and_wait_for_the_program(&mut self, file: &Path) {
+        self.save_and_wait_for_a_pass(file);
+        self.send_notification("$/ping", json!(null))
+            .expect("Failed to send the notification the main loop reads before the result");
         let uri = format!("file://{}", self.working_dir.join(file).display());
-        for _ in 0..2 {
-            let id = self
-                .send_request(
-                    "textDocument/semanticTokens/full",
-                    json!({ "textDocument": { "uri": uri } }),
-                )
-                .expect("Failed to send the request that waits out the main loop");
-            self.wait_for_response(id, Duration::from_secs(10))
-                .expect("the request that waits out the main loop is expected to be answered");
-        }
+        let id = self
+            .send_request(
+                "textDocument/semanticTokens/full",
+                json!({ "textDocument": { "uri": uri } }),
+            )
+            .expect("Failed to send the request that waits the main loop out");
+        self.wait_for_response(id, Self::PASS_TIMEOUT)
+            .expect("the request that waits the main loop out is expected to be answered");
     }
 
     /// The diagnostics the server last published for `file_path`, which is taken as relative to
@@ -566,7 +573,7 @@ impl LspClient {
         self.send_notification("exit", json!(null))?;
 
         // A process still running when `exit_timeout` runs out is an error; `Drop` kills it.
-        match self.poll_until(exit_timeout, |client| match client.process.try_wait() {
+        match poll_until(exit_timeout, || match self.process.try_wait() {
             Ok(Some(_status)) => Some(Ok(())),
             Ok(None) => None,
             Err(e) => Some(Err(format!("Failed to check process status: {:?}", e))),

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -35,8 +35,8 @@ pub(super) fn poll_every<T>(
     }
 }
 
-/// Call `look` every `POLL_INTERVAL` until it answers `Some`, for a wait each look of which
-/// reads what has already arrived.
+/// Call `look` every `POLL_INTERVAL` until it answers `Some`. The interval suits a look that
+/// reads what the reader thread has already taken in.
 pub(super) fn poll<T>(timeout: Duration, look: impl FnMut() -> Option<T>) -> Option<T> {
     poll_every(POLL_INTERVAL, timeout, look)
 }

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -57,9 +57,11 @@ struct SharedState {
     responses: Arc<Mutex<Map<u32, Value>>>,
     /// The diagnostics last published for each file, under the file's absolute path.
     diagnostics: Arc<Mutex<Map<PathBuf, Value>>>,
-    /// Number of `$/progress` end notifications received so far.
-    progress_end_count: Arc<Mutex<usize>>,
-    /// The protocol error the reader thread stopped on, which `finish` hands to the test.
+    /// How many diagnostics passes have ended, counted by the `$/progress` end notifications
+    /// that mark them.
+    ended_pass_count: Arc<Mutex<usize>>,
+    /// The protocol error the reader thread stopped on, which `verify_no_protocol_error` hands
+    /// to the test.
     reader_thread_error: Arc<Mutex<Option<String>>>,
 }
 
@@ -70,7 +72,7 @@ impl SharedState {
             message_queue: Arc::new(Mutex::new(VecDeque::new())),
             responses: Arc::new(Mutex::new(Map::default())),
             diagnostics: Arc::new(Mutex::new(Map::default())),
-            progress_end_count: Arc::new(Mutex::new(0)),
+            ended_pass_count: Arc::new(Mutex::new(0)),
             reader_thread_error: Arc::new(Mutex::new(None)),
         }
     }
@@ -153,7 +155,7 @@ fn process_message(message: Value, shared: &SharedState) {
             .and_then(|k| k.as_str())
             == Some("end")
     {
-        *shared.progress_end_count.lock().unwrap() += 1;
+        *shared.ended_pass_count.lock().unwrap() += 1;
     }
 
     // Check if it's a publishDiagnostics notification
@@ -316,7 +318,7 @@ impl LspClient {
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
     pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
-        poll(timeout, || self.get_response(id))
+        poll(timeout, || self.take_response(id))
     }
 
     /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
@@ -327,34 +329,32 @@ impl LspClient {
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
     /// once. `None` says the response is yet to arrive.
-    pub fn get_response(&mut self, id: u32) -> Option<Value> {
+    pub fn take_response(&mut self, id: u32) -> Option<Value> {
         self.shared.responses.lock().unwrap().remove(&id)
     }
 
-    /// Return the number of `$/progress` end notifications received so far.
-    pub fn count_progress_end_messages(&self) -> usize {
-        *self.shared.progress_end_count.lock().unwrap()
+    /// How many diagnostics passes have ended so far.
+    pub fn ended_pass_count(&self) -> usize {
+        *self.shared.ended_pass_count.lock().unwrap()
     }
 
-    /// Wait until the total number of `$/progress` end notifications
-    /// reaches at least `target_count`.
-    ///
-    /// This is used to detect when diagnostics have completed, since the
-    /// server sends `$/progress` with `kind: "end"` after each diagnostics run.
-    pub fn wait_for_progress_end_count(
+    /// Wait until at least `target_count` diagnostics passes have ended. The server marks the
+    /// end of each pass with a `$/progress` notification carrying `kind: "end"`, which is what
+    /// the count is taken from.
+    pub fn wait_for_ended_passes(
         &self,
         target_count: usize,
         timeout: Duration,
     ) -> Result<(), String> {
         poll(timeout, || {
-            (self.count_progress_end_messages() >= target_count).then_some(())
+            (self.ended_pass_count() >= target_count).then_some(())
         })
         .ok_or_else(|| {
             format!(
-                "Timeout ({:?}) waiting for progress end count to reach {}. Current: {}",
+                "Timeout ({:?}) waiting for {} passes to end. Ended: {}",
                 timeout,
                 target_count,
-                self.count_progress_end_messages()
+                self.ended_pass_count()
             )
         })
     }
@@ -369,9 +369,9 @@ impl LspClient {
     /// has ended than had ended before it ran, so that the reports that pass publishes have
     /// arrived.
     pub fn wait_for_one_more_pass(&mut self, trigger: impl FnOnce(&mut Self)) {
-        let passes_before = self.count_progress_end_messages();
+        let passes_before = self.ended_pass_count();
         trigger(self);
-        self.wait_for_progress_end_count(passes_before + 1, Self::PASS_TIMEOUT)
+        self.wait_for_ended_passes(passes_before + 1, Self::PASS_TIMEOUT)
             .expect("the pass the buffer asks for is expected to end");
     }
 
@@ -441,15 +441,15 @@ impl LspClient {
         diagnostics_by_path
     }
 
-    /// Checks that the diagnostics of every file are empty, answering with an error that names a
-    /// file carrying any and shows what it carries.
-    pub fn verify_no_diagnostic_errors(&self) -> Result<(), String> {
+    /// Checks that no file carries a diagnostic of any severity, answering with an error that
+    /// names a file carrying one and shows what it carries.
+    pub fn verify_no_diagnostics(&self) -> Result<(), String> {
         let diagnostics = self.shared.diagnostics.lock().unwrap();
         for (file_path, diagnostics_value) in diagnostics.iter() {
             if let Some(diag_array) = diagnostics_value.as_array() {
                 if !diag_array.is_empty() {
                     return Err(format!(
-                        "Expected no diagnostic errors but found errors in {:?}: {:?}",
+                        "Expected no diagnostics but found some in {:?}: {:?}",
                         file_path, diag_array
                     ));
                 }
@@ -609,9 +609,10 @@ impl LspClient {
         }
     }
 
-    /// The protocol error the reader thread met, as an `Err`. Called at the end of a test, so
-    /// that an error met on a thread of its own reaches the test's result.
-    pub fn finish(&self) -> Result<(), String> {
+    /// Checks that the reader thread met no protocol error, answering with the error it met.
+    /// Called at the end of a test, so that an error met on a thread of its own reaches the
+    /// test's result.
+    pub fn verify_no_protocol_error(&self) -> Result<(), String> {
         let error = self.shared.reader_thread_error.lock().unwrap();
         if let Some(err_msg) = error.as_ref() {
             return Err(format!("LSP protocol error occurred: {}", err_msg));

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -263,46 +263,11 @@ impl LspClient {
         })
     }
 
-    /// Send LSP request
-    pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
-        let id = self.next_id;
-        self.next_id += 1;
-
-        let message = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-            "params": params,
-        });
-
-        let content = serde_json::to_string(&message)
-            .map_err(|e| format!("Failed to serialize request: {:?}", e))?;
-
-        let header = format!("Content-Length: {}\r\n\r\n", content.len());
-
-        self.stdin
-            .write_all(header.as_bytes())
-            .map_err(|e| format!("Failed to write header: {:?}", e))?;
-        self.stdin
-            .write_all(content.as_bytes())
-            .map_err(|e| format!("Failed to write content: {:?}", e))?;
-        self.stdin
-            .flush()
-            .map_err(|e| format!("Failed to flush: {:?}", e))?;
-
-        Ok(id)
-    }
-
-    /// Send LSP notification
-    pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
-        let message = json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        });
-
-        let content = serde_json::to_string(&message)
-            .map_err(|e| format!("Failed to serialize notification: {:?}", e))?;
+    /// Write `message` to the server, headed by the `Content-Length` the protocol frames a
+    /// message with.
+    fn send_message(&mut self, message: &Value) -> Result<(), String> {
+        let content = serde_json::to_string(message)
+            .map_err(|e| format!("Failed to serialize message: {:?}", e))?;
 
         let header = format!("Content-Length: {}\r\n\r\n", content.len());
 
@@ -317,6 +282,30 @@ impl LspClient {
             .map_err(|e| format!("Failed to flush: {:?}", e))?;
 
         Ok(())
+    }
+
+    /// Send LSP request
+    pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.send_message(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+
+        Ok(id)
+    }
+
+    /// Send LSP notification
+    pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
+        self.send_message(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }))
     }
 
     /// Pop one message from the message queue
@@ -479,7 +468,7 @@ impl LspClient {
         // Convert to absolute path
         let absolute_root = to_absolute_path(root_path)
             .map_err(|e| format!("Failed to convert root_path to absolute path: {}", e))?;
-        let root_uri = format!("file://{}", absolute_root.display());
+        let root_uri = uri_of(&absolute_root);
 
         let params = json!({
             "processId": null,

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -13,9 +13,16 @@ use std::time::{Duration, Instant};
 /// How long a wait sits between two looks at what has arrived.
 const POLL_INTERVAL: Duration = Duration::from_millis(2);
 
-/// Look every `POLL_INTERVAL` until `ready` answers `Some`, and hand that answer back. `None`
-/// says `timeout` ran out with `ready` still answering `None`.
-pub(super) fn poll_until<T>(timeout: Duration, mut ready: impl FnMut() -> Option<T>) -> Option<T> {
+/// Look every `interval` until `ready` answers `Some`, and hand that answer back. `None` says
+/// `timeout` ran out with `ready` still answering `None`.
+///
+/// `interval` is what one look costs: `POLL_INTERVAL` where a look reads what the reader thread
+/// has already taken in, and a round trip's worth where each look asks the server again.
+pub(super) fn poll_every<T>(
+    interval: Duration,
+    timeout: Duration,
+    mut ready: impl FnMut() -> Option<T>,
+) -> Option<T> {
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(answer) = ready() {
@@ -24,8 +31,19 @@ pub(super) fn poll_until<T>(timeout: Duration, mut ready: impl FnMut() -> Option
         if Instant::now() >= deadline {
             return None;
         }
-        thread::sleep(POLL_INTERVAL);
+        thread::sleep(interval);
     }
+}
+
+/// Look every `POLL_INTERVAL` until `ready` answers `Some`, for a wait each look of which reads
+/// what has already arrived.
+pub(super) fn poll_until<T>(timeout: Duration, ready: impl FnMut() -> Option<T>) -> Option<T> {
+    poll_every(POLL_INTERVAL, timeout, ready)
+}
+
+/// The `file://` URI naming `absolute_path`.
+fn uri_of(absolute_path: &Path) -> String {
+    format!("file://{}", absolute_path.display())
 }
 
 /// Shared state between `LspClient` and the background reader thread.
@@ -312,6 +330,12 @@ impl LspClient {
         poll_until(timeout, || self.get_response(id))
     }
 
+    /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
+    pub fn response_of(&mut self, id: u32) -> Value {
+        self.wait_for_response(id, Self::RESPONSE_TIMEOUT)
+            .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
+    }
+
     /// The response to the request `id`, taken out of the responses so that it is handed over
     /// once. `None` says the response is yet to arrive.
     pub fn get_response(&mut self, id: u32) -> Option<Value> {
@@ -350,15 +374,24 @@ impl LspClient {
     pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
     /// How long a diagnostics pass is given to end.
-    const PASS_TIMEOUT: Duration = Duration::from_secs(60);
+    pub const PASS_TIMEOUT: Duration = Duration::from_secs(180);
+
+    /// Run `trigger`, which asks the server for a diagnostics pass, and return once one more pass
+    /// has ended than had ended before it ran, so that the reports that pass publishes have
+    /// arrived.
+    pub fn wait_for_one_more_pass(&mut self, trigger: impl FnOnce(&mut Self)) {
+        let passes_before = self.count_progress_end_messages();
+        trigger(self);
+        self.wait_for_progress_end_count(passes_before + 1, Self::PASS_TIMEOUT)
+            .expect("the pass the buffer asks for is expected to end");
+    }
 
     /// Save `file` and return once the pass it triggers has ended, so that the reports the pass
     /// publishes have arrived.
     pub fn save_and_wait_for_a_pass(&mut self, file: &Path) {
-        let passes_before = self.count_progress_end_messages();
-        self.save_document(file).expect("Failed to save document");
-        self.wait_for_progress_end_count(passes_before + 1, Self::PASS_TIMEOUT)
-            .expect("the pass over the saved buffer is expected to end");
+        self.wait_for_one_more_pass(|client| {
+            client.save_document(file).expect("Failed to save document")
+        });
     }
 
     /// Save `file` and return once the server's main loop holds what the pass it triggers
@@ -378,15 +411,20 @@ impl LspClient {
         self.save_and_wait_for_a_pass(file);
         self.send_notification("$/ping", json!(null))
             .expect("Failed to send the notification the main loop reads before the result");
-        let uri = format!("file://{}", self.working_dir.join(file).display());
         let id = self
             .send_request(
                 "textDocument/semanticTokens/full",
-                json!({ "textDocument": { "uri": uri } }),
+                json!({ "textDocument": { "uri": self.file_uri(file) } }),
             )
             .expect("Failed to send the request that waits the main loop out");
         self.wait_for_response(id, Self::PASS_TIMEOUT)
             .expect("the request that waits the main loop out is expected to be answered");
+    }
+
+    /// The `file://` URI the server knows `file` by, `file` being taken as relative to the
+    /// project root.
+    pub fn file_uri(&self, file: &Path) -> String {
+        uri_of(&self.working_dir.join(file))
     }
 
     /// The diagnostics the server last published for `file_path`, which is taken as relative to
@@ -469,8 +507,7 @@ impl LspClient {
     fn read_document(absolute_path: &Path) -> Result<(String, String), String> {
         let text = fs::read_to_string(absolute_path)
             .map_err(|e| format!("Failed to read file {:?}: {:?}", absolute_path, e))?;
-        let uri = format!("file://{}", absolute_path.display());
-        Ok((text, uri))
+        Ok((text, uri_of(absolute_path)))
     }
 
     /// Send didOpen notification for a document
@@ -568,7 +605,7 @@ impl LspClient {
     /// * `exit_timeout` - Maximum time to wait for the process to exit after sending exit notification
     pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
-        let _ = self.wait_for_response(id, Duration::from_secs(5));
+        let _ = self.wait_for_response(id, Self::RESPONSE_TIMEOUT);
 
         self.send_notification("exit", json!(null))?;
 

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -13,19 +13,19 @@ use std::time::{Duration, Instant};
 /// How long a wait sits between two looks at what has arrived.
 const POLL_INTERVAL: Duration = Duration::from_millis(2);
 
-/// Look every `interval` until `ready` answers `Some`, and hand that answer back. `None` says
-/// `timeout` ran out with `ready` still answering `None`.
+/// Call `look` every `interval` until it answers `Some`, and hand that answer back. `None` says
+/// `timeout` ran out with `look` still answering `None`.
 ///
 /// `interval` is what one look costs: `POLL_INTERVAL` where a look reads what the reader thread
 /// has already taken in, and a round trip's worth where each look asks the server again.
 pub(super) fn poll_every<T>(
     interval: Duration,
     timeout: Duration,
-    mut ready: impl FnMut() -> Option<T>,
+    mut look: impl FnMut() -> Option<T>,
 ) -> Option<T> {
     let deadline = Instant::now() + timeout;
     loop {
-        if let Some(answer) = ready() {
+        if let Some(answer) = look() {
             return Some(answer);
         }
         if Instant::now() >= deadline {
@@ -35,10 +35,10 @@ pub(super) fn poll_every<T>(
     }
 }
 
-/// Look every `POLL_INTERVAL` until `ready` answers `Some`, for a wait each look of which reads
-/// what has already arrived.
-pub(super) fn poll_until<T>(timeout: Duration, ready: impl FnMut() -> Option<T>) -> Option<T> {
-    poll_every(POLL_INTERVAL, timeout, ready)
+/// Call `look` every `POLL_INTERVAL` until it answers `Some`, for a wait each look of which
+/// reads what has already arrived.
+pub(super) fn poll<T>(timeout: Duration, look: impl FnMut() -> Option<T>) -> Option<T> {
+    poll_every(POLL_INTERVAL, timeout, look)
 }
 
 /// The `file://` URI naming `absolute_path`.
@@ -327,11 +327,11 @@ impl LspClient {
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
     pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
-        poll_until(timeout, || self.get_response(id))
+        poll(timeout, || self.get_response(id))
     }
 
     /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
-    pub fn response_of(&mut self, id: u32) -> Value {
+    pub fn expect_response(&mut self, id: u32) -> Value {
         self.wait_for_response(id, Self::RESPONSE_TIMEOUT)
             .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
     }
@@ -357,7 +357,7 @@ impl LspClient {
         target_count: usize,
         timeout: Duration,
     ) -> Result<(), String> {
-        poll_until(timeout, || {
+        poll(timeout, || {
             (self.count_progress_end_messages() >= target_count).then_some(())
         })
         .ok_or_else(|| {
@@ -417,7 +417,7 @@ impl LspClient {
                 json!({ "textDocument": { "uri": self.file_uri(file) } }),
             )
             .expect("Failed to send the request that waits the main loop out");
-        self.wait_for_response(id, Self::PASS_TIMEOUT)
+        self.wait_for_response(id, Self::RESPONSE_TIMEOUT)
             .expect("the request that waits the main loop out is expected to be answered");
     }
 
@@ -610,7 +610,7 @@ impl LspClient {
         self.send_notification("exit", json!(null))?;
 
         // A process still running when `exit_timeout` runs out is an error; `Drop` kills it.
-        match poll_until(exit_timeout, || match self.process.try_wait() {
+        match poll(exit_timeout, || match self.process.try_wait() {
             Ok(Some(_status)) => Some(Ok(())),
             Ok(None) => None,
             Err(e) => Some(Err(format!("Failed to check process status: {:?}", e))),

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -102,7 +102,9 @@ fn is_publish_diagnostics(message: &Value) -> bool {
     message.get("method").and_then(|m| m.as_str()) == Some("textDocument/publishDiagnostics")
 }
 
-/// Process a received message and update internal state
+/// Take `message` into `shared`: the response to a request under the request's id, the end of a
+/// diagnostics pass into the count of the passes that have ended, the diagnostics of a file under
+/// the file's path, and the message itself into the queue.
 fn process_message(message: Value, shared: &SharedState) {
     /// Handle a `textDocument/publishDiagnostics` notification.
     fn process_publish_diagnostics(message: &Value, shared: &SharedState) {
@@ -166,10 +168,9 @@ fn process_message(message: Value, shared: &SharedState) {
 }
 
 impl LspClient {
-    /// Start fix command in language server mode
-    ///
-    /// The working_dir can be either a relative or absolute path.
-    /// It will be converted to an absolute path internally.
+    /// Run `fix language-server` in `working_dir`, which is the project root the paths a test
+    /// passes are taken as relative to, and read what it sends on a thread of its own.
+    /// `working_dir` itself may be relative to the directory the test runs in.
     pub fn new(working_dir: &Path) -> Result<Self, String> {
         // Convert to absolute path
         let absolute_working_dir = to_absolute_path(working_dir)
@@ -191,8 +192,8 @@ impl LspClient {
         let shared = SharedState::new();
         let shared_clone = shared.clone();
 
-        // Start dedicated reader thread (detached - JoinHandle is not stored)
-        // The thread will exit when stdout is closed (process termination) or on protocol error
+        // The reader thread runs on its own, and ends when the process closes its stdout or when
+        // it meets a protocol error.
         thread::spawn(move || {
             let mut reader = BufReader::new(stdout);
             loop {
@@ -286,7 +287,8 @@ impl LspClient {
         Ok(())
     }
 
-    /// Send LSP request
+    /// Send the request `method` with `params`, and hand back the id it was sent under, which the
+    /// response to it carries.
     pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
         let id = self.next_id;
         self.next_id += 1;
@@ -301,7 +303,7 @@ impl LspClient {
         Ok(id)
     }
 
-    /// Send LSP notification
+    /// Send the notification `method` with `params`, which the server answers nothing to.
     pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
         self.send_message(&json!({
             "jsonrpc": "2.0",
@@ -310,7 +312,7 @@ impl LspClient {
         }))
     }
 
-    /// Pop one message from the message queue
+    /// The oldest message the server sent that the queue still holds, taken out of it.
     pub fn pop_message(&mut self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
     }
@@ -458,12 +460,10 @@ impl LspClient {
         Ok(())
     }
 
-    /// Run the initialization handshake: send the `initialize` request, wait for its response,
-    /// then send the `initialized` notification the server starts its diagnostics on.
-    ///
-    /// # Arguments
-    /// * `root_path` - Project root directory path (can be relative or absolute)
-    /// * `timeout` - Maximum time to wait for initialize response
+    /// Run the initialization handshake: send the `initialize` request naming `root_path` as the
+    /// project root, wait up to `timeout` for its response, then send the `initialized`
+    /// notification the server starts its diagnostics on. `root_path` may itself be relative to
+    /// the directory the test runs in.
     pub fn initialize(&mut self, root_path: &Path, timeout: Duration) -> Result<(), String> {
         // Convert to absolute path
         let absolute_root = to_absolute_path(root_path)
@@ -499,13 +499,9 @@ impl LspClient {
         Ok((text, uri_of(absolute_path)))
     }
 
-    /// Send didOpen notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// and sends a didOpen notification to the language server.
-    /// Initializes the document version to 1.
-    ///
-    /// Returns an error if the document is already opened.
+    /// Tell the server that the client now holds `file_path`, whose content it reads from disk and
+    /// sends along. `file_path` is taken as relative to the project root, and the version the
+    /// client counts its changes from starts here.
     pub fn open_document(&mut self, file_path: &Path) -> Result<(), String> {
         /// The version the protocol counts an opened document from.
         const INITIAL_VERSION_NUMBER: i32 = 1;
@@ -536,11 +532,9 @@ impl LspClient {
         )
     }
 
-    /// Send didChange notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// increments the document version, and sends a didChange notification to the language server.
-    /// The document must have been opened with open_document first.
+    /// Tell the server that what the client holds for `file_path` is now the content on disk,
+    /// under the next version. `file_path` is taken as relative to the project root, and is
+    /// expected to have been opened by `open_document`.
     pub fn change_document(&mut self, file_path: &Path) -> Result<(), String> {
         let absolute_path = self.working_dir.join(file_path);
         let (text, uri) = Self::read_document(&absolute_path)?;
@@ -569,10 +563,8 @@ impl LspClient {
         )
     }
 
-    /// Send didSave notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// and sends a didSave notification to the language server.
+    /// Tell the server that `file_path` has been saved, along with the content on disk, which is
+    /// what asks it for a diagnostics pass. `file_path` is taken as relative to the project root.
     pub fn save_document(&mut self, file_path: &Path) -> Result<(), String> {
         let absolute_path = self.working_dir.join(file_path);
         let (text, uri) = Self::read_document(&absolute_path)?;
@@ -588,10 +580,8 @@ impl LspClient {
         )
     }
 
-    /// Ask the server to shut down and exit, and wait for its process to end.
-    ///
-    /// # Arguments
-    /// * `exit_timeout` - Maximum time to wait for the process to exit after sending exit notification
+    /// Ask the server to shut down and exit, and wait up to `exit_timeout` for its process to end
+    /// once the `exit` notification has been sent.
     pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
         let _ = self.wait_for_response(id, Self::RESPONSE_TIMEOUT);

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -76,12 +76,7 @@ mod tests {
             .expect("Failed to open main.fix");
 
         // Send didSave to trigger diagnostics
-        client
-            .save_document(Path::new("main.fix"))
-            .expect("Failed to save main.fix");
-
-        // Wait for initial diagnostics
-        client.wait_for_server(Duration::from_secs(5));
+        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
 
         // Verify that main.fix has the specific error message
         let main_diagnostics = client.get_diagnostics(Path::new("main.fix"));
@@ -115,12 +110,7 @@ mod tests {
         );
 
         // Send didSave to trigger diagnostics and LSP lock file generation
-        client
-            .save_document(Path::new("main.fix"))
-            .expect("Failed to save main.fix");
-
-        // Wait for LSP to process and generate lock file
-        client.wait_for_server(Duration::from_secs(10));
+        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
 
         // Check if LSP lock file was generated
         let lsp_lock_file = project_dir.join(LOCK_FILE_LSP_PATH);
@@ -180,12 +170,7 @@ mod tests {
             .expect("Failed to open test.fix");
 
         // Send didSave to trigger diagnostics
-        client
-            .save_document(Path::new("test.fix"))
-            .expect("Failed to save test.fix");
-
-        // Wait for initial diagnostics
-        client.wait_for_server(Duration::from_secs(5));
+        client.trigger_and_wait_for_diagnostics(Path::new("test.fix"));
 
         // Verify that test.fix has the specific error message about missing Character module
         let test_diagnostics = client.get_diagnostics(Path::new("test.fix"));
@@ -220,12 +205,7 @@ mod tests {
         );
 
         // Send didSave to trigger diagnostics and LSP lock file generation
-        client
-            .save_document(Path::new("test.fix"))
-            .expect("Failed to save test.fix");
-
-        // Wait for LSP to process and generate lock file
-        client.wait_for_server(Duration::from_secs(10));
+        client.trigger_and_wait_for_diagnostics(Path::new("test.fix"));
 
         // Check if LSP lock file was generated
         let lsp_lock_file = project_dir.join(LOCK_FILE_LSP_PATH);
@@ -284,12 +264,7 @@ mod tests {
             .expect("Failed to open main.fix");
 
         // Send didSave to trigger diagnostics and dependency resolution
-        client
-            .save_document(Path::new("main.fix"))
-            .expect("Failed to save main.fix");
-
-        // Wait for LSP to process
-        client.wait_for_server(Duration::from_secs(10));
+        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
 
         // Get all diagnostics (dependency resolution errors may not be tied to main.fix)
         let all_diagnostics = client.get_all_diagnostics();

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -130,7 +130,7 @@ mod tests {
 
         // Verify that all diagnostic errors have been resolved
         client
-            .verify_no_diagnostic_errors()
+            .verify_no_diagnostics()
             .expect("All diagnostic errors should be resolved after adding dependencies");
 
         // Shutdown
@@ -140,7 +140,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -225,7 +225,7 @@ mod tests {
 
         // Verify that all diagnostic errors have been resolved
         client
-            .verify_no_diagnostic_errors()
+            .verify_no_diagnostics()
             .expect("All diagnostic errors should be resolved after adding test dependencies");
 
         // Shutdown
@@ -235,7 +235,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -342,7 +342,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -1,5 +1,6 @@
 // LSP integration tests module
 pub mod bench_completion;
+pub mod case_project;
 pub mod completion_harness;
 pub mod lsp_client;
 pub mod test_code_action;
@@ -21,34 +22,11 @@ pub mod test_workspace_symbol;
 
 #[cfg(test)]
 mod tests {
+    use super::case_project::setup_test_env;
     use super::lsp_client::LspClient;
     use crate::constants::LOCK_FILE_LSP_PATH;
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        time::Duration,
-    };
-    use tempfile::TempDir;
-
-    /// Path to the directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Create a temporary test environment with copied project files.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-
-        // Copy test case directory
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-
-        (temp_dir, test_case_dst)
-    }
+    use crate::tests::test_util::fix_command;
+    use std::{fs, path::Path, time::Duration};
 
     /// The LSP server automatically generates a lock file containing the
     /// project's dependencies, and diagnostics clear once a missing
@@ -134,9 +112,7 @@ mod tests {
             .expect("All diagnostic errors should be resolved after adding dependencies");
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client
@@ -229,9 +205,7 @@ mod tests {
             .expect("All diagnostic errors should be resolved after adding test dependencies");
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client
@@ -336,9 +310,7 @@ mod tests {
         );
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -16,8 +16,8 @@ pub mod test_semantic_tokens;
 pub mod test_stdin_eof;
 pub mod test_workspace_symbol;
 
-// LSP Integration Tests
-// Tests for automatic lock file management in language server mode
+// The lock file the language server writes for the project it is serving, and the report the
+// editor is shown when that project's dependencies cannot be resolved.
 
 #[cfg(test)]
 mod tests {

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -76,7 +76,7 @@ mod tests {
             .expect("Failed to open main.fix");
 
         // Send didSave to trigger diagnostics
-        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        client.save_and_wait_for_a_pass(Path::new("main.fix"));
 
         // Verify that main.fix has the specific error message
         let main_diagnostics = client.get_diagnostics(Path::new("main.fix"));
@@ -110,7 +110,7 @@ mod tests {
         );
 
         // Send didSave to trigger diagnostics and LSP lock file generation
-        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        client.save_and_wait_for_a_pass(Path::new("main.fix"));
 
         // Check if LSP lock file was generated
         let lsp_lock_file = project_dir.join(LOCK_FILE_LSP_PATH);
@@ -170,7 +170,7 @@ mod tests {
             .expect("Failed to open test.fix");
 
         // Send didSave to trigger diagnostics
-        client.trigger_and_wait_for_diagnostics(Path::new("test.fix"));
+        client.save_and_wait_for_a_pass(Path::new("test.fix"));
 
         // Verify that test.fix has the specific error message about missing Character module
         let test_diagnostics = client.get_diagnostics(Path::new("test.fix"));
@@ -205,7 +205,7 @@ mod tests {
         );
 
         // Send didSave to trigger diagnostics and LSP lock file generation
-        client.trigger_and_wait_for_diagnostics(Path::new("test.fix"));
+        client.save_and_wait_for_a_pass(Path::new("test.fix"));
 
         // Check if LSP lock file was generated
         let lsp_lock_file = project_dir.join(LOCK_FILE_LSP_PATH);
@@ -264,7 +264,7 @@ mod tests {
             .expect("Failed to open main.fix");
 
         // Send didSave to trigger diagnostics and dependency resolution
-        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        client.save_and_wait_for_a_pass(Path::new("main.fix"));
 
         // Get all diagnostics (dependency resolution errors may not be tied to main.fix)
         let all_diagnostics = client.get_all_diagnostics();

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -8,12 +8,12 @@ pub mod test_diagnostics;
 pub mod test_goto_definition;
 pub mod test_hover;
 pub mod test_import_completion;
+pub mod test_polling;
 pub mod test_references;
 pub mod test_rename;
 pub mod test_request_handling;
 pub mod test_semantic_tokens;
 pub mod test_stdin_eof;
-pub mod test_waits;
 pub mod test_workspace_symbol;
 
 // LSP Integration Tests

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -13,6 +13,7 @@ pub mod test_rename;
 pub mod test_request_handling;
 pub mod test_semantic_tokens;
 pub mod test_stdin_eof;
+pub mod test_waits;
 pub mod test_workspace_symbol;
 
 // LSP Integration Tests

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -157,8 +157,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send codeAction request");
-            self.client.wait_for_server(Duration::from_secs(10));
-            let response = self.client.get_response(id);
+            let response = self.client.wait_for_response(id, Duration::from_secs(10));
             if response.is_none() {
                 return vec![];
             }

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -98,6 +98,10 @@ mod tests {
         _temp_dir: TempDir,
     }
 
+    /// How long a `codeAction` request is given to be answered. A quick fix is built out of the
+    /// whole program, so it is given longer than an ordinary request.
+    const CODE_ACTION_TIMEOUT: Duration = Duration::from_secs(10);
+
     impl LspQuickFixCtx {
         /// Starts a server on a copy of the named case project, opens each of `files`, and waits
         /// for the diagnostics of the last of them, which the tests read.
@@ -157,11 +161,10 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send codeAction request");
-            let response = self.client.wait_for_response(id, Duration::from_secs(10));
-            if response.is_none() {
-                return vec![];
-            }
-            let response = response.unwrap();
+            let response = self
+                .client
+                .wait_for_response(id, CODE_ACTION_TIMEOUT)
+                .expect("the codeAction request is expected to be answered");
             let result = response
                 .get("result")
                 .expect("Response should have a result field");

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::edit::edit_util::apply_text_edits;
     use lsp_types::TextEdit;
@@ -97,7 +97,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -156,9 +156,7 @@ mod tests {
 
         /// Ends the session and fails the test if the server's reader thread met an error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -160,7 +160,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -117,7 +117,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 project_dir,
@@ -421,7 +421,7 @@ mod tests {
             .change_document(Path::new("main.fix"))
             .expect("Failed to send didChange");
         ctx.client
-            .trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+            .save_and_wait_for_the_program(Path::new("main.fix"));
 
         let diagnostics = ctx.client.get_diagnostics(Path::new("main.fix"));
         assert!(

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -4,9 +4,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::edit::edit_util::apply_text_edits;
-    use crate::tests::test_util::copy_dir_recursive;
     use lsp_types::TextEdit;
     use serde_json::{json, Value};
     use std::{
@@ -65,27 +65,6 @@ mod tests {
             .collect()
     }
 
-    /// The directory holding the Fix projects these tests run the language server on.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copies the named case project into a temporary directory, so that tests editing their
-    /// project's files run beside one another, and returns that directory with the canonical path
-    /// of the copy inside it.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     /// A language server running on a copy of one case project, with its documents open and its
     /// first diagnostics published.
     struct LspQuickFixCtx {
@@ -131,7 +110,7 @@ mod tests {
 
         /// The URI the server names the project's `file` by, as the responses spell it.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Request code actions for a given range with the provided diagnostics.

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -1,6 +1,5 @@
-// LSP integration tests for "textDocument/completion" feature.
-//
-// Verifies that associated types appear in completion candidates.
+// LSP integration tests for the "textDocument/completion" feature: which candidates the server
+// offers, what a resolved candidate inserts, and the order the candidates are ranked in.
 
 #[cfg(test)]
 mod tests {
@@ -85,9 +84,8 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Snapshot of the completion *insertion* behavior. Pins down what
-    /// the server sends back for `completionItem/resolve` for the four
-    /// shapes that have so far been verified manually:
+    /// Snapshot of the completion *insertion* behavior. Pins down what the
+    /// server sends back for `completionItem/resolve` for four shapes:
     ///
     ///   typing            expected insert_text         notes
     ///   ----              --------------------         -----
@@ -237,9 +235,9 @@ mod tests {
             tags
         );
 
-        // Sanity: a non-deprecated symbol from the same fixture must NOT
-        // carry the deprecation markers, otherwise the test above would
-        // pass even if we accidentally tagged everything.
+        // A live symbol of the same fixture carries neither marker, which is
+        // what tells a server that marks the deprecated symbol from one that
+        // marks every symbol.
         let live_item = items
             .iter()
             .find(|it| it.get("label").and_then(|l| l.as_str()) == Some("Main::Hoge::new_func"))
@@ -306,9 +304,9 @@ mod tests {
         let mut ctx = LspCompletionCtx::setup("completion-dot-sort", &["main.fix"]);
 
         // Cursor right after the dot in `    42.` on line 13 (0-indexed),
-        // column 7 (= byte right after `.`).
-        // Use a polling wait — the dot-completion full re-elaborate can take
-        // longer than `complete`'s hard-coded 5s sleep on a cold cache.
+        // column 7 (= byte right after `.`). The dot-completion full
+        // re-elaborate can take longer than the five seconds `complete` waits
+        // on a cold cache, so the wait here is given longer.
         let items = ctx.complete_with_timeout("main.fix", 13, 7, Duration::from_secs(60));
 
         assert_myfunc2_outranks_myfunc1(&items);
@@ -921,12 +919,11 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Regression: `(a, a).<cursor>` inside a non-exhaustive `match`
-    /// arm. The scenario can crash the elaborator if the Match's
-    /// failed exhaustiveness check leaves the child subtree untyped
-    /// and `fix_types` then unwrap-panics on the missing `type_`; a
-    /// panic in the LSP process leaves the editor hung on the
-    /// completion request.
+    /// `(a, a).<cursor>` inside a non-exhaustive `match` arm. The scenario
+    /// can crash the elaborator if the Match's failed exhaustiveness check
+    /// leaves the child subtree untyped and `fix_types` then unwrap-panics on
+    /// the missing `type_`; a panic in the LSP process leaves the editor hung
+    /// on the completion request.
     ///
     /// This test asserts only "the server stays up and replies".
     /// `test_completion_dot_after_tuple_infers_tuple_receiver` checks
@@ -949,18 +946,18 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Stronger version of the regression above: when dot completion
-    /// fires at `(a, a).<cursor>` inside a structurally broken Match
-    /// arm, every sub-node still carries an inferred type, so the
-    /// dot-completion pipeline can read off `(I64, I64)` as the
-    /// receiver. Tuple field accessors should land in Tier 0;
-    /// unrelated methods on different TyCons (e.g. `Iterator::fold`)
-    /// should not.
+    /// Where `test_completion_dot_after_tuple_no_crash` asks only that the
+    /// server reply, this asks what the reply says: when dot completion fires
+    /// at `(a, a).<cursor>` inside a structurally broken Match arm, every
+    /// sub-node still carries an inferred type, so the dot-completion pipeline
+    /// can read off `(I64, I64)` as the receiver. Tuple field accessors should
+    /// land in Tier 0; unrelated methods on different TyCons (e.g.
+    /// `Iterator::fold`) should not.
     ///
-    /// A regression here signals that the tolerant elaborator is
-    /// discarding typed sub-trees (or `fix_types` is truncating the
-    /// substituted types) — a fresh tyvar at the receiver would put
-    /// every method into the catch-all Tier 2/3, not Tier 0.
+    /// A failure here signals that the tolerant elaborator is discarding
+    /// typed sub-trees (or `fix_types` is truncating the substituted types) —
+    /// a fresh tyvar at the receiver would put every method into the
+    /// catch-all Tier 2/3, not Tier 0.
     #[test]
     fn test_completion_dot_after_tuple_infers_tuple_receiver() {
         let mut ctx = LspCompletionCtx::setup("completion-dot-after-tuple", &["main.fix"]);
@@ -976,11 +973,10 @@ mod tests {
         );
 
         // `Std::Iterator::fold` is a typical receiver-of-different-TyCon
-        // method that, if the receiver were merely a fresh tyvar (the
-        // pre-refactor fallback shape), would still bucket-match and
-        // could be wrongly promoted. After the refactor, the receiver
-        // is `(I64, I64)`, which doesn't unify with `Iterator i`, so
-        // `fold` must stay out of Tier 0.
+        // method: were the receiver merely a fresh tyvar, it would
+        // bucket-match and could be wrongly promoted. The receiver here is
+        // `(I64, I64)`, which doesn't unify with `Iterator i`, so `fold` must
+        // stay out of Tier 0.
         let sort_fold = find_sort_text(&items, "Std::Iterator::fold")
             .expect("Std::Iterator::fold should appear in the completion list");
         assert!(
@@ -1133,10 +1129,9 @@ mod tests {
         //  11:     pure()
         //  12: );
         //
-        // Column 7 = byte just after `.` on `    42.`.
-        // Use a polling wait because the dot-context elaborate can
-        // take longer than `complete`'s hard-coded 5s sleep on a cold
-        // cache.
+        // Column 7 = byte just after `.` on `    42.`. The dot-context
+        // elaborate can take longer than the five seconds `complete` waits on
+        // a cold cache, so the wait here is given longer.
         let items = ctx.complete_with_timeout("main.fix", 10, 7, Duration::from_secs(60));
 
         let sort_live = find_sort_text(&items, "Main::live_func")

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -338,7 +338,7 @@ mod tests {
         client
             .open_document(Path::new("main.fix"))
             .expect("open main.fix");
-        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        client.save_and_wait_for_the_program(Path::new("main.fix"));
 
         // Replay: the user types `.` after `42`, turning the line
         // into `    42.`. didChange notifications carry the full text
@@ -1299,7 +1299,7 @@ mod tests {
         client
             .open_document(Path::new("main.fix"))
             .expect("open main.fix");
-        client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        client.save_and_wait_for_the_program(Path::new("main.fix"));
 
         let abs_path = project_dir.join("main.fix");
         let with_multibyte = fs::read_to_string(&abs_path)

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -436,7 +436,7 @@ mod tests {
         );
 
         let _ = client.shutdown(Duration::from_millis(500));
-        let _ = client.finish();
+        let _ = client.verify_no_protocol_error();
         drop(temp_dir);
 
         // Assertion: myfunc2 should out-rank myfunc1 even when the

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::completion_harness::{
-        collect_completion_items, find_sort_text, setup_test_env, LspCompletionCtx,
+        find_sort_text, setup_test_env, wait_for_completion_items, LspCompletionCtx,
     };
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
@@ -381,7 +381,7 @@ mod tests {
             )
             .expect("send completion");
 
-        let items = collect_completion_items(&mut client, id, Duration::from_secs(60))
+        let items = wait_for_completion_items(&mut client, id, Duration::from_secs(60))
             .unwrap_or_else(|| {
                 let log_path = project_dir.join(".fixlang/fix.log");
                 let log_content =
@@ -1340,7 +1340,7 @@ mod tests {
                 }),
             )
             .expect("send completion");
-        let items = collect_completion_items(&mut client, id, Duration::from_secs(60))
+        let items = wait_for_completion_items(&mut client, id, Duration::from_secs(60))
             .expect("completion did not respond within 60s");
 
         let sort_push_back = find_sort_text(&items, "Std::Array::push_back")

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -347,7 +347,7 @@ mod tests {
         let dot_added = fs::read_to_string(&abs_path)
             .expect("read main.fix")
             .replace("    42\n", "    42.\n");
-        let uri = format!("file://{}", abs_path.display());
+        let uri = client.file_uri(Path::new("main.fix"));
         client
             .send_notification(
                 "textDocument/didChange",
@@ -1308,7 +1308,7 @@ mod tests {
                 "    let _ = arr.",
                 "    let _ = /* \u{65e5}\u{672c}\u{8a9e} */ arr.",
             );
-        let uri = format!("file://{}", abs_path.display());
+        let uri = client.file_uri(Path::new("main.fix"));
         client
             .send_notification(
                 "textDocument/didChange",

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -3,8 +3,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::case_project::setup_test_env;
     use super::super::completion_harness::{
-        find_sort_text, setup_test_env, wait_for_completion_items, LspCompletionCtx,
+        find_sort_text, wait_for_completion_items, LspCompletionCtx,
     };
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
@@ -433,7 +434,7 @@ mod tests {
             item_summary.join("\n")
         );
 
-        let _ = client.shutdown(Duration::from_millis(500));
+        let _ = client.shutdown();
         let _ = client.verify_no_protocol_error();
         drop(temp_dir);
 
@@ -1346,6 +1347,6 @@ mod tests {
             sort_push_back
         );
 
-        let _ = client.shutdown(Duration::from_millis(500));
+        let _ = client.shutdown();
     }
 }

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -450,9 +450,6 @@ mod tests {
         );
     }
 
-    /// The time one diagnostics pass is given to end.
-    const PASS_TIMEOUT: Duration = Duration::from_secs(180);
-
     /// A session over the project, with `file` opened. `initialize_timeout` is how long the
     /// response to `initialize` is waited for.
     fn open_session(project_dir: &Path, file: &Path, initialize_timeout: Duration) -> LspClient {
@@ -478,7 +475,7 @@ mod tests {
         settled: impl Fn(&[Value]) -> bool,
     ) -> Vec<Value> {
         let mut last_seen = Vec::new();
-        poll_until(PASS_TIMEOUT, || {
+        poll_until(LspClient::PASS_TIMEOUT, || {
             last_seen = client.get_diagnostics(file);
             settled(&last_seen).then(|| last_seen.clone())
         })
@@ -490,7 +487,6 @@ mod tests {
         !diagnostics_containing(diagnostics, text).is_empty()
     }
 
-    /// Saves `file` and waits until the pass the save asks for has ended. `expectation` names
     /// A program carrying one ordinary error, which the analysis finishes and reports.
     const PROGRAM_WITH_AN_UNKNOWN_NAME: &str =
         "module Main;\n\nmain : IO ();\nmain = println(nonexistent_name);\n";
@@ -637,20 +633,18 @@ mod tests {
         sole_diagnostic_containing(&diagnostics, UNKNOWN_NAME_REPORT);
 
         // The repair, which stays in the editor: the file on disk keeps the error.
-        let uri = format!("file://{}", project_dir.join(main_fix).display());
-        let passes_before = client.count_progress_end_messages();
-        client
-            .send_notification(
-                "textDocument/didChange",
-                json!({
-                    "textDocument": { "uri": uri, "version": 2 },
-                    "contentChanges": [ { "text": PROGRAM_WITHOUT_AN_ERROR } ]
-                }),
-            )
-            .expect("Failed to send didChange");
-        client
-            .wait_for_progress_end_count(passes_before + 1, PASS_TIMEOUT)
-            .expect("the pass over the repaired buffer is expected to end");
+        let uri = client.file_uri(main_fix);
+        client.wait_for_one_more_pass(|client| {
+            client
+                .send_notification(
+                    "textDocument/didChange",
+                    json!({
+                        "textDocument": { "uri": uri, "version": 2 },
+                        "contentChanges": [ { "text": PROGRAM_WITHOUT_AN_ERROR } ]
+                    }),
+                )
+                .expect("Failed to send didChange");
+        });
 
         let diagnostics = wait_until_diagnostics(&mut client, main_fix, |d| d.is_empty());
         assert!(

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::completion_harness::LspCompletionCtx;
-    use super::super::lsp_client::{poll_until, LspClient};
+    use super::super::lsp_client::{poll, LspClient};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::fs;
@@ -474,7 +474,7 @@ mod tests {
         file: &Path,
         settled: impl Fn(&[Value]) -> bool,
     ) -> Vec<Value> {
-        poll_until(LspClient::PASS_TIMEOUT, || {
+        poll(LspClient::PASS_TIMEOUT, || {
             let diagnostics = client.get_diagnostics(file);
             settled(&diagnostics).then_some(diagnostics)
         })

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -12,7 +12,7 @@ mod tests {
     use serde_json::{json, Value};
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Copies the named case project into a temporary directory and returns it with the project's
@@ -29,8 +29,11 @@ mod tests {
     /// The diagnostics the server publishes for `file` of the project, after opening and saving it.
     fn diagnostics_of(project_dir: &Path, file: &Path) -> Vec<Value> {
         let mut client = open_session(project_dir, file, Duration::from_secs(5));
-        client.save_document(file).expect("Failed to save document");
-        client.wait_for_server(Duration::from_secs(10));
+        save_and_wait_for_a_pass(
+            &mut client,
+            file,
+            "the pass over the saved buffer is expected to end",
+        );
         client.get_diagnostics(file)
     }
 
@@ -479,14 +482,12 @@ mod tests {
         file: &Path,
         settled: impl Fn(&[Value]) -> bool,
     ) -> Vec<Value> {
-        let deadline = Instant::now() + PASS_TIMEOUT;
-        loop {
-            let diagnostics = client.get_diagnostics(file);
-            if settled(&diagnostics) || Instant::now() >= deadline {
-                return diagnostics;
-            }
-            client.wait_for_server(Duration::from_millis(100));
-        }
+        client
+            .poll_until(PASS_TIMEOUT, |client| {
+                let diagnostics = client.get_diagnostics(file);
+                settled(&diagnostics).then_some(diagnostics)
+            })
+            .unwrap_or_else(|| client.get_diagnostics(file))
     }
 
     /// Whether the reports carry the one whose message contains `text`.

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -6,25 +6,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::case_project::setup_test_env;
     use super::super::completion_harness::LspCompletionCtx;
     use super::super::lsp_client::{poll, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::Duration;
     use tempfile::TempDir;
-
-    /// Copies the named case project into a temporary directory and returns it with the project's
-    /// path inside it.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cases_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
-        let project_dir = temp_dir.path().join(project_name);
-        copy_dir_recursive(&cases_dir.join(project_name), &project_dir)
-            .expect("Failed to copy test case");
-        (temp_dir, project_dir)
-    }
 
     /// The diagnostics the server publishes for `file` of the project, after opening and saving it.
     fn diagnostics_of(project_dir: &Path, file: &Path) -> Vec<Value> {

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -474,12 +474,11 @@ mod tests {
         file: &Path,
         settled: impl Fn(&[Value]) -> bool,
     ) -> Vec<Value> {
-        let mut last_seen = Vec::new();
         poll_until(LspClient::PASS_TIMEOUT, || {
-            last_seen = client.get_diagnostics(file);
-            settled(&last_seen).then(|| last_seen.clone())
+            let diagnostics = client.get_diagnostics(file);
+            settled(&diagnostics).then_some(diagnostics)
         })
-        .unwrap_or(last_seen)
+        .unwrap_or_else(|| client.get_diagnostics(file))
     }
 
     /// Whether the reports carry the one whose message contains `text`.

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::completion_harness::LspCompletionCtx;
-    use super::super::lsp_client::LspClient;
+    use super::super::lsp_client::{poll_until, LspClient};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::fs;
@@ -29,11 +29,7 @@ mod tests {
     /// The diagnostics the server publishes for `file` of the project, after opening and saving it.
     fn diagnostics_of(project_dir: &Path, file: &Path) -> Vec<Value> {
         let mut client = open_session(project_dir, file, Duration::from_secs(5));
-        save_and_wait_for_a_pass(
-            &mut client,
-            file,
-            "the pass over the saved buffer is expected to end",
-        );
+        client.save_and_wait_for_a_pass(file);
         client.get_diagnostics(file)
     }
 
@@ -349,8 +345,7 @@ mod tests {
             items.len()
         );
 
-        ctx.client
-            .trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+        ctx.client.save_and_wait_for_a_pass(Path::new("main.fix"));
         let diagnostics_after = ctx.client.get_diagnostics(lib_file);
         assert_eq!(
             diagnostics_after, diagnostics_before,
@@ -402,7 +397,7 @@ mod tests {
 
         let main_fix = Path::new("main.fix");
         let mut client = open_session(&project_dir, main_fix, Duration::from_secs(10));
-        save_and_wait_for_a_pass(&mut client, main_fix, "the first pass is expected to end");
+        client.save_and_wait_for_a_pass(main_fix);
 
         // Both files write the literal on the 4th line, and each escape is 6 characters wide. It
         // begins at the 21st character of `null_character.fix` and at the 16th of `surrogate.fix`,
@@ -482,12 +477,12 @@ mod tests {
         file: &Path,
         settled: impl Fn(&[Value]) -> bool,
     ) -> Vec<Value> {
-        client
-            .poll_until(PASS_TIMEOUT, |client| {
-                let diagnostics = client.get_diagnostics(file);
-                settled(&diagnostics).then_some(diagnostics)
-            })
-            .unwrap_or_else(|| client.get_diagnostics(file))
+        let mut last_seen = Vec::new();
+        poll_until(PASS_TIMEOUT, || {
+            last_seen = client.get_diagnostics(file);
+            settled(&last_seen).then(|| last_seen.clone())
+        })
+        .unwrap_or(last_seen)
     }
 
     /// Whether the reports carry the one whose message contains `text`.
@@ -496,15 +491,6 @@ mod tests {
     }
 
     /// Saves `file` and waits until the pass the save asks for has ended. `expectation` names
-    /// what the wait is for, and is shown when the wait times out.
-    fn save_and_wait_for_a_pass(client: &mut LspClient, file: &Path, expectation: &str) {
-        let passes_before = client.count_progress_end_messages();
-        client.save_document(file).expect("Failed to save document");
-        client
-            .wait_for_progress_end_count(passes_before + 1, PASS_TIMEOUT)
-            .expect(expectation);
-    }
-
     /// A program carrying one ordinary error, which the analysis finishes and reports.
     const PROGRAM_WITH_AN_UNKNOWN_NAME: &str =
         "module Main;\n\nmain : IO ();\nmain = println(nonexistent_name);\n";
@@ -548,11 +534,7 @@ mod tests {
         let main_fix = Path::new("main.fix");
 
         let mut client = open_session(&project_dir, main_fix, Duration::from_secs(10));
-        save_and_wait_for_a_pass(
-            &mut client,
-            main_fix,
-            "the pass over the program that panics is expected to end",
-        );
+        client.save_and_wait_for_a_pass(main_fix);
 
         // What the rest of this test measures exists only after a pass has panicked, so the panic
         // is asserted rather than assumed. A pass that fails publishes nothing, and the case
@@ -573,11 +555,7 @@ mod tests {
         client
             .change_document(main_fix)
             .expect("Failed to change document");
-        save_and_wait_for_a_pass(
-            &mut client,
-            main_fix,
-            "the pass over the repaired program is expected to end",
-        );
+        client.save_and_wait_for_a_pass(main_fix);
 
         let diagnostics = wait_until_diagnostics(&mut client, main_fix, |d| {
             carries_report(d, UNKNOWN_NAME_REPORT)
@@ -604,11 +582,7 @@ mod tests {
             .expect("Failed to write the program the session starts from");
 
         let mut client = open_session(&project_dir, main_fix, Duration::from_secs(10));
-        save_and_wait_for_a_pass(
-            &mut client,
-            main_fix,
-            "the pass over the program carrying an ordinary error is expected to end",
-        );
+        client.save_and_wait_for_a_pass(main_fix);
         let diagnostics = wait_until_diagnostics(&mut client, main_fix, |d| {
             carries_report(d, UNKNOWN_NAME_REPORT)
         });
@@ -617,11 +591,7 @@ mod tests {
         // The program written next, which the analysis fails on.
         fs::write(project_dir.join(main_fix), &program_the_analysis_fails_on)
             .expect("Failed to write the program the analysis fails on");
-        save_and_wait_for_a_pass(
-            &mut client,
-            main_fix,
-            "the pass over the program the analysis fails on is expected to end",
-        );
+        client.save_and_wait_for_a_pass(main_fix);
 
         // The report of the pass before, still where that pass put it. It is also what says the
         // pass failed: a pass that analyzed this program would report its duplicated type
@@ -631,11 +601,7 @@ mod tests {
         // The program written last, which the analysis finishes with nothing to report.
         fs::write(project_dir.join(main_fix), PROGRAM_WITHOUT_AN_ERROR)
             .expect("Failed to write the program carrying no error");
-        save_and_wait_for_a_pass(
-            &mut client,
-            main_fix,
-            "the pass over the program carrying no error is expected to end",
-        );
+        client.save_and_wait_for_a_pass(main_fix);
 
         let diagnostics = wait_until_diagnostics(&mut client, main_fix, |d| d.is_empty());
         assert!(
@@ -664,7 +630,7 @@ mod tests {
         let main_fix = Path::new("main.fix");
 
         let mut client = open_session(&project_dir, main_fix, Duration::from_secs(10));
-        save_and_wait_for_a_pass(&mut client, main_fix, "the first pass is expected to end");
+        client.save_and_wait_for_a_pass(main_fix);
         let diagnostics = wait_until_diagnostics(&mut client, main_fix, |d| {
             carries_report(d, UNKNOWN_NAME_REPORT)
         });

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -49,7 +49,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 project_dir,
@@ -77,7 +77,7 @@ mod tests {
                 .expect("Failed to send definition request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a definition response");
             response
                 .get("result")

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -75,10 +75,9 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send definition request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a definition response");
             response
                 .get("result")

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -8,6 +8,7 @@ mod tests {
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -75,8 +76,7 @@ mod tests {
 
     /// Read the substring of `file` covered by an LSP range.
     fn read_text_at_range(file: &Path, range: &Value) -> String {
-        let content =
-            std::fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
+        let content = fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
         let lines: Vec<&str> = content.lines().collect();
         let sl = range["start"]["line"].as_u64().unwrap() as usize;
         let sc = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -37,7 +37,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -76,9 +76,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
@@ -87,7 +85,8 @@ mod tests {
 
     /// Read the substring of `file` covered by an LSP range.
     fn read_text_at_range(file: &Path, range: &Value) -> String {
-        let content = fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
+        let content =
+            fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read file: {:?}", file));
         let lines: Vec<&str> = content.lines().collect();
         let sl = range["start"]["line"].as_u64().unwrap() as usize;
         let sc = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -14,12 +14,20 @@ mod tests {
     };
     use tempfile::TempDir;
 
+    /// A running language server over a private copy of one fixture project, with that
+    /// project's files open.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the copy alive; dropping it deletes
+        /// the copy.
         _temp_dir: TempDir,
     }
 
     impl LspTestCtx {
+        /// Start a server over a fresh copy of `project_name` and open each of `files`, paths
+        /// relative to the project root, in the given order. Returns once the last of them has
+        /// been elaborated, so the program the jumps are answered from is in place.
         fn setup(project_name: &str, files: &[&str]) -> Self {
             let (temp_dir, project_dir) = setup_test_env(project_name);
             let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
@@ -39,6 +47,8 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
@@ -64,6 +74,7 @@ mod tests {
                 .expect("Response should have a result field")
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -202,21 +213,17 @@ mod tests {
         let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);
         // Use at line 52, col 4.
         let result = ctx.goto_definition("lib.fix", 52, 4);
-        // Inner binder at line 51, col 8 (NOT the outer at line 50).
+        // The inner binder at line 51, col 8, which shadows the one at line 50.
         assert_location(&result, &ctx, "lib.fix", 51, 8, "s");
         ctx.shutdown();
     }
 
-    // --- Repro: source span missing on `&&`-desugared `if` ---
+    // --- The `if` that `&&` desugars to ---
     //
-    // `parse_expr_and` (parser.rs:1342) builds the synthesized
-    // `expr_if(lhs, rhs, expr_bool_lit(false, None), None)` with
-    // `source: None`. `ExprNode::find_node_at` short-circuits on a
-    // None source, so anything underneath the synthesized If is
-    // unreachable — including the LHS and RHS sub-expressions of
-    // `&&`. Hover, goto-definition, and find-references all break
-    // there. The outer `if`'s THEN/ELSE branches are not affected
-    // because they sit on the outer (user-written) `if`.
+    // `parse_expr_and` builds a synthesized `expr_if` for each `&&`, and gives it the span
+    // uniting its two operands. `ExprNode::find_node_at` walks into a node only through its
+    // span, so that span is what keeps the operands of `&&` reachable — to
+    // goto-definition here, and to hover and find-references alike.
 
     /// Cursor on `b` of `b >= 0` (LHS of `&&`).
     #[test]
@@ -239,7 +246,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Sanity: cursor on `b` inside `{ b }` (outer If's THEN branch) — works.
+    /// Cursor on `b` inside `{ b }`, the THEN branch of the user-written `if`.
     #[test]
     fn test_goto_local_and_then_branch() {
         let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -75,7 +75,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send definition request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             response
                 .get("result")
                 .cloned()

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -68,7 +68,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -75,10 +75,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send definition request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a definition response");
+            let response = self.client.response_of(id);
             response
                 .get("result")
                 .cloned()

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -4,8 +4,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
@@ -13,26 +13,8 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -52,13 +34,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/definition and return the result value (the LSP

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -7,8 +7,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         fs,
@@ -16,27 +16,6 @@ mod tests {
         time::Duration,
     };
     use tempfile::TempDir;
-
-    /// Absolute path to the LSP `cases/` directory.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test project into a fresh temp directory and
-    /// return both the temp dir handle (to keep it alive) and the
-    /// canonicalised path of the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// Per-test LSP harness: owns the running language server, the
     /// temp directory holding the copied project, and the project
@@ -73,7 +52,7 @@ mod tests {
 
         /// Build a `file://` URI for `file` relative to the project root.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/hover and return the result value (the LSP

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -90,10 +90,9 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send hover request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a hover response");
             response
                 .get("result")
@@ -232,10 +231,9 @@ mod tests {
                 }),
             )
             .expect("Failed to send definition request");
-        ctx.client.wait_for_server(Duration::from_secs(5));
         let response = ctx
             .client
-            .get_response(id)
+            .wait_for_response(id, Duration::from_secs(5))
             .expect("Should receive a definition response");
         let result = response
             .get("result")

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -83,7 +83,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -90,10 +90,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send hover request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a hover response");
+            let response = self.client.response_of(id);
             response
                 .get("result")
                 .cloned()
@@ -231,10 +228,7 @@ mod tests {
                 }),
             )
             .expect("Failed to send definition request");
-        let response = ctx
-            .client
-            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-            .expect("Should receive a definition response");
+        let response = ctx.client.response_of(id);
         let result = response
             .get("result")
             .cloned()

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -7,7 +7,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -43,7 +43,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -83,9 +83,7 @@ mod tests {
         /// Shut the server down; panics if it fails to exit or if its reader
         /// thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -90,7 +90,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send hover request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             response
                 .get("result")
                 .cloned()
@@ -228,7 +228,7 @@ mod tests {
                 }),
             )
             .expect("Failed to send definition request");
-        let response = ctx.client.response_of(id);
+        let response = ctx.client.expect_response(id);
         let result = response
             .get("result")
             .cloned()

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -63,7 +63,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 project_dir,
@@ -92,7 +92,7 @@ mod tests {
                 .expect("Failed to send hover request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a hover response");
             response
                 .get("result")
@@ -233,7 +233,7 @@ mod tests {
             .expect("Failed to send definition request");
         let response = ctx
             .client
-            .wait_for_response(id, Duration::from_secs(5))
+            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
             .expect("Should receive a definition response");
         let result = response
             .get("result")

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -21,8 +21,12 @@ mod tests {
     /// temp directory holding the copied project, and the project
     /// path itself.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// The copy of the fixture project the server was started on.
         project_dir: PathBuf,
+        /// Holds the temporary directory containing `project_dir` alive; dropping
+        /// it deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -76,8 +80,8 @@ mod tests {
                 .expect("Response should have a result field")
         }
 
-        /// Cleanly shut down the LSP server and join its reader
-        /// thread; panics if either step fails.
+        /// Shut the server down; panics if it fails to exit or if its reader
+        /// thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))

--- a/src/tests/test_lsp/test_polling.rs
+++ b/src/tests/test_lsp/test_polling.rs
@@ -50,9 +50,9 @@ mod tests {
     /// wait that gives up without taking the second one answers nothing at all.
     #[test]
     fn test_a_wait_looks_once_more_when_its_time_runs_out() {
-        let span = Duration::from_millis(100);
+        let interval = Duration::from_millis(100);
         let mut looks = 0;
-        let answer = poll_every(span, span, || {
+        let answer = poll_every(interval, interval, || {
             looks += 1;
             (looks > 1).then_some(looks)
         });

--- a/src/tests/test_lsp/test_polling.rs
+++ b/src/tests/test_lsp/test_polling.rs
@@ -1,18 +1,18 @@
-//! What the polling the harness waits by promises.
+//! What `poll_every` promises.
 //!
-//! Every wait in this directory is written on `poll_every`, so what it promises is what a wait
-//! for a response, for a pass, or for the server's exit means.
+//! Every wait in this directory is built on `poll_every`, so its promises are what a wait for a
+//! response, for a pass, or for the server's exit means.
 
 #[cfg(test)]
 mod tests {
     use super::super::lsp_client::poll_every;
     use std::time::{Duration, Instant};
 
-    /// A wait whose condition already holds hands that look's answer back and stops, so that a
+    /// A wait whose condition already holds returns that look's answer and stops, so that a
     /// test asking for what the server has already sent pays nothing for the asking.
     ///
-    /// The timeout is empty, which leaves the wait with no time to spend, and the interval is
-    /// long enough that a wait spending any shows it.
+    /// The timeout is zero, so the wait has no time to spend, and the interval is long enough
+    /// that a wait sleeping even once takes longer than the assertion allows.
     #[test]
     fn test_a_wait_answers_a_condition_that_already_holds() {
         /// The gap between two looks.
@@ -43,7 +43,7 @@ mod tests {
     }
 
     /// A wait looks once more when its time runs out, so that a condition turning true while the
-    /// wait sleeps is answered rather than missed.
+    /// wait sleeps is still answered.
     ///
     /// The interval is the whole timeout, so the wait sleeps once and the look after that sleep
     /// is the one taken at the deadline. The condition answers nothing on the first look, so a

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -133,7 +133,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
 

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -6,8 +6,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
+    use crate::misc::Set;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
@@ -15,34 +16,10 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    // -----------------------------------------------------------------------
-    // Helpers
-    // -----------------------------------------------------------------------
-
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        // Canonicalize to resolve symlinks (e.g., /tmp -> /private/tmp on macOS).
-        // This ensures the path matches the canonicalized rootUri sent to the LSP server.
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     /// A convenience wrapper around `LspClient` that provides high-level
     /// helpers for common test patterns (find-refs, call hierarchy, etc.).
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -64,13 +41,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/references and return the result array.
@@ -209,7 +185,7 @@ mod tests {
                 Some(format!("{}:{}:{}", uri, line, ch))
             })
             .collect();
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = Set::default();
         for key in &keys {
             assert!(
                 seen.insert(key),

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -61,7 +61,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 project_dir,
@@ -89,7 +89,7 @@ mod tests {
                 .expect("Failed to send references request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a references response");
             let result = response
                 .get("result")
@@ -120,7 +120,7 @@ mod tests {
                 .expect("Failed to send prepareCallHierarchy request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive prepareCallHierarchy response");
             let result = response
                 .get("result")
@@ -137,7 +137,7 @@ mod tests {
                 .expect("Failed to send incomingCalls request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive incomingCalls response");
             let result = response
                 .get("result")
@@ -155,7 +155,7 @@ mod tests {
                 .expect("Failed to send outgoingCalls request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive outgoingCalls response");
             let result = response
                 .get("result")

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::misc::Set;
     use serde_json::{json, Value};
@@ -39,7 +39,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -136,9 +136,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
@@ -206,8 +204,8 @@ mod tests {
 
     /// Read the text at an LSP range from a source file.
     fn read_text_at_range(file_path: &Path, range: &Value) -> String {
-        let content =
-            fs::read_to_string(file_path).expect(&format!("Failed to read file: {:?}", file_path));
+        let content = fs::read_to_string(file_path)
+            .unwrap_or_else(|_| panic!("Failed to read file: {:?}", file_path));
         let lines: Vec<&str> = content.lines().collect();
         let start_line = range["start"]["line"].as_u64().unwrap() as usize;
         let start_char = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -87,7 +87,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send references request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -115,7 +115,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareCallHierarchy request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -129,7 +129,7 @@ mod tests {
                 .client
                 .send_request("callHierarchy/incomingCalls", json!({ "item": item }))
                 .expect("Failed to send incomingCalls request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -144,7 +144,7 @@ mod tests {
                 .client
                 .send_request("callHierarchy/outgoingCalls", json!({ "item": item }))
                 .expect("Failed to send outgoingCalls request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -87,10 +87,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send references request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a references response");
+            let response = self.client.response_of(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -118,10 +115,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareCallHierarchy request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive prepareCallHierarchy response");
+            let response = self.client.response_of(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -135,10 +129,7 @@ mod tests {
                 .client
                 .send_request("callHierarchy/incomingCalls", json!({ "item": item }))
                 .expect("Failed to send incomingCalls request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive incomingCalls response");
+            let response = self.client.response_of(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");
@@ -153,10 +144,7 @@ mod tests {
                 .client
                 .send_request("callHierarchy/outgoingCalls", json!({ "item": item }))
                 .expect("Failed to send outgoingCalls request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive outgoingCalls response");
+            let response = self.client.response_of(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::misc::Set;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -199,8 +200,8 @@ mod tests {
 
     /// Read the text at an LSP range from a source file.
     fn read_text_at_range(file_path: &Path, range: &Value) -> String {
-        let content = std::fs::read_to_string(file_path)
-            .expect(&format!("Failed to read file: {:?}", file_path));
+        let content =
+            fs::read_to_string(file_path).expect(&format!("Failed to read file: {:?}", file_path));
         let lines: Vec<&str> = content.lines().collect();
         let start_line = range["start"]["line"].as_u64().unwrap() as usize;
         let start_char = range["start"]["character"].as_u64().unwrap() as usize;
@@ -876,7 +877,7 @@ mod tests {
         let mut found_caret_x = false;
         for loc in &locs {
             let uri = loc["uri"].as_str().unwrap();
-            let file_path = std::path::PathBuf::from(uri.strip_prefix("file://").unwrap());
+            let file_path = PathBuf::from(uri.strip_prefix("file://").unwrap());
             let text = read_text_at_range(&file_path, loc.get("range").unwrap());
             if text == "^x" {
                 found_caret_x = true;

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -1,8 +1,8 @@
 // LSP integration tests for "Find All References" and "Call Hierarchy" features.
 //
-// Each test case corresponds to a case in agents/test-refs.20260301/test_plan.md.
-// Each symbol-type group has its own Fix project under cases/ to keep tests simple
-// and resilient to line-number changes.
+// Each symbol kind has its own Fix project under cases/, which keeps the tests simple and
+// resilient to line-number changes. The tests of one kind carry that kind's label (`GV`, `Ty`,
+// `Tr`, `TrA`, `AT`, `IMP`, `FV`, `Loc`) and a number within it.
 
 #[cfg(test)]
 mod tests {
@@ -20,7 +20,10 @@ mod tests {
     /// A convenience wrapper around `LspClient` that provides high-level
     /// helpers for common test patterns (find-refs, call hierarchy, etc.).
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the project copy alive; dropping it
+        /// deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -46,6 +49,8 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
@@ -129,6 +134,7 @@ mod tests {
             result.as_array().unwrap().clone()
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -229,6 +235,7 @@ mod tests {
         text == full_name || full_name.ends_with(&format!("::{}", text))
     }
 
+    /// Assert that at least one of `locations` names a file whose URI contains `file_name`.
     fn assert_has_ref_in_file(locations: &[Value], file_name: &str) {
         assert!(
             locations.iter().any(|loc| loc
@@ -241,6 +248,8 @@ mod tests {
         );
     }
 
+    /// The name of the item at each call's `direction` end, `direction` being `"from"` for an
+    /// incoming call and `"to"` for an outgoing one.
     fn call_names(calls: &[Value], direction: &str) -> Vec<String> {
         calls
             .iter()
@@ -253,6 +262,8 @@ mod tests {
             .collect()
     }
 
+    /// Assert that one of the incoming `calls` comes from an item whose name contains
+    /// `name_fragment`.
     fn assert_has_caller(calls: &[Value], name_fragment: &str) {
         let names = call_names(calls, "from");
         assert!(
@@ -263,6 +274,8 @@ mod tests {
         );
     }
 
+    /// Assert that one of the outgoing `calls` goes to an item whose name contains
+    /// `name_fragment`.
     #[allow(dead_code)]
     fn assert_has_callee(calls: &[Value], name_fragment: &str) {
         let names = call_names(calls, "to");

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -87,10 +87,9 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send references request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a references response");
             let result = response
                 .get("result")
@@ -119,10 +118,9 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareCallHierarchy request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive prepareCallHierarchy response");
             let result = response
                 .get("result")
@@ -137,10 +135,9 @@ mod tests {
                 .client
                 .send_request("callHierarchy/incomingCalls", json!({ "item": item }))
                 .expect("Failed to send incomingCalls request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive incomingCalls response");
             let result = response
                 .get("result")
@@ -156,10 +153,9 @@ mod tests {
                 .client
                 .send_request("callHierarchy/outgoingCalls", json!({ "item": item }))
                 .expect("Failed to send outgoingCalls request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive outgoingCalls response");
             let result = response
                 .get("result")

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -51,7 +51,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 project_dir,
@@ -79,7 +79,7 @@ mod tests {
                 )
                 .expect("Failed to send rename request");
             self.client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a rename response")
         }
 
@@ -112,7 +112,7 @@ mod tests {
                 )
                 .expect("Failed to send prepareRename request");
             self.client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a prepareRename response")
         }
 

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -78,9 +78,8 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send rename request");
-            self.client.wait_for_server(Duration::from_secs(5));
             self.client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a rename response")
         }
 
@@ -112,9 +111,8 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareRename request");
-            self.client.wait_for_server(Duration::from_secs(5));
             self.client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a prepareRename response")
         }
 
@@ -716,9 +714,6 @@ mod tests {
                 }),
             )
             .expect("Failed to send didChange");
-        // Give the server a moment to process the notification (no
-        // diagnostic re-run is triggered, so the AST stays stale).
-        ctx.client.wait_for_server(Duration::from_millis(300));
 
         let resp = ctx.rename_raw("lib.fix", 3, 5, "Counter");
         let msg = resp
@@ -751,7 +746,6 @@ mod tests {
                 }),
             )
             .expect("Failed to send didChange");
-        ctx.client.wait_for_server(Duration::from_millis(300));
 
         let resp = ctx.prepare_rename_raw("lib.fix", 3, 5);
         let msg = resp

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -8,12 +8,20 @@ mod tests {
     use std::{path::Path, time::Duration};
     use tempfile::TempDir;
 
+    /// A running language server over a private copy of one fixture project, with that
+    /// project's files open.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the copy alive; dropping it deletes
+        /// the copy.
         _temp_dir: TempDir,
     }
 
     impl LspTestCtx {
+        /// Start a server over a fresh copy of `project_name` and open each of `files`, paths
+        /// relative to the project root, in the given order. Returns once the last of them has
+        /// been elaborated, so the program the renames are worked out from is in place.
         fn setup(project_name: &str, files: &[&str]) -> Self {
             let (temp_dir, project_dir) = setup_test_env(project_name);
             let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
@@ -33,12 +41,14 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
 
-        // Send `textDocument/rename` and return the response value (full
-        // JSON-RPC response object, including any error).
+        /// Send `textDocument/rename` and return the whole JSON-RPC response, an error
+        /// among its fields included.
         fn rename_raw(&mut self, file: &str, line: u32, col: u32, new_name: &str) -> Value {
             let uri = self.file_uri(file);
             let id = self
@@ -55,8 +65,8 @@ mod tests {
             self.client.expect_response(id)
         }
 
-        // Send `textDocument/rename` and unwrap the `result` (asserting it
-        // is a `WorkspaceEdit` rather than an error).
+        /// Send `textDocument/rename` and return the `WorkspaceEdit` of its `result`,
+        /// asserting that the server answered with one.
         fn rename(&mut self, file: &str, line: u32, col: u32, new_name: &str) -> Value {
             let resp = self.rename_raw(file, line, col, new_name);
             assert!(
@@ -69,8 +79,8 @@ mod tests {
                 .clone()
         }
 
-        // Send `textDocument/prepareRename` and return the full response
-        // value (so tests can inspect `result` and `error` independently).
+        /// Send `textDocument/prepareRename` and return the whole JSON-RPC response, so
+        /// that a test can read its `result` and its `error` each on its own.
         fn prepare_rename_raw(&mut self, file: &str, line: u32, col: u32) -> Value {
             let uri = self.file_uri(file);
             let id = self
@@ -86,8 +96,8 @@ mod tests {
             self.client.expect_response(id)
         }
 
-        // Send `textDocument/prepareRename` and return the `result`
-        // value; panics if the server returned a `ResponseError`.
+        /// Send `textDocument/prepareRename` and return the `result` value; panics if the
+        /// server answered with a `ResponseError`.
         fn prepare_rename(&mut self, file: &str, line: u32, col: u32) -> Value {
             let resp = self.prepare_rename_raw(file, line, col);
             assert!(
@@ -100,6 +110,7 @@ mod tests {
                 .clone()
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -110,8 +121,7 @@ mod tests {
         }
     }
 
-    // Count the total number of TextEdits across every URI in a
-    // WorkspaceEdit `result` value.
+    /// The number of `TextEdit`s a `WorkspaceEdit` carries, over all the URIs it changes.
     fn count_edits(workspace_edit: &Value) -> usize {
         workspace_edit
             .get("changes")
@@ -124,7 +134,8 @@ mod tests {
             .unwrap_or(0)
     }
 
-    // Collect (uri suffix, count) pairs for the changes in a WorkspaceEdit.
+    /// The file name of each URI a `WorkspaceEdit` changes, paired with how many
+    /// `TextEdit`s it carries for that URI, sorted by file name.
     fn changes_per_file(workspace_edit: &Value) -> Vec<(String, usize)> {
         workspace_edit
             .get("changes")
@@ -144,6 +155,7 @@ mod tests {
             .unwrap_or_default()
     }
 
+    /// Assert that every `TextEdit` of `workspace_edit` writes `new_name` and nothing else.
     fn assert_all_edits_have_new_text(workspace_edit: &Value, new_name: &str) {
         let changes = workspace_edit
             .get("changes")
@@ -179,7 +191,7 @@ mod tests {
     //  11: );
     // =======================================================================
 
-    /// RB-1: rename a global value across files. Cursor on the declaration
+    /// Rename a global value across files. Cursor on the declaration
     /// LHS in lib.fix.
     #[test]
     fn test_rename_global_decl() {
@@ -202,7 +214,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-2: rename a global value, starting from a use site in lib.fix.
+    /// Rename a global value, starting from a use site in lib.fix.
     #[test]
     fn test_rename_global_from_use_same_file() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -212,7 +224,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-3: rename a global value, starting from a use site in main.fix.
+    /// Rename a global value, starting from a use site in main.fix.
     #[test]
     fn test_rename_global_from_use_other_file() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -222,7 +234,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-4: rename a global value, starting from the import statement.
+    /// Rename a global value, starting from the import statement.
     #[test]
     fn test_rename_global_from_import() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -260,7 +272,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-5: rename a local let-bound variable.
+    /// Rename a local let-bound variable.
     #[test]
     fn test_rename_local_let() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -274,7 +286,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-6: rename rejected on an invalid identifier (keyword).
+    /// Rename rejected on an invalid identifier (keyword).
     #[test]
     fn test_rename_reject_keyword() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -287,7 +299,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-7: rename rejected on an invalid identifier (uppercase start).
+    /// Rename rejected on an invalid identifier (uppercase start).
     #[test]
     fn test_rename_reject_uppercase() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -300,7 +312,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-8: prepareRename returns defaultBehavior for a global value.
+    /// `prepareRename` returns defaultBehavior for a global value.
     #[test]
     fn test_prepare_rename_global_value() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -317,7 +329,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-9: prepareRename returns defaultBehavior for a local variable.
+    /// `prepareRename` returns defaultBehavior for a local variable.
     #[test]
     fn test_prepare_rename_local() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -333,7 +345,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-10: prepareRename returns defaultBehavior on a struct type.
+    /// `prepareRename` returns defaultBehavior on a struct type.
     #[test]
     fn test_prepare_rename_struct_type() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -372,7 +384,7 @@ mod tests {
     //   4: bump : MyInt -> MyInt;           (cols 7, 16)
     // =======================================================================
 
-    /// RT-1: rename a type alias from its declaration.
+    /// Rename a type alias from its declaration.
     #[test]
     fn test_rename_type_alias_decl() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -388,7 +400,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-2: rename a trait.
+    /// Rename a trait.
     #[test]
     fn test_rename_trait() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -400,7 +412,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-3: rename a struct field. Auto-method occurrences (`@x`,
+    /// Rename a struct field. Auto-method occurrences (`@x`,
     /// `[^x]`) must switch to `@new_name` / `^new_name`, and the bare
     /// field-name (decl + MakeStruct) edits must use just `new_name`.
     #[test]
@@ -441,7 +453,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-4: rename a union variant. Pattern::Union and bare-name
+    /// Rename a union variant. Pattern::Union and bare-name
     /// occurrences both update.
     #[test]
     fn test_rename_union_variant() {
@@ -454,7 +466,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-5: rename a type alias from a use site in another file.
+    /// Rename a type alias from a use site in another file.
     #[test]
     fn test_rename_type_alias_from_other_file() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -464,7 +476,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-6: renaming a struct type renames every bare-name occurrence
+    /// Renaming a struct type renames every bare-name occurrence
     /// (declaration, MakeStruct, type sigs, impl blocks).
     #[test]
     fn test_rename_struct_type() {
@@ -479,7 +491,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-7: renaming a union type renames every bare-name occurrence.
+    /// Renaming a union type renames every bare-name occurrence.
     #[test]
     fn test_rename_union_type() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -491,7 +503,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-8: renaming a struct field to `@y` is rejected by the
+    /// Renaming a struct field to `@y` is rejected by the
     /// `type_field_name` rule (no leading `@`).
     #[test]
     fn test_rename_field_reject_at_prefix() {
@@ -505,7 +517,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-9: renaming a type alias to a lowercase name is rejected by the
+    /// Renaming a type alias to a lowercase name is rejected by the
     /// `capital_name` rule.
     #[test]
     fn test_rename_type_alias_reject_lowercase() {
@@ -519,7 +531,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-10: prepareRename returns defaultBehavior for a type alias.
+    /// `prepareRename` returns defaultBehavior for a type alias.
     #[test]
     fn test_prepare_rename_type_alias() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -535,7 +547,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-11: prepareRename returns defaultBehavior for a trait.
+    /// `prepareRename` returns defaultBehavior for a trait.
     #[test]
     fn test_prepare_rename_trait() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -551,7 +563,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-12: prepareRename returns defaultBehavior for a struct field.
+    /// `prepareRename` returns defaultBehavior for a struct field.
     #[test]
     fn test_prepare_rename_field() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -572,7 +584,7 @@ mod tests {
     // stale-buffer rejection.
     // =======================================================================
 
-    /// RG-1: rename rejected on `@x` (auto-generated getter).
+    /// Rename rejected on `@x` (auto-generated getter).
     #[test]
     fn test_rename_reject_at_accessor() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -591,7 +603,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-2: rename rejected on `[^x]` index syntax (the Var the parser
+    /// Rename rejected on `[^x]` index syntax (the Var the parser
     /// generates is `Point::act_x`, also auto-generated).
     #[test]
     fn test_rename_reject_index_syntax() {
@@ -606,7 +618,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-3: prepareRename returns a ResponseError with an explanatory
+    /// `prepareRename` returns a ResponseError with an explanatory
     /// message on an auto-generated accessor (so the editor can surface
     /// a useful message instead of the generic "can't be renamed").
     #[test]
@@ -626,7 +638,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-4: rename rejected on a Std symbol (defined outside the project).
+    /// Rename rejected on a Std symbol (defined outside the project).
     /// The cursor on `I64` in `type MyInt = I64;` resolves to `Std::I64`,
     /// which is not in the diagnostics result's `user_source_contents`.
     #[test]
@@ -647,7 +659,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-5: prepareRename returns a ResponseError on an external symbol.
+    /// `prepareRename` returns a ResponseError on an external symbol.
     #[test]
     fn test_prepare_rename_reject_external() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -665,7 +677,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-6: rename rejected after the buffer drifts from the AST.
+    /// Rename rejected after the buffer drifts from the AST.
     /// We send a didChange with modified text but don't trigger a rebuild,
     /// so the recorded `user_source_contents[lib.fix]` is now out of sync.
     #[test]
@@ -699,7 +711,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-7: prepareRename returns a ResponseError when the buffer is
+    /// `prepareRename` returns a ResponseError when the buffer is
     /// stale, so the editor can show the actionable message ("save and
     /// wait for diagnostics").
     #[test]
@@ -754,7 +766,7 @@ mod tests {
     //  13: qualified_idx = |p| p[^Point::x].iset(0);  (col 23 = inline `Point`)
     // =======================================================================
 
-    /// RD-1: rename a struct type and observe that all bare uses, the
+    /// Rename a struct type and observe that all bare uses, the
     /// auto-namespace component in the all-auto import, and the inline
     /// qualified Var references are all rewritten.
     #[test]
@@ -793,9 +805,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-2: the user-defined namespace block in lib.fix
-    /// (`namespace Point { ... }`) must NOT be touched, because its
-    /// `Point` is a user-written namespace name, independent of the type.
+    /// The user-defined namespace block in lib.fix (`namespace Point { ... }`) is left as
+    /// it stands when the type is renamed, because its `Point` is a user-written namespace
+    /// name, independent of the type.
     #[test]
     fn test_rename_struct_type_skips_user_namespace_block() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -818,9 +830,8 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-3: the inline qualified reference `Point::@x` in main.fix has
-    /// just its `Point` sub-span rewritten to `Pixel`, leaving `::@x`.
-    /// We verify by reading the post-edit text at the reported range.
+    /// The inline qualified reference `Point::@x` in main.fix has just its `Point` sub-span
+    /// rewritten to `Pixel`, leaving `::@x` as it stands.
     #[test]
     fn test_rename_struct_type_inline_qualified_var() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -858,7 +869,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-4: the qualified index syntax `[^Point::x]` has its `Point`
+    /// The qualified index syntax `[^Point::x]` has its `Point`
     /// sub-span rewritten too — Var.source covers `^Point::x`, so the
     /// `^` is skipped during sub-span extraction.
     #[test]
@@ -896,7 +907,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-5: prepareRename returns defaultBehavior on a struct type.
+    /// `prepareRename` returns defaultBehavior on a struct type.
     #[test]
     fn test_prepare_rename_struct_type_phase_d() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -912,11 +923,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-6 regression: a qualified call to a user-defined helper
-    /// (`MinCostFlowGraph::create(...)`) sitting in the type's
-    /// namespace must NOT have its `MinCostFlowGraph::` prefix rewritten
-    /// when the type is renamed. Only auto-generated accessors travel
-    /// with the type.
+    /// A qualified call to a user-defined helper (`MinCostFlowGraph::create(...)`) sitting
+    /// in the type's namespace keeps its `MinCostFlowGraph::` prefix when the type is
+    /// renamed. Only auto-generated accessors travel with the type.
     #[test]
     fn test_rename_struct_type_skips_user_helper_qualified_call() {
         let mut ctx = LspTestCtx::setup("rename_user_helper_qualified", &["lib.fix", "main.fix"]);
@@ -957,7 +966,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-7: a mixed import (`Lib::{Point::{act_x, user_helper}}`) is
+    /// A mixed import (`Lib::{Point::{act_x, user_helper}}`) is
     /// rebuilt as a single TextEdit covering the entire import statement.
     /// The new text must contain both `Pixel::` (for the auto-method
     /// half) and `Point::` (for the user-defined half).

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{path::Path, time::Duration};
@@ -31,7 +31,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -112,9 +112,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -105,7 +105,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -2,39 +2,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
-    use std::{
-        path::{Path, PathBuf},
-        time::Duration,
-    };
+    use std::{path::Path, time::Duration};
     use tempfile::TempDir;
-
-    // -----------------------------------------------------------------------
-    // Helpers
-    // -----------------------------------------------------------------------
-
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -54,13 +29,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         // Send `textDocument/rename` and return the response value (full

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -78,9 +78,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send rename request");
-            self.client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a rename response")
+            self.client.response_of(id)
         }
 
         // Send `textDocument/rename` and unwrap the `result` (asserting it
@@ -111,9 +109,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareRename request");
-            self.client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a prepareRename response")
+            self.client.response_of(id)
         }
 
         // Send `textDocument/prepareRename` and return the `result`

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -78,7 +78,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send rename request");
-            self.client.response_of(id)
+            self.client.expect_response(id)
         }
 
         // Send `textDocument/rename` and unwrap the `result` (asserting it
@@ -109,7 +109,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send prepareRename request");
-            self.client.response_of(id)
+            self.client.expect_response(id)
         }
 
         // Send `textDocument/prepareRename` and return the `result`

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -13,15 +13,14 @@ mod tests {
     use std::time::Duration;
     use tempfile::TempDir;
 
+    /// How long a request is given to be answered.
+    const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// The response to the request `id`, waited for until it arrives.
     fn wait_for_response(client: &mut LspClient, id: u32) -> Value {
-        for _ in 0..50 {
-            if let Some(response) = client.get_response(id) {
-                return response;
-            }
-            client.wait_for_server(Duration::from_millis(100));
-        }
-        panic!("the request {} is expected to be answered", id);
+        client
+            .wait_for_response(id, RESPONSE_TIMEOUT)
+            .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
     }
 
     /// The delta-encoded semantic tokens the server answers for the buffer `uri` names.

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -97,9 +97,7 @@ mod tests {
         // the message above sends no progress, and the wait times out.
         client.save_and_wait_for_the_program(lib_fix);
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
@@ -187,9 +185,7 @@ mod tests {
             decodable
         );
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
@@ -220,9 +216,7 @@ mod tests {
             "a uri naming no file on disk is expected to be answered with no symbols"
         );
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -8,17 +8,10 @@
 mod tests {
     use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use serde_json::{json, Value};
+    use serde_json::json;
     use std::path::{Path, PathBuf};
     use std::time::Duration;
     use tempfile::TempDir;
-
-    /// The response to the request `id`, waited for until it arrives.
-    fn wait_for_response(client: &mut LspClient, id: u32) -> Value {
-        client
-            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-            .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
-    }
 
     /// The delta-encoded semantic tokens the server answers for the buffer `uri` names.
     fn semantic_token_data(client: &mut LspClient, uri: &str) -> Vec<u64> {
@@ -28,7 +21,7 @@ mod tests {
                 json!({ "textDocument": { "uri": uri } }),
             )
             .expect("Failed to send semanticTokens");
-        wait_for_response(client, id)["result"]["data"]
+        client.response_of(id)["result"]["data"]
             .as_array()
             .expect("a semanticTokens response carries its data")
             .iter()
@@ -44,7 +37,7 @@ mod tests {
                 json!({ "textDocument": { "uri": uri } }),
             )
             .expect("Failed to send documentSymbol");
-        wait_for_response(client, id)["result"]
+        client.response_of(id)["result"]
             .as_array()
             .expect("a documentSymbol response carries an array of symbols")
             .iter()

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -21,7 +21,7 @@ mod tests {
                 json!({ "textDocument": { "uri": uri } }),
             )
             .expect("Failed to send semanticTokens");
-        client.response_of(id)["result"]["data"]
+        client.expect_response(id)["result"]["data"]
             .as_array()
             .expect("a semanticTokens response carries its data")
             .iter()
@@ -37,7 +37,7 @@ mod tests {
                 json!({ "textDocument": { "uri": uri } }),
             )
             .expect("Failed to send documentSymbol");
-        client.response_of(id)["result"]
+        client.expect_response(id)["result"]
             .as_array()
             .expect("a documentSymbol response carries an array of symbols")
             .iter()

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -13,13 +13,10 @@ mod tests {
     use std::time::Duration;
     use tempfile::TempDir;
 
-    /// How long a request is given to be answered.
-    const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-
     /// The response to the request `id`, waited for until it arrives.
     fn wait_for_response(client: &mut LspClient, id: u32) -> Value {
         client
-            .wait_for_response(id, RESPONSE_TIMEOUT)
+            .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
             .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
     }
 
@@ -68,7 +65,7 @@ mod tests {
             .initialize(&project_dir, Duration::from_secs(10))
             .expect("Failed to initialize LSP");
         client.open_document(file).expect("Failed to open document");
-        client.trigger_and_wait_for_diagnostics(file);
+        client.save_and_wait_for_the_program(file);
         (temp_dir, project_dir, client)
     }
 
@@ -105,7 +102,7 @@ mod tests {
 
         // The pass this asks for is what says the server is still running: a server that ended on
         // the message above sends no progress, and the wait times out.
-        client.trigger_and_wait_for_diagnostics(lib_fix);
+        client.save_and_wait_for_the_program(lib_fix);
 
         client
             .shutdown(Duration::from_millis(500))

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -101,7 +101,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -191,7 +191,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -224,7 +224,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -157,12 +157,11 @@ mod tests {
         /// after the progress-end notification, so retry until a typechecked
         /// token (a local variable, which only the overlay emits) appears.
         fn token_types_with_overlay(&mut self, file: &str) -> Vec<u64> {
-            let mut last_seen = Vec::new();
-            poll_every(OVERLAY_RETRY_INTERVAL, OVERLAY_TIMEOUT, || {
-                last_seen = self.token_types(file);
-                last_seen.contains(&T_VARIABLE).then(|| last_seen.clone())
-            })
-            .unwrap_or(last_seen)
+            let with_overlay = poll_every(OVERLAY_RETRY_INTERVAL, OVERLAY_TIMEOUT, || {
+                let types = self.token_types(file);
+                types.contains(&T_VARIABLE).then_some(types)
+            });
+            with_overlay.unwrap_or_else(|| self.token_types(file))
         }
 
         /// Replace the whole content of `file` via a `didChange` notification.

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,12 +9,13 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::lsp_client::LspClient;
+    use super::super::lsp_client::{LspClient, POLL_INTERVAL};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::{
         path::{Path, PathBuf},
-        time::Duration,
+        thread,
+        time::{Duration, Instant},
     };
     use tempfile::TempDir;
 
@@ -64,6 +65,12 @@ mod tests {
         _temp_dir: TempDir,
     }
 
+    /// How long a `semanticTokens` request is given to be answered.
+    const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// How long the overlay a finished analysis adds to the tokens is waited for.
+    const OVERLAY_TIMEOUT: Duration = Duration::from_secs(10);
+
     impl Ctx {
         /// Start a server on a fresh copy of the `semantic_tokens` project, open
         /// `main.fix`, and wait for an initial elaboration.
@@ -111,15 +118,10 @@ mod tests {
                     json!({ "textDocument": { "uri": uri } }),
                 )
                 .expect("Failed to send semanticTokens request");
-            let mut response = None;
-            for _ in 0..50 {
-                if let Some(r) = self.client.get_response(id) {
-                    response = Some(r);
-                    break;
-                }
-                self.client.wait_for_server(Duration::from_millis(100));
-            }
-            let response = response.expect("Should receive a semanticTokens response");
+            let response = self
+                .client
+                .wait_for_response(id, RESPONSE_TIMEOUT)
+                .expect("Should receive a semanticTokens response");
             let data = response
                 .get("result")
                 .and_then(|r| r.get("data"))
@@ -158,14 +160,14 @@ mod tests {
         /// after the progress-end notification, so retry until a typechecked
         /// token (a local variable, which only the overlay emits) appears.
         fn token_types_with_overlay(&mut self, file: &str) -> Vec<u64> {
-            for _ in 0..40 {
+            let deadline = Instant::now() + OVERLAY_TIMEOUT;
+            loop {
                 let types = self.token_types(file);
-                if types.contains(&T_VARIABLE) {
+                if types.contains(&T_VARIABLE) || Instant::now() >= deadline {
                     return types;
                 }
-                self.client.wait_for_server(Duration::from_millis(250));
+                thread::sleep(POLL_INTERVAL);
             }
-            self.token_types(file)
         }
 
         /// Replace the whole content of `file` via a `didChange` notification.
@@ -180,7 +182,6 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send didChange");
-            self.client.wait_for_server(Duration::from_millis(300));
         }
 
         /// Shut the server down cleanly and join its reader thread.

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -80,7 +80,6 @@ mod tests {
 
         /// Request semantic tokens and return the flat list of per-token type
         /// indices (the 4th element of each 5-tuple in the delta-encoded data).
-        /// Polls for the response rather than sleeping a fixed time.
         fn token_types(&mut self, file: &str) -> Vec<u64> {
             self.token_data(file)
                 .chunks_exact(5)
@@ -158,7 +157,7 @@ mod tests {
                 .expect("Failed to send didChange");
         }
 
-        /// Shut the server down cleanly and join its reader thread.
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -234,8 +233,8 @@ mod tests {
     }
 
     /// Verifies that on a broken / drifted buffer the server still responds with
-    /// the base lexical layer, and does NOT emit the AST overlay (which would be
-    /// misaligned), so no variable/function tokens appear.
+    /// the base lexical layer, and withholds the AST overlay, which would be
+    /// misaligned there: the answer carries base-layer token types alone.
     #[test]
     fn test_semantic_tokens_base_layer_survives_broken_buffer() {
         let mut ctx = LspSemanticTokensCtx::setup();

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,13 +9,12 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::lsp_client::LspClient;
+    use super::super::lsp_client::{poll_every, LspClient};
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::{
         path::{Path, PathBuf},
-        thread,
-        time::{Duration, Instant},
+        time::Duration,
     };
     use tempfile::TempDir;
 
@@ -158,14 +157,12 @@ mod tests {
         /// after the progress-end notification, so retry until a typechecked
         /// token (a local variable, which only the overlay emits) appears.
         fn token_types_with_overlay(&mut self, file: &str) -> Vec<u64> {
-            let deadline = Instant::now() + OVERLAY_TIMEOUT;
-            loop {
-                let types = self.token_types(file);
-                if types.contains(&T_VARIABLE) || Instant::now() >= deadline {
-                    return types;
-                }
-                thread::sleep(OVERLAY_RETRY_INTERVAL);
-            }
+            let mut last_seen = Vec::new();
+            poll_every(OVERLAY_RETRY_INTERVAL, OVERLAY_TIMEOUT, || {
+                last_seen = self.token_types(file);
+                last_seen.contains(&T_VARIABLE).then(|| last_seen.clone())
+            })
+            .unwrap_or(last_seen)
         }
 
         /// Replace the whole content of `file` via a `didChange` notification.

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,8 +9,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::{poll_every, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::{
         path::{Path, PathBuf},
@@ -32,27 +32,6 @@ mod tests {
     const T_STRUCT: u64 = 12;
     const T_ENUM: u64 = 13;
     const T_INTERFACE: u64 = 14;
-
-    /// The directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test-case project into a fresh temp directory so tests can
-    /// run in parallel. Returns the temp dir (kept alive for cleanup) and the
-    /// canonical path to the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// A running language server connected to a copied test project.
     struct Ctx {
@@ -95,7 +74,7 @@ mod tests {
 
         /// The `file://` URI for a project-relative file path.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Request semantic tokens and return the flat list of per-token type

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,7 +9,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::{
@@ -159,9 +159,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not error");
@@ -310,7 +308,7 @@ mod tests {
     /// elaboration completed and the overlay never appears.
     #[test]
     fn test_semantic_tokens_refresh_sent_after_diagnostics() {
-        let mut ctx = LspSemanticTokensCtx::setup();
+        let ctx = LspSemanticTokensCtx::setup();
 
         let mut saw_refresh = false;
         while let Some(msg) = ctx.client.pop_message() {

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -34,7 +34,7 @@ mod tests {
     const T_INTERFACE: u64 = 14;
 
     /// A running language server connected to a copied test project.
-    struct Ctx {
+    struct LspSemanticTokensCtx {
         /// The client driving the `fix language-server` subprocess.
         client: LspClient,
         /// The copied project's root directory.
@@ -50,7 +50,7 @@ mod tests {
     /// of that wait asks the server for the tokens again, so the gap is sized for a round trip.
     const OVERLAY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-    impl Ctx {
+    impl LspSemanticTokensCtx {
         /// Start a server on a fresh copy of the `semantic_tokens` project, open
         /// `main.fix`, and wait for an initial elaboration.
         fn setup() -> Self {
@@ -163,7 +163,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not error");
         }
     }
@@ -174,8 +174,8 @@ mod tests {
     /// colors the namespace and the type separately, so an overlay token spanning the path lands on
     /// top of the base layer's.
     #[test]
-    fn semantic_tokens_do_not_overlap() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_do_not_overlap() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         // Wait for the overlay, which is the layer that can produce a token spanning a whole path.
         ctx.token_types_with_overlay("main.fix");
         let positions = ctx.token_positions("main.fix");
@@ -201,8 +201,8 @@ mod tests {
     /// union variants and field accessors — while the base layer keeps coloring
     /// comments, strings, keywords and built-in types.
     #[test]
-    fn semantic_tokens_overlay_precise_classification() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_overlay_precise_classification() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         let types = ctx.token_types_with_overlay("main.fix");
 
         let want = [
@@ -236,8 +236,8 @@ mod tests {
     /// the base lexical layer, and does NOT emit the AST overlay (which would be
     /// misaligned), so no variable/function tokens appear.
     #[test]
-    fn semantic_tokens_base_layer_survives_broken_buffer() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_base_layer_survives_broken_buffer() {
+        let mut ctx = LspSemanticTokensCtx::setup();
 
         // Drift the buffer away from the elaborated snapshot, with broken
         // syntax (unbalanced paren, unterminated string).
@@ -272,8 +272,8 @@ mod tests {
     /// from the elaborated snapshot, even though the buffer no longer matches it
     /// exactly.
     #[test]
-    fn semantic_tokens_overlay_survives_single_line_edit() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_overlay_survives_single_line_edit() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         // Apply the overlay first.
         let _ = ctx.token_types_with_overlay("main.fix");
 
@@ -310,8 +310,8 @@ mod tests {
     /// otherwise the client keeps the base-layer-only result it fetched before
     /// elaboration completed and the overlay never appears.
     #[test]
-    fn semantic_tokens_refresh_sent_after_diagnostics() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_refresh_sent_after_diagnostics() {
+        let mut ctx = LspSemanticTokensCtx::setup();
 
         let mut saw_refresh = false;
         while let Some(msg) = ctx.client.pop_message() {

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -119,10 +119,7 @@ mod tests {
                     json!({ "textDocument": { "uri": uri } }),
                 )
                 .expect("Failed to send semanticTokens request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a semanticTokens response");
+            let response = self.client.response_of(id);
             let data = response
                 .get("result")
                 .and_then(|r| r.get("data"))

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,7 +9,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::lsp_client::{LspClient, POLL_INTERVAL};
+    use super::super::lsp_client::LspClient;
     use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::{
@@ -65,11 +65,12 @@ mod tests {
         _temp_dir: TempDir,
     }
 
-    /// How long a `semanticTokens` request is given to be answered.
-    const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-
     /// How long the overlay a finished analysis adds to the tokens is waited for.
     const OVERLAY_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// How long the wait for the overlay sits between two `semanticTokens` requests. Each round
+    /// of that wait asks the server for the tokens again, so the gap is sized for a round trip.
+    const OVERLAY_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
     impl Ctx {
         /// Start a server on a fresh copy of the `semantic_tokens` project, open
@@ -85,7 +86,7 @@ mod tests {
                 .expect("Failed to open main.fix");
             // Elaborate the project so the AST overlay has a program whose
             // snapshot matches the (unmodified) buffer.
-            client.trigger_and_wait_for_diagnostics(Path::new("main.fix"));
+            client.save_and_wait_for_the_program(Path::new("main.fix"));
             Self {
                 client,
                 project_dir,
@@ -120,7 +121,7 @@ mod tests {
                 .expect("Failed to send semanticTokens request");
             let response = self
                 .client
-                .wait_for_response(id, RESPONSE_TIMEOUT)
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a semanticTokens response");
             let data = response
                 .get("result")
@@ -166,7 +167,7 @@ mod tests {
                 if types.contains(&T_VARIABLE) || Instant::now() >= deadline {
                     return types;
                 }
-                thread::sleep(POLL_INTERVAL);
+                thread::sleep(OVERLAY_RETRY_INTERVAL);
             }
         }
 

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -69,7 +69,7 @@ mod tests {
 
     /// How long the wait for the overlay sits between two `semanticTokens` requests. Each round
     /// of that wait asks the server for the tokens again, so the gap is sized for a round trip.
-    const OVERLAY_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+    const OVERLAY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
     impl Ctx {
         /// Start a server on a fresh copy of the `semantic_tokens` project, open
@@ -118,7 +118,7 @@ mod tests {
                     json!({ "textDocument": { "uri": uri } }),
                 )
                 .expect("Failed to send semanticTokens request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let data = response
                 .get("result")
                 .and_then(|r| r.get("data"))
@@ -157,11 +157,11 @@ mod tests {
         /// after the progress-end notification, so retry until a typechecked
         /// token (a local variable, which only the overlay emits) appears.
         fn token_types_with_overlay(&mut self, file: &str) -> Vec<u64> {
-            let with_overlay = poll_every(OVERLAY_RETRY_INTERVAL, OVERLAY_TIMEOUT, || {
+            let types_with_overlay = poll_every(OVERLAY_POLL_INTERVAL, OVERLAY_TIMEOUT, || {
                 let types = self.token_types(file);
                 types.contains(&T_VARIABLE).then_some(types)
             });
-            with_overlay.unwrap_or_else(|| self.token_types(file))
+            types_with_overlay.unwrap_or_else(|| self.token_types(file))
         }
 
         /// Replace the whole content of `file` via a `didChange` notification.

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -13,6 +13,7 @@ mod tests {
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -279,8 +280,7 @@ mod tests {
 
         // Edit a single body line; the type/trait/struct definitions on other
         // lines are untouched.
-        let original =
-            std::fs::read_to_string(ctx.project_dir.join("main.fix")).expect("read main.fix");
+        let original = fs::read_to_string(ctx.project_dir.join("main.fix")).expect("read main.fix");
         let edited = original.replace("let n = p.size;", "let n = p.size; // tweak");
         assert_ne!(original, edited, "the edit should change the buffer");
         ctx.change_text("main.fix", &edited);

--- a/src/tests/test_lsp/test_stdin_eof.rs
+++ b/src/tests/test_lsp/test_stdin_eof.rs
@@ -7,27 +7,9 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::test_util::{copy_dir_recursive, fix_command, wait_within};
-    use std::{path::PathBuf, process::Stdio, thread::sleep, time::Duration};
-    use tempfile::TempDir;
-
-    /// Absolute path to the LSP `cases/` directory.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test project into a fresh temp directory and
-    /// return both the temp dir handle (to keep it alive) and the path
-    /// of the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        (temp_dir, test_case_dst)
-    }
+    use super::super::case_project::setup_test_env;
+    use crate::tests::test_util::{fix_command, wait_within};
+    use std::{process::Stdio, thread::sleep, time::Duration};
 
     /// Verifies that the language server terminates promptly once its
     /// stdin reaches EOF (parent editor closed the pipe).

--- a/src/tests/test_lsp/test_waits.rs
+++ b/src/tests/test_lsp/test_waits.rs
@@ -1,17 +1,12 @@
-//! What the waits the harness is built on promise.
+//! What the polling the harness waits by promises.
 //!
-//! A test in this directory reads what the server sent once a wait has returned, so what the wait
-//! promises is what that reading means.
+//! Every wait in this directory is written on `poll_every`, so what it promises is what a wait
+//! for a response, for a pass, or for the server's exit means.
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
-    use super::super::lsp_client::{poll_every, LspClient};
-    use serde_json::{json, Value};
-    use std::fs;
-    use std::path::{Path, PathBuf};
+    use super::super::lsp_client::poll_every;
     use std::time::{Duration, Instant};
-    use tempfile::TempDir;
 
     /// A wait whose condition already holds hands that look's answer back and stops, so that a
     /// test asking for what the server has already sent pays nothing for the asking.
@@ -67,149 +62,5 @@ mod tests {
             "the wait gave up after {} look(s), without looking again when its time ran out",
             looks
         );
-    }
-
-    /// The project the session tests run over, whose `main.fix` they write.
-    const PROJECT: &str = "goto_local";
-
-    /// A program carrying one error, which the analysis finishes and reports.
-    const PROGRAM_WITH_AN_ERROR: &str =
-        "module Main;\n\nmain : IO ();\nmain = println(nonexistent_name);\n";
-
-    /// A program declaring `main` alone.
-    const PROGRAM_WITHOUT_THE_GLOBAL: &str =
-        "module Main;\n\nmain : IO ();\nmain = println(\"\");\n";
-
-    /// A program declaring the global `answer` besides `main`.
-    const PROGRAM_WITH_THE_GLOBAL: &str =
-        "module Main;\n\nanswer : I64;\nanswer = 42;\n\nmain : IO ();\nmain = println(answer.to_string);\n";
-
-    /// A session over a copy of `PROJECT` whose `main.fix` carries `program`, with `main.fix`
-    /// opened.
-    fn open_session(program: &str) -> (TempDir, PathBuf, LspClient) {
-        let (temp_dir, project_dir) = setup_test_env(PROJECT);
-        fs::write(project_dir.join("main.fix"), program).expect("Failed to write main.fix");
-        let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
-        client
-            .initialize(&project_dir, Duration::from_secs(10))
-            .expect("Failed to initialize LSP");
-        client
-            .open_document(Path::new("main.fix"))
-            .expect("Failed to open main.fix");
-        (temp_dir, project_dir, client)
-    }
-
-    /// The name of each symbol the server answers for the file `uri` names.
-    fn document_symbol_names(client: &mut LspClient, uri: &str) -> Vec<String> {
-        let id = client
-            .send_request(
-                "textDocument/documentSymbol",
-                json!({ "textDocument": { "uri": uri } }),
-            )
-            .expect("Failed to send documentSymbol");
-        client.response_of(id)["result"]
-            .as_array()
-            .expect("a documentSymbol response carries an array of symbols")
-            .iter()
-            .map(|symbol| {
-                symbol["name"]
-                    .as_str()
-                    .expect("a symbol carries its name")
-                    .to_string()
-            })
-            .collect()
-    }
-
-    /// Every message the server has sent that the client has yet to look at, oldest first.
-    fn recorded_messages(client: &mut LspClient) -> Vec<Value> {
-        let mut messages = Vec::new();
-        while let Some(message) = client.pop_message() {
-            messages.push(message);
-        }
-        messages
-    }
-
-    /// Whether `message` publishes at least one report.
-    fn publishes_a_report(message: &Value) -> bool {
-        message["method"] == json!("textDocument/publishDiagnostics")
-            && message["params"]["diagnostics"]
-                .as_array()
-                .is_some_and(|reports| !reports.is_empty())
-    }
-
-    /// Whether `message` is the `$/progress` notification a pass ends with.
-    fn ends_a_pass(message: &Value) -> bool {
-        message["method"] == json!("$/progress")
-            && message["params"]["value"]["kind"] == json!("end")
-    }
-
-    /// The wait for a pass returns with the reports that pass published, which rests on the pass
-    /// sending its end after everything it publishes.
-    #[test]
-    fn test_the_wait_for_a_pass_returns_with_the_reports_the_pass_published() {
-        let main_fix = Path::new("main.fix");
-        let (_temp_dir, _project_dir, mut client) = open_session(PROGRAM_WITH_AN_ERROR);
-
-        client.save_and_wait_for_a_pass(main_fix);
-
-        assert!(
-            !client.get_diagnostics(main_fix).is_empty(),
-            "the wait ended on the pass over a program carrying an error, so `main.fix` is \
-             expected to carry that pass's report"
-        );
-
-        let messages = recorded_messages(&mut client);
-        let published = messages
-            .iter()
-            .position(publishes_a_report)
-            .expect("the pass over a program carrying an error is expected to publish a report");
-        let ended = messages
-            .iter()
-            .position(ends_a_pass)
-            .expect("the pass is expected to end");
-        assert!(
-            published < ended,
-            "a pass is expected to publish its reports before it ends, but it ended at message {} \
-             and published its first report at message {}",
-            ended,
-            published
-        );
-
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
-        client
-            .finish()
-            .expect("Reader thread should not have errors");
-    }
-
-    /// The wait for the program returns with the server's main loop holding the program of the
-    /// pass the save asked for, so the request sent next is answered out of that program.
-    #[test]
-    fn test_the_wait_for_the_program_returns_with_this_passs_program_in_hand() {
-        let main_fix = Path::new("main.fix");
-        let (_temp_dir, project_dir, mut client) = open_session(PROGRAM_WITHOUT_THE_GLOBAL);
-        client.save_and_wait_for_the_program(main_fix);
-
-        // The second pass, over a program declaring a global the first pass's program has none of.
-        fs::write(project_dir.join(main_fix), PROGRAM_WITH_THE_GLOBAL)
-            .expect("Failed to write the program declaring the global");
-        client.save_and_wait_for_the_program(main_fix);
-
-        let uri = client.file_uri(main_fix);
-        let names = document_symbol_names(&mut client, &uri);
-        assert!(
-            names.contains(&"Main::answer".to_string()),
-            "the symbols of `main.fix` are answered out of the program the main loop holds, which \
-             is expected to be the one declaring `Main::answer`, but the answer carries {:?}",
-            names
-        );
-
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
-        client
-            .finish()
-            .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/test_waits.rs
+++ b/src/tests/test_lsp/test_waits.rs
@@ -1,0 +1,215 @@
+//! What the waits the harness is built on promise.
+//!
+//! A test in this directory reads what the server sent once a wait has returned, so what the wait
+//! promises is what that reading means.
+
+#[cfg(test)]
+mod tests {
+    use super::super::completion_harness::setup_test_env;
+    use super::super::lsp_client::{poll_every, LspClient};
+    use serde_json::{json, Value};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    /// A wait whose condition already holds hands that look's answer back and stops, so that a
+    /// test asking for what the server has already sent pays nothing for the asking.
+    ///
+    /// The timeout is empty, which leaves the wait with no time to spend, and the interval is
+    /// long enough that a wait spending any shows it.
+    #[test]
+    fn test_a_wait_answers_a_condition_that_already_holds() {
+        /// The gap between two looks.
+        const INTERVAL: Duration = Duration::from_secs(5);
+
+        let mut looks = 0;
+        let started = Instant::now();
+        let answer = poll_every(INTERVAL, Duration::ZERO, || {
+            looks += 1;
+            Some(looks)
+        });
+
+        assert_eq!(
+            answer,
+            Some(1),
+            "the wait is expected to hand back the answer of the look that answered"
+        );
+        assert_eq!(
+            looks, 1,
+            "the wait is expected to stop at the look that answered, but it looked {} times",
+            looks
+        );
+        assert!(
+            started.elapsed() < INTERVAL,
+            "the wait took {:?}, which is the interval it is expected to spend none of",
+            started.elapsed()
+        );
+    }
+
+    /// A wait looks once more when its time runs out, so that a condition turning true while the
+    /// wait sleeps is answered rather than missed.
+    ///
+    /// The interval is the whole timeout, so the wait sleeps once and the look after that sleep
+    /// is the one taken at the deadline. The condition answers nothing on the first look, so a
+    /// wait that gives up without taking the second one answers nothing at all.
+    #[test]
+    fn test_a_wait_looks_once_more_when_its_time_runs_out() {
+        let span = Duration::from_millis(100);
+        let mut looks = 0;
+        let answer = poll_every(span, span, || {
+            looks += 1;
+            (looks > 1).then_some(looks)
+        });
+
+        assert!(
+            answer.is_some(),
+            "the wait gave up after {} look(s), without looking again when its time ran out",
+            looks
+        );
+    }
+
+    /// The project the session tests run over, whose `main.fix` they write.
+    const PROJECT: &str = "goto_local";
+
+    /// A program carrying one error, which the analysis finishes and reports.
+    const PROGRAM_WITH_AN_ERROR: &str =
+        "module Main;\n\nmain : IO ();\nmain = println(nonexistent_name);\n";
+
+    /// A program declaring `main` alone.
+    const PROGRAM_WITHOUT_THE_GLOBAL: &str =
+        "module Main;\n\nmain : IO ();\nmain = println(\"\");\n";
+
+    /// A program declaring the global `answer` besides `main`.
+    const PROGRAM_WITH_THE_GLOBAL: &str =
+        "module Main;\n\nanswer : I64;\nanswer = 42;\n\nmain : IO ();\nmain = println(answer.to_string);\n";
+
+    /// A session over a copy of `PROJECT` whose `main.fix` carries `program`, with `main.fix`
+    /// opened.
+    fn open_session(program: &str) -> (TempDir, PathBuf, LspClient) {
+        let (temp_dir, project_dir) = setup_test_env(PROJECT);
+        fs::write(project_dir.join("main.fix"), program).expect("Failed to write main.fix");
+        let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
+        client
+            .initialize(&project_dir, Duration::from_secs(10))
+            .expect("Failed to initialize LSP");
+        client
+            .open_document(Path::new("main.fix"))
+            .expect("Failed to open main.fix");
+        (temp_dir, project_dir, client)
+    }
+
+    /// The name of each symbol the server answers for the file `uri` names.
+    fn document_symbol_names(client: &mut LspClient, uri: &str) -> Vec<String> {
+        let id = client
+            .send_request(
+                "textDocument/documentSymbol",
+                json!({ "textDocument": { "uri": uri } }),
+            )
+            .expect("Failed to send documentSymbol");
+        client.response_of(id)["result"]
+            .as_array()
+            .expect("a documentSymbol response carries an array of symbols")
+            .iter()
+            .map(|symbol| {
+                symbol["name"]
+                    .as_str()
+                    .expect("a symbol carries its name")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// Every message the server has sent that the client has yet to look at, oldest first.
+    fn recorded_messages(client: &mut LspClient) -> Vec<Value> {
+        let mut messages = Vec::new();
+        while let Some(message) = client.pop_message() {
+            messages.push(message);
+        }
+        messages
+    }
+
+    /// Whether `message` publishes at least one report.
+    fn publishes_a_report(message: &Value) -> bool {
+        message["method"] == json!("textDocument/publishDiagnostics")
+            && message["params"]["diagnostics"]
+                .as_array()
+                .is_some_and(|reports| !reports.is_empty())
+    }
+
+    /// Whether `message` is the `$/progress` notification a pass ends with.
+    fn ends_a_pass(message: &Value) -> bool {
+        message["method"] == json!("$/progress")
+            && message["params"]["value"]["kind"] == json!("end")
+    }
+
+    /// The wait for a pass returns with the reports that pass published, which rests on the pass
+    /// sending its end after everything it publishes.
+    #[test]
+    fn test_the_wait_for_a_pass_returns_with_the_reports_the_pass_published() {
+        let main_fix = Path::new("main.fix");
+        let (_temp_dir, _project_dir, mut client) = open_session(PROGRAM_WITH_AN_ERROR);
+
+        client.save_and_wait_for_a_pass(main_fix);
+
+        assert!(
+            !client.get_diagnostics(main_fix).is_empty(),
+            "the wait ended on the pass over a program carrying an error, so `main.fix` is \
+             expected to carry that pass's report"
+        );
+
+        let messages = recorded_messages(&mut client);
+        let published = messages
+            .iter()
+            .position(publishes_a_report)
+            .expect("the pass over a program carrying an error is expected to publish a report");
+        let ended = messages
+            .iter()
+            .position(ends_a_pass)
+            .expect("the pass is expected to end");
+        assert!(
+            published < ended,
+            "a pass is expected to publish its reports before it ends, but it ended at message {} \
+             and published its first report at message {}",
+            ended,
+            published
+        );
+
+        client
+            .shutdown(Duration::from_millis(500))
+            .expect("Failed to shutdown LSP");
+        client
+            .finish()
+            .expect("Reader thread should not have errors");
+    }
+
+    /// The wait for the program returns with the server's main loop holding the program of the
+    /// pass the save asked for, so the request sent next is answered out of that program.
+    #[test]
+    fn test_the_wait_for_the_program_returns_with_this_passs_program_in_hand() {
+        let main_fix = Path::new("main.fix");
+        let (_temp_dir, project_dir, mut client) = open_session(PROGRAM_WITHOUT_THE_GLOBAL);
+        client.save_and_wait_for_the_program(main_fix);
+
+        // The second pass, over a program declaring a global the first pass's program has none of.
+        fs::write(project_dir.join(main_fix), PROGRAM_WITH_THE_GLOBAL)
+            .expect("Failed to write the program declaring the global");
+        client.save_and_wait_for_the_program(main_fix);
+
+        let uri = client.file_uri(main_fix);
+        let names = document_symbol_names(&mut client, &uri);
+        assert!(
+            names.contains(&"Main::answer".to_string()),
+            "the symbols of `main.fix` are answered out of the program the main loop holds, which \
+             is expected to be the one declaring `Main::answer`, but the answer carries {:?}",
+            names
+        );
+
+        client
+            .shutdown(Duration::from_millis(500))
+            .expect("Failed to shutdown LSP");
+        client
+            .finish()
+            .expect("Reader thread should not have errors");
+    }
+}

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -7,7 +7,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -41,7 +41,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -74,9 +74,7 @@ mod tests {
         /// Shuts the server down, and fails the test if its reader thread met a protocol
         /// error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -60,7 +60,7 @@ mod tests {
                     .expect(&format!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
-            client.trigger_and_wait_for_diagnostics(Path::new(trigger_file));
+            client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
                 _project_dir: project_dir,
@@ -82,7 +82,7 @@ mod tests {
                 .expect("Failed to send workspace/symbol request");
             let response = self
                 .client
-                .wait_for_response(id, Duration::from_secs(5))
+                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
                 .expect("Should receive a workspace/symbol response");
             let result = response
                 .get("result")

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -19,8 +19,12 @@ mod tests {
     /// Test fixture that owns an initialized `LspClient` together with
     /// the temporary project directory it operates on.
     struct LspWorkspaceSymbolCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// The copy of the fixture project the server was started on.
         _project_dir: PathBuf,
+        /// Holds the temporary directory containing `_project_dir` alive; dropping it
+        /// deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -67,7 +71,8 @@ mod tests {
             result.as_array().cloned().unwrap_or_default()
         }
 
-        /// Performs a clean LSP shutdown and joins the reader thread.
+        /// Shuts the server down, and fails the test if its reader thread met a protocol
+        /// error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -188,8 +193,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Each returned symbol's `location.uri` should point into the
-    /// project directory (not into std lib or dependency caches).
+    /// Each returned symbol's `location.uri` points into the project
+    /// directory, which leaves out the std library and the dependency
+    /// caches.
     #[test]
     fn test_workspace_symbol_locations_are_in_project() {
         let mut ctx = LspWorkspaceSymbolCtx::setup("completion", &["lib.fix", "main.fix"]);

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -7,34 +7,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
         time::Duration,
     };
     use tempfile::TempDir;
-
-    /// Absolute path to the directory containing LSP test fixture projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copies the named fixture project into a fresh temporary directory
-    /// and returns the temp dir handle plus the canonicalized project path.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// Test fixture that owns an initialized `LspClient` together with
     /// the temporary project directory it operates on.

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -80,10 +80,9 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send workspace/symbol request");
-            self.client.wait_for_server(Duration::from_secs(5));
             let response = self
                 .client
-                .get_response(id)
+                .wait_for_response(id, Duration::from_secs(5))
                 .expect("Should receive a workspace/symbol response");
             let result = response
                 .get("result")

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -80,7 +80,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send workspace/symbol request");
-            let response = self.client.response_of(id);
+            let response = self.client.expect_response(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -73,7 +73,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -80,10 +80,7 @@ mod tests {
                     }),
                 )
                 .expect("Failed to send workspace/symbol request");
-            let response = self
-                .client
-                .wait_for_response(id, LspClient::RESPONSE_TIMEOUT)
-                .expect("Should receive a workspace/symbol response");
+            let response = self.client.response_of(id);
             let result = response
                 .get("result")
                 .expect("Response should have a result field");


### PR DESCRIPTION
LSP のテストが、サーバに何かを頼むたびに決め打ちの秒数だけ眠っていた。この変更は、眠るのをやめて、サーバが送ってきたものを待つ形にする。`cargo test --release tests::test_lsp` は **278.9 秒から 11.4 秒**になる。

issue は無く、利用者に見える振る舞いも変わらないので、`CHANGELOG.md` には項目を足していない。

## 何が起きていたか

テストの client が持つ待ちは `wait_for_server(d)` 1 つで、中身は `thread::sleep(d)` そのものだった。応答は見ていない。

- `initialize(root, timeout)` の doc は「send the `initialize` request, wait for its response」と述べていたが、コードは `timeout` をまるごと眠ってから応答を 1 度見るだけだった。テスト 1 本につき 5 秒。
- `shutdown(exit_timeout)` は応答待ちに 5 秒、`exit` のあとプロセス終了待ちに 0.5 秒、どちらも無条件。17 か所で 5.5 秒。
- 各機能のヘルパ (hover / definition / references / rename / workspace symbol / completionItem resolve) は 1 リクエストにつき 5 秒、`codeAction` は 10 秒眠ってから応答を読んでいた。

サーバが実際に答えるのに要る時間は、`quickfix` プロジェクトに stdio で JSON-RPC を書く driver で測るとこうである。

```
initialize response          : 0.003 s
first diagnostics (progress) : 0.489 s   (うち 400 ms は debounce)
codeAction response          : 0.000 s
codeAction response (2nd)    : 0.002 s
shutdown response            : 0.000 s
process exit                 : 0.015 s
```

セッション 1 本の実仕事は 0.5 秒で、テストはそこに 17 秒使っていた。

## 何をしたか

**待ちを 1 つの原理に載せた。** [`poll_every`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L21-L36) は `interval` ごとに `look` を呼び、`Some` が返ればその答えを返し、`timeout` が尽きたら最後にもう一度見てから諦める。[`poll`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L40-L42) はその `interval` を `POLL_INTERVAL` (2 ms) に固定した形で、届いたものを読むだけの待ちが使う。サーバに聞き直す待ちは自分の間隔を渡す。

この上に、client の待ちが 3 つ載っている。[`wait_for_response`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L329-L331) は応答が来るまで、[`wait_for_progress_end_count`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L355-L371) は診断のパスが指定の数だけ終わるまで、`shutdown` の中の待ちはプロセスが終わるまで。応答が来ることを前提にしてよい呼び手のために [`expect_response`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L334-L337) がある。

**テストが選ぶ待ちを 2 つに分け、名前を付けた。** 診断のパスを起こしたテストが欲しいものは 2 通りある。

- [`save_and_wait_for_a_pass`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L391-L395) — パスが終わり、そのパスが publish した報告が届いた状態。診断やロックファイルを読むテストはこれで足りる。
- [`save_and_wait_for_the_program`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L410-L422) — 加えて、サーバのメインループがそのパスの elaborate したプログラムを保持した状態。hover / definition / references / rename / documentSymbol はどれもそのプログラムから答えるので、機能のテストはこれを待つ。

後者が要る理由は、メインループが結果を取り込むのがループ先頭の `try_recv` で、そこは `stdin` のブロック読みの**手前**だからである。パスが終わった時点ではまだ取り込まれておらず、メッセージが 1 通届いて初めて取り込まれる。そこで、パスの終了を待ってから `$/ping` (サーバが黙って捨てる通知) を送ってループを 1 周させ、続く `textDocument/semanticTokens/full` の応答をもって取り込み済みと判断する。

その待ちに `semanticTokens/full` を使うのは、**サーバがプログラムを持っていなくても答える唯一の要求**だからである。他の機能は `last_diag` が `None` の間は応答を返さない。そして elaborate に失敗するプロジェクトではプログラムが送られないので、「プログラムが届いた」ことを直接観測する信号 (サーバが取り込んだ瞬間に送る `workspace/semanticTokens/refresh`) では待てない。実際、`quickfix_trait_impl` (メンバを 1 つも書いていない `impl`) でその形は固まった。

**待ちの持ち物を 1 か所にした。** [`wait_for_one_more_pass`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L382-L387) は引き金を引数に取るので、`didChange` でパスを起こすテストも同じ待ちを使う。[`file_uri`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L426-L428) と [`uri_of`](https://github.com/tttmmmyyyy/fixlang/blob/cdb031db7bc39197e7c855c54152178b507ef28a/src/tests/test_lsp/lsp_client.rs#L45-L47) が `file://` の URI を作る唯一の場所になり、`RESPONSE_TIMEOUT` (5 秒) と `PASS_TIMEOUT` (180 秒) が時間の名前になった。

**答えの無い `codeAction` を失敗として扱う。** 以前は応答が来なければ空のリストを返しており、それは「行動が 1 つも無い応答」と区別が付かなかった。

## 測ったこと

183 本 (テストを 2 本足したので 185 本) を 1 本ずつ直列に走らせた合計と、`cargo test --release tests::test_lsp` の並列の壁時間。

|  | 直列合計 | 1 本平均 | 並列 |
|---|---|---|---|
| 変更前 | 3183.3 s (53.1 分) | 17.39 s | 278.9 s |
| 変更後 | 127.8 s (2.13 分) | 0.70 s | **11.4 s** |

並列は 4 回続けて 11.2 / 11.3 / 11.4 / 11.5 秒。ファイル別の直列合計はこうなる。

```
                        本数    変更前     変更後
test_references          52    956.0 s    34.0 s
test_rename              43    749.3 s    28.0 s
test_completion          24    332.9 s    17.2 s
test_goto_definition     13    251.1 s     8.5 s
test_hover                9    237.3 s     5.9 s
test_diagnostics         13    181.2 s    10.5 s
test_import_completion    9    131.7 s     5.9 s
test_code_action          4    100.5 s     3.0 s
mod.rs                    3     74.9 s     6.5 s
test_semantic_tokens      5     62.3 s     3.2 s
test_request_handling     3     53.9 s     2.4 s
test_workspace_symbol     3     51.7 s     2.0 s
```

スイート全体 (1869 本) はこのブランチで緑である。`FIX_LSP_BENCH=1` の completion ベンチは変更前後で同じ値を出す (non-dot 14.8 -> 14.7 ms、dot/array 83.7 -> 84.3 ms)。

残る 0.70 秒/本 は、サーバのプロセス起動と 400 ms の debounce である。テストの初期化で `workspace/didChangeConfiguration` に `fix.analyze.delayMs: 0` を送れば、ここも縮む。

## テスト

2 本。どちらも `poll_every` だけを相手にする単体テストで、`src/tests/test_lsp/test_polling.rs` にある。

- **`test_a_wait_answers_a_condition_that_already_holds`** — 条件が既に成立している待ちは、眠らずにその答えを返す。この変更の目的そのものを述べている。`poll_every` のループ先頭に `sleep` を移すと赤になる。
- **`test_a_wait_looks_once_more_when_its_time_runs_out`** — 期限が切れても最後にもう一度見てから諦める。期限の判定を `look` の手前に移すと赤になる。

どちらの変異でも、この 2 本以外は 185 本すべて緑のままだった。つまりこの軸を見張っている既存のテストは無い。

**落としたテストが 2 本ある。** 「パスは終了を告げる前に報告を publish する」を見るテストと、「プログラムを待つ待ちが返った時点で、メインループはこのパスのプログラムを持っている」を見るテストを書いたが、前者を壊すと 157 本、後者を壊すと 133 本が赤になった。どちらの軸もスイートが既に持っている。

## 判断を仰ぎたいこと

- `wait_for_one_more_pass` は**パスを同定せず数えている**。`ended_pass_count` を読んだ後に終わったパスなら、その save が頼んだものでなくても待ちは満たされる。セッション開始時の run と最初の `didSave` の run が 1 本に畳まれるのは、両者が 400 ms の debounce に収まるからで、スイート全体がこの前提に乗っている。id でパスを同定する形にすべきかどうか。
- 各テストファイルの `Ctx` 構造体 7 個 (`LspCompletionCtx` / `LspQuickFixCtx` / `LspSemanticTokensCtx` / `LspWorkspaceSymbolCtx` と `LspTestCtx` 4 つ) は `setup` と `shutdown` が同一で、ほぼ写しである。1 つに畳むのは呼び出し側の作り直しになるので手を付けていない。
- `lsp_client.rs` の reader thread は、プロトコルが保証する JSON の形が外れたとき黙って捨てる (`publishDiagnostics` の `params` / `uri` / `diagnostics` の欠落、応答の `id` が整数でない場合)。fail loud にすると reader thread が落ち、テストは timeout 経由の分かりにくい失敗になるので、そのままにしてある。

項目ごとの役割・変更・目的と、項目に区切った diff は、この pull request のコメントに置いた。
