### PR TITLE
レビュー清掃 (#614): テストプロジェクトの写しと URI の組み立てを 1 か所にする

### DIFF
--- a/src/commands/lsp/server.rs
+++ b/src/commands/lsp/server.rs
@@ -240,7 +240,10 @@ pub fn launch_language_server() {
         VecDeque::new();
 
     loop {
-        // Take in whatever the diagnostics thread has finished, keeping the newest result.
+        // Take in whatever the diagnostics thread has finished, keeping the newest result. This
+        // sits above the read below, so a result finished while the loop was blocked reading
+        // arrives only after one more message has been handled. `save_and_wait_for_the_program`
+        // of the test client waits that message out, and must stay in step with this placement.
         let mut diagnostics_updated = false;
         while let Ok(diagnostics_result) = diag_res_recv.try_recv() {
             last_diag = Some(diagnostics_result);

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -1,19 +1,19 @@
 // Opt-in benchmark for warm-state `textDocument/completion` latency.
 //
-// This is NOT a correctness test: it measures the round-trip latency the
-// editor experiences for a completion request *after* the initial
-// diagnostics run has settled (the cache is warm). It is gated behind the
-// `FIX_LSP_BENCH` environment variable so it returns immediately during
-// normal `cargo test` runs and only does work when explicitly requested:
+// It measures, and asserts nothing about, the round-trip latency the editor
+// experiences for a completion request once the initial diagnostics run has
+// settled (the cache is warm). It is gated behind the `FIX_LSP_BENCH`
+// environment variable, so it returns immediately during a normal
+// `cargo test` run and does its work when asked for:
 //
 //   FIX_LSP_BENCH=1 cargo test --release \
 //     --  tests::test_lsp::bench_completion --nocapture
 //
 // The reported numbers are end-to-end (send request -> receive response),
-// so they include the client-side JSON parse of the response in this test
-// harness. For the non-dot case that returns the full candidate list,
-// that parse is non-trivial; treat the absolute numbers as an upper bound
-// and use the before/after delta as the signal when optimizing.
+// so they include this harness's own JSON parse of the response. That parse
+// costs something for the non-dot case, which returns the full candidate
+// list; read the absolute numbers as an upper bound and the before/after
+// delta as the signal when optimizing.
 
 #[cfg(test)]
 mod bench {
@@ -104,9 +104,7 @@ mod bench {
     }
 
     /// Locate the cursor `(line, col)` at the end of the first occurrence
-    /// of `needle` (used for a non-dot context where `needle` is a
-    /// lowercase identifier, yielding an empty namespace filter -> the
-    /// full candidate list).
+    /// of `needle`.
     fn pos_after(text: &str, needle: &str) -> (u32, u32) {
         for (i, line) in text.lines().enumerate() {
             if let Some(start) = line.find(needle) {
@@ -138,9 +136,8 @@ mod bench {
             .expect("initialize LSP");
         client.open_document(main_rel).expect("open main.fix");
 
-        // Warm the typecheck cache / snapshot by running diagnostics once
-        // and waiting for it to settle. The user considers this initial
-        // cost acceptable; we measure what happens *after* this.
+        // Warm the typecheck cache / snapshot by running diagnostics once and
+        // waiting for it to settle, so that what follows is measured warm.
         client.save_and_wait_for_the_program(main_rel);
 
         let uri = client.file_uri(main_rel);

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,13 +17,11 @@
 
 #[cfg(test)]
 mod bench {
-    use super::super::completion_harness::completion_items;
+    use super::super::completion_harness::{completion_items, setup_test_env};
     use super::super::lsp_client::{poll_every, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::time::{Duration, Instant};
-    use tempfile::TempDir;
 
     /// Number of measured completion requests per benchmark point.
     const ITERS: usize = 15;
@@ -34,24 +32,6 @@ mod bench {
     /// How long the wait for one response sits between two looks. It bounds how coarse the
     /// latency this benchmark reports can be.
     const POLL_INTERVAL: Duration = Duration::from_millis(1);
-
-    /// Absolute path to the directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy a test-case project into a fresh temp directory and return the
-    /// temp dir (kept alive for cleanup) and the canonicalized project path.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let src = get_test_cases_dir().join(project_name);
-        let dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&src, &dst).expect("Failed to copy test case");
-        let dst = dst.canonicalize().expect("canonicalize");
-        (temp_dir, dst)
-    }
 
     /// Send one completion request and finely poll for the response,
     /// returning the round-trip duration and the number of items.
@@ -161,7 +141,7 @@ mod bench {
         // cost acceptable; we measure what happens *after* this.
         client.save_and_wait_for_the_program(main_rel);
 
-        let uri = format!("file://{}", project_dir.join(main_rel).display());
+        let uri = client.file_uri(main_rel);
 
         // Non-dot, full candidate list (empty namespace filter).
         let (l, c) = pos_after(&text, "let _ = sz");

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -51,20 +51,20 @@ mod bench {
                 }),
             )
             .expect("send completion");
-        let resp = poll_every(POLL_INTERVAL, TIMEOUT, || client.get_response(id))
+        let resp = poll_every(POLL_INTERVAL, TIMEOUT, || client.take_response(id))
             .unwrap_or_else(|| panic!("completion did not respond within {:?}", TIMEOUT));
         let elapsed = start.elapsed();
         (elapsed, completion_items(&resp).len())
     }
 
     /// Convert a `Duration` to fractional milliseconds.
-    fn millis(d: Duration) -> f64 {
-        d.as_secs_f64() * 1000.0
+    fn millis(duration: Duration) -> f64 {
+        duration.as_secs_f64() * 1000.0
     }
 
     /// Run `ITERS` measured completions at `(line, col)` after `WARMUP`
     /// discarded warm-up calls, and print min / median / mean / max.
-    fn bench_one(client: &mut LspClient, uri: &str, line: u32, col: u32, label: &str) {
+    fn bench_position(client: &mut LspClient, uri: &str, line: u32, col: u32, label: &str) {
         let (cold, n_items) = timed_completion(client, uri, line, col);
         for _ in 1..WARMUP {
             timed_completion(client, uri, line, col);
@@ -145,19 +145,21 @@ mod bench {
 
         // Non-dot, full candidate list (empty namespace filter).
         let (l, c) = pos_after(&text, "let _ = sz");
-        bench_one(&mut client, &uri, l, c, "non-dot/full");
+        bench_position(&mut client, &uri, l, c, "non-dot/full");
 
         // Dot on an `Array I64` receiver.
         let (l, c) = pos_after_dot(&text, "arr.get_size");
-        bench_one(&mut client, &uri, l, c, "dot/array");
+        bench_position(&mut client, &uri, l, c, "dot/array");
 
         // Dot on an `I64` receiver.
         let (l, c) = pos_after_dot(&text, "42.compute");
-        bench_one(&mut client, &uri, l, c, "dot/i64");
+        bench_position(&mut client, &uri, l, c, "dot/i64");
 
         client
             .shutdown(Duration::from_millis(500))
             .expect("shutdown LSP");
-        client.finish().expect("reader thread clean");
+        client
+            .verify_no_protocol_error()
+            .expect("reader thread clean");
     }
 }

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -20,6 +20,8 @@ mod bench {
     use super::super::completion_harness::{completion_items, setup_test_env};
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
+    use std::env;
+    use std::fs;
     use std::path::Path;
     use std::time::{Duration, Instant};
 
@@ -119,7 +121,7 @@ mod bench {
     /// receivers); opt-in via `FIX_LSP_BENCH`, otherwise a no-op.
     #[test]
     fn bench_completion_warm() {
-        if std::env::var("FIX_LSP_BENCH").is_err() {
+        if env::var("FIX_LSP_BENCH").is_err() {
             eprintln!(
                 "[bench] skipped (set FIX_LSP_BENCH=1 to run the completion latency benchmark)"
             );
@@ -128,7 +130,7 @@ mod bench {
 
         let (_temp_dir, project_dir) = setup_test_env("completion-bench");
         let main_rel = Path::new("main.fix");
-        let text = std::fs::read_to_string(project_dir.join(main_rel)).expect("read main.fix");
+        let text = fs::read_to_string(project_dir.join(main_rel)).expect("read main.fix");
 
         let mut client = LspClient::new(&project_dir).expect("start LSP");
         client

--- a/src/tests/test_lsp/bench_completion.rs
+++ b/src/tests/test_lsp/bench_completion.rs
@@ -17,7 +17,8 @@
 
 #[cfg(test)]
 mod bench {
-    use super::super::completion_harness::{completion_items, setup_test_env};
+    use super::super::case_project::setup_test_env;
+    use super::super::completion_harness::completion_items;
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::env;
@@ -154,9 +155,7 @@ mod bench {
         let (l, c) = pos_after_dot(&text, "42.compute");
         bench_position(&mut client, &uri, l, c, "dot/i64");
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("shutdown LSP");
+        client.shutdown().expect("shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("reader thread clean");

--- a/src/tests/test_lsp/case_project.rs
+++ b/src/tests/test_lsp/case_project.rs
@@ -1,0 +1,33 @@
+//! The copy of a test project a session runs over.
+
+use crate::tests::test_util::copy_dir_recursive;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// The directory holding the LSP test projects, one subdirectory per
+/// project, named as the tests name it.
+fn get_test_cases_dir() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/tests/test_lsp/cases");
+    path
+}
+
+/// Copy the test project `project_name` into a temporary directory of its
+/// own, so tests that build and edit it can run in parallel.
+///
+/// # Returns
+/// The guard whose drop deletes the copy, and the canonicalized path of
+/// the copied project. Canonicalizing resolves the symlinks a temporary
+/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
+/// matches the root URI the server is initialized with and the URIs it
+/// publishes under.
+pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let test_case_src = get_test_cases_dir().join(project_name);
+    let test_case_dst = temp_dir.path().join(project_name);
+    copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
+    let test_case_dst = test_case_dst
+        .canonicalize()
+        .expect("Failed to canonicalize test case path");
+    (temp_dir, test_case_dst)
+}

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -171,7 +171,7 @@ impl LspCompletionCtx {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         self.client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -2,42 +2,14 @@
 // over a private copy of a test project and sends completion /
 // resolve requests against it.
 
+use super::case_project::setup_test_env;
 use super::lsp_client::LspClient;
-use crate::tests::test_util::copy_dir_recursive;
 use serde_json::{json, Value};
 use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
 use tempfile::TempDir;
-
-/// The directory holding the LSP test projects, one subdirectory per
-/// project, named as the tests name it.
-fn get_test_cases_dir() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src/tests/test_lsp/cases");
-    path
-}
-
-/// Copy the test project `project_name` into a temporary directory of its
-/// own, so tests that build and edit it can run in parallel.
-///
-/// # Returns
-/// The guard whose drop deletes the copy, and the canonicalized path of
-/// the copied project. Canonicalizing resolves the symlinks a temporary
-/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
-/// matches the root URI the server is initialized with and the URIs it
-/// publishes under.
-pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-    let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let test_case_src = get_test_cases_dir().join(project_name);
-    let test_case_dst = temp_dir.path().join(project_name);
-    copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-    let test_case_dst = test_case_dst
-        .canonicalize()
-        .expect("Failed to canonicalize test case path");
-    (temp_dir, test_case_dst)
-}
 
 /// Look up the `sortText` of the completion item whose `label` is `label`.
 pub fn find_sort_text(items: &[Value], label: &str) -> Option<String> {
@@ -101,7 +73,7 @@ impl LspCompletionCtx {
         for f in files {
             client
                 .open_document(Path::new(f))
-                .expect(&format!("Failed to open {}", f));
+                .unwrap_or_else(|_| panic!("Failed to open {}", f));
         }
         let trigger_file = files.last().unwrap();
         client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -165,9 +137,7 @@ impl LspCompletionCtx {
 
     /// Shut the server down and assert its reader thread saw no errors.
     pub fn shutdown(mut self) {
-        self.client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        self.client.shutdown().expect("Failed to shutdown LSP");
         self.client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -24,7 +24,10 @@ fn get_test_cases_dir() -> PathBuf {
 ///
 /// # Returns
 /// The guard whose drop deletes the copy, and the canonicalized path of
-/// the copied project.
+/// the copied project. Canonicalizing resolves the symlinks a temporary
+/// directory sits behind (`/tmp` -> `/private/tmp` on macOS), so the path
+/// matches the root URI the server is initialized with and the URIs it
+/// publishes under.
 pub fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let test_case_src = get_test_cases_dir().join(project_name);
@@ -114,7 +117,7 @@ impl LspCompletionCtx {
     /// The `file://` URI the server knows `file` by, `file` being a path
     /// relative to the project root.
     pub fn file_uri(&self, file: &str) -> String {
-        format!("file://{}", self.project_dir.join(file).display())
+        self.client.file_uri(Path::new(file))
     }
 
     /// Send textDocument/completion and return the result items,

--- a/src/tests/test_lsp/completion_harness.rs
+++ b/src/tests/test_lsp/completion_harness.rs
@@ -64,10 +64,8 @@ pub fn completion_items(response: &Value) -> Vec<Value> {
         .unwrap_or_default()
 }
 
-/// Poll an in-flight `textDocument/completion` request until the
-/// server replies or `timeout` elapses. Returns the completion items;
-/// returns `None` when the timeout expires so the caller can format
-/// its own diagnostic.
+/// The completion items the answer to the request `request_id` carries, waited for until it
+/// arrives or `timeout` runs out. `None` says the wait ran out.
 pub fn wait_for_completion_items(
     client: &mut LspClient,
     request_id: u32,
@@ -126,10 +124,10 @@ impl LspCompletionCtx {
         self.complete_with_timeout(file, line, col, Duration::from_secs(5))
     }
 
-    /// Send textDocument/completion and poll for the response with
-    /// the given timeout. Use this in dot-completion tests where
-    /// the server's first-time re-elaborate can take longer than
-    /// `complete`'s 5-second wait on a cold cache.
+    /// Send `textDocument/completion` and return the result items, waiting up
+    /// to `timeout` for the response. A request the server answers only after
+    /// re-elaborating the project takes longer than `complete` waits on a cold
+    /// cache, and `timeout` is what such a request is given.
     pub fn complete_with_timeout(
         &mut self,
         file: &str,

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -168,6 +168,15 @@ fn process_message(message: Value, shared: &SharedState) {
 }
 
 impl LspClient {
+    /// How long a request is given to be answered.
+    pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// How long a diagnostics pass is given to end.
+    pub const PASS_TIMEOUT: Duration = Duration::from_secs(180);
+
+    /// How long the server is given to exit once it has been told to.
+    pub const EXIT_TIMEOUT: Duration = Duration::from_millis(500);
+
     /// Run `fix language-server` in `working_dir`, which is the project root the paths a test
     /// passes are taken as relative to, and read what it sends on a thread of its own.
     /// `working_dir` itself may be relative to the directory the test runs in.
@@ -313,25 +322,25 @@ impl LspClient {
     }
 
     /// The oldest message the server sent that the queue still holds, taken out of it.
-    pub fn pop_message(&mut self) -> Option<Value> {
+    pub fn pop_message(&self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
     }
 
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
-    pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
+    pub fn wait_for_response(&self, id: u32, timeout: Duration) -> Option<Value> {
         poll(timeout, || self.take_response(id))
     }
 
     /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
-    pub fn expect_response(&mut self, id: u32) -> Value {
+    pub fn expect_response(&self, id: u32) -> Value {
         self.wait_for_response(id, Self::RESPONSE_TIMEOUT)
             .unwrap_or_else(|| panic!("the request {} is expected to be answered", id))
     }
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
     /// once. `None` says the response is yet to arrive.
-    pub fn take_response(&mut self, id: u32) -> Option<Value> {
+    pub fn take_response(&self, id: u32) -> Option<Value> {
         self.shared.responses.lock().unwrap().remove(&id)
     }
 
@@ -360,12 +369,6 @@ impl LspClient {
             )
         })
     }
-
-    /// How long a request is given to be answered.
-    pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-
-    /// How long a diagnostics pass is given to end.
-    pub const PASS_TIMEOUT: Duration = Duration::from_secs(180);
 
     /// Run `trigger`, which asks the server for a diagnostics pass, and return once one more pass
     /// has ended than had ended before it ran, so that the reports that pass publishes have
@@ -580,16 +583,16 @@ impl LspClient {
         )
     }
 
-    /// Ask the server to shut down and exit, and wait up to `exit_timeout` for its process to end
+    /// Ask the server to shut down and exit, and wait up to `EXIT_TIMEOUT` for its process to end
     /// once the `exit` notification has been sent.
-    pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
+    pub fn shutdown(&mut self) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
         let _ = self.wait_for_response(id, Self::RESPONSE_TIMEOUT);
 
         self.send_notification("exit", json!(null))?;
 
         // A process still running when `exit_timeout` runs out is an error; `Drop` kills it.
-        match poll(exit_timeout, || match self.process.try_wait() {
+        match poll(Self::EXIT_TIMEOUT, || match self.process.try_wait() {
             Ok(Some(_status)) => Some(Ok(())),
             Ok(None) => None,
             Err(e) => Some(Err(format!("Failed to check process status: {:?}", e))),

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -57,9 +57,11 @@ struct SharedState {
     responses: Arc<Mutex<Map<u32, Value>>>,
     /// The diagnostics last published for each file, under the file's absolute path.
     diagnostics: Arc<Mutex<Map<PathBuf, Value>>>,
-    /// Number of `$/progress` end notifications received so far.
-    progress_end_count: Arc<Mutex<usize>>,
-    /// The protocol error the reader thread stopped on, which `finish` hands to the test.
+    /// How many diagnostics passes have ended, counted by the `$/progress` end notifications
+    /// that mark them.
+    ended_pass_count: Arc<Mutex<usize>>,
+    /// The protocol error the reader thread stopped on, which `verify_no_protocol_error` hands
+    /// to the test.
     reader_thread_error: Arc<Mutex<Option<String>>>,
 }
 
@@ -70,7 +72,7 @@ impl SharedState {
             message_queue: Arc::new(Mutex::new(VecDeque::new())),
             responses: Arc::new(Mutex::new(Map::default())),
             diagnostics: Arc::new(Mutex::new(Map::default())),
-            progress_end_count: Arc::new(Mutex::new(0)),
+            ended_pass_count: Arc::new(Mutex::new(0)),
             reader_thread_error: Arc::new(Mutex::new(None)),
         }
     }
@@ -153,7 +155,7 @@ fn process_message(message: Value, shared: &SharedState) {
             .and_then(|k| k.as_str())
             == Some("end")
     {
-        *shared.progress_end_count.lock().unwrap() += 1;
+        *shared.ended_pass_count.lock().unwrap() += 1;
     }
 
     // Check if it's a publishDiagnostics notification
@@ -316,7 +318,7 @@ impl LspClient {
     /// The response to the request `id`, waited for until it arrives or `timeout` runs out.
     /// `None` says the wait ran out.
     pub fn wait_for_response(&mut self, id: u32, timeout: Duration) -> Option<Value> {
-        poll(timeout, || self.get_response(id))
+        poll(timeout, || self.take_response(id))
     }
 
     /// The response to the request `id`, which is expected to arrive within `RESPONSE_TIMEOUT`.
@@ -327,34 +329,32 @@ impl LspClient {
 
     /// The response to the request `id`, taken out of the responses so that it is handed over
     /// once. `None` says the response is yet to arrive.
-    pub fn get_response(&mut self, id: u32) -> Option<Value> {
+    pub fn take_response(&mut self, id: u32) -> Option<Value> {
         self.shared.responses.lock().unwrap().remove(&id)
     }
 
-    /// Return the number of `$/progress` end notifications received so far.
-    pub fn count_progress_end_messages(&self) -> usize {
-        *self.shared.progress_end_count.lock().unwrap()
+    /// How many diagnostics passes have ended so far.
+    pub fn ended_pass_count(&self) -> usize {
+        *self.shared.ended_pass_count.lock().unwrap()
     }
 
-    /// Wait until the total number of `$/progress` end notifications
-    /// reaches at least `target_count`.
-    ///
-    /// This is used to detect when diagnostics have completed, since the
-    /// server sends `$/progress` with `kind: "end"` after each diagnostics run.
-    pub fn wait_for_progress_end_count(
+    /// Wait until at least `target_count` diagnostics passes have ended. The server marks the
+    /// end of each pass with a `$/progress` notification carrying `kind: "end"`, which is what
+    /// the count is taken from.
+    pub fn wait_for_ended_passes(
         &self,
         target_count: usize,
         timeout: Duration,
     ) -> Result<(), String> {
         poll(timeout, || {
-            (self.count_progress_end_messages() >= target_count).then_some(())
+            (self.ended_pass_count() >= target_count).then_some(())
         })
         .ok_or_else(|| {
             format!(
-                "Timeout ({:?}) waiting for progress end count to reach {}. Current: {}",
+                "Timeout ({:?}) waiting for {} passes to end. Ended: {}",
                 timeout,
                 target_count,
-                self.count_progress_end_messages()
+                self.ended_pass_count()
             )
         })
     }
@@ -369,9 +369,9 @@ impl LspClient {
     /// has ended than had ended before it ran, so that the reports that pass publishes have
     /// arrived.
     pub fn wait_for_one_more_pass(&mut self, trigger: impl FnOnce(&mut Self)) {
-        let passes_before = self.count_progress_end_messages();
+        let passes_before = self.ended_pass_count();
         trigger(self);
-        self.wait_for_progress_end_count(passes_before + 1, Self::PASS_TIMEOUT)
+        self.wait_for_ended_passes(passes_before + 1, Self::PASS_TIMEOUT)
             .expect("the pass the buffer asks for is expected to end");
     }
 
@@ -441,15 +441,15 @@ impl LspClient {
         diagnostics_by_path
     }
 
-    /// Checks that the diagnostics of every file are empty, answering with an error that names a
-    /// file carrying any and shows what it carries.
-    pub fn verify_no_diagnostic_errors(&self) -> Result<(), String> {
+    /// Checks that no file carries a diagnostic of any severity, answering with an error that
+    /// names a file carrying one and shows what it carries.
+    pub fn verify_no_diagnostics(&self) -> Result<(), String> {
         let diagnostics = self.shared.diagnostics.lock().unwrap();
         for (file_path, diagnostics_value) in diagnostics.iter() {
             if let Some(diag_array) = diagnostics_value.as_array() {
                 if !diag_array.is_empty() {
                     return Err(format!(
-                        "Expected no diagnostic errors but found errors in {:?}: {:?}",
+                        "Expected no diagnostics but found some in {:?}: {:?}",
                         file_path, diag_array
                     ));
                 }
@@ -609,9 +609,10 @@ impl LspClient {
         }
     }
 
-    /// The protocol error the reader thread met, as an `Err`. Called at the end of a test, so
-    /// that an error met on a thread of its own reaches the test's result.
-    pub fn finish(&self) -> Result<(), String> {
+    /// Checks that the reader thread met no protocol error, answering with the error it met.
+    /// Called at the end of a test, so that an error met on a thread of its own reaches the
+    /// test's result.
+    pub fn verify_no_protocol_error(&self) -> Result<(), String> {
         let error = self.shared.reader_thread_error.lock().unwrap();
         if let Some(err_msg) = error.as_ref() {
             return Err(format!("LSP protocol error occurred: {}", err_msg));

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -263,46 +263,11 @@ impl LspClient {
         })
     }
 
-    /// Send LSP request
-    pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
-        let id = self.next_id;
-        self.next_id += 1;
-
-        let message = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-            "params": params,
-        });
-
-        let content = serde_json::to_string(&message)
-            .map_err(|e| format!("Failed to serialize request: {:?}", e))?;
-
-        let header = format!("Content-Length: {}\r\n\r\n", content.len());
-
-        self.stdin
-            .write_all(header.as_bytes())
-            .map_err(|e| format!("Failed to write header: {:?}", e))?;
-        self.stdin
-            .write_all(content.as_bytes())
-            .map_err(|e| format!("Failed to write content: {:?}", e))?;
-        self.stdin
-            .flush()
-            .map_err(|e| format!("Failed to flush: {:?}", e))?;
-
-        Ok(id)
-    }
-
-    /// Send LSP notification
-    pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
-        let message = json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        });
-
-        let content = serde_json::to_string(&message)
-            .map_err(|e| format!("Failed to serialize notification: {:?}", e))?;
+    /// Write `message` to the server, headed by the `Content-Length` the protocol frames a
+    /// message with.
+    fn send_message(&mut self, message: &Value) -> Result<(), String> {
+        let content = serde_json::to_string(message)
+            .map_err(|e| format!("Failed to serialize message: {:?}", e))?;
 
         let header = format!("Content-Length: {}\r\n\r\n", content.len());
 
@@ -317,6 +282,30 @@ impl LspClient {
             .map_err(|e| format!("Failed to flush: {:?}", e))?;
 
         Ok(())
+    }
+
+    /// Send LSP request
+    pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.send_message(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+
+        Ok(id)
+    }
+
+    /// Send LSP notification
+    pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
+        self.send_message(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }))
     }
 
     /// Pop one message from the message queue
@@ -479,7 +468,7 @@ impl LspClient {
         // Convert to absolute path
         let absolute_root = to_absolute_path(root_path)
             .map_err(|e| format!("Failed to convert root_path to absolute path: {}", e))?;
-        let root_uri = format!("file://{}", absolute_root.display());
+        let root_uri = uri_of(&absolute_root);
 
         let params = json!({
             "processId": null,

--- a/src/tests/test_lsp/lsp_client.rs
+++ b/src/tests/test_lsp/lsp_client.rs
@@ -102,7 +102,9 @@ fn is_publish_diagnostics(message: &Value) -> bool {
     message.get("method").and_then(|m| m.as_str()) == Some("textDocument/publishDiagnostics")
 }
 
-/// Process a received message and update internal state
+/// Take `message` into `shared`: the response to a request under the request's id, the end of a
+/// diagnostics pass into the count of the passes that have ended, the diagnostics of a file under
+/// the file's path, and the message itself into the queue.
 fn process_message(message: Value, shared: &SharedState) {
     /// Handle a `textDocument/publishDiagnostics` notification.
     fn process_publish_diagnostics(message: &Value, shared: &SharedState) {
@@ -166,10 +168,9 @@ fn process_message(message: Value, shared: &SharedState) {
 }
 
 impl LspClient {
-    /// Start fix command in language server mode
-    ///
-    /// The working_dir can be either a relative or absolute path.
-    /// It will be converted to an absolute path internally.
+    /// Run `fix language-server` in `working_dir`, which is the project root the paths a test
+    /// passes are taken as relative to, and read what it sends on a thread of its own.
+    /// `working_dir` itself may be relative to the directory the test runs in.
     pub fn new(working_dir: &Path) -> Result<Self, String> {
         // Convert to absolute path
         let absolute_working_dir = to_absolute_path(working_dir)
@@ -191,8 +192,8 @@ impl LspClient {
         let shared = SharedState::new();
         let shared_clone = shared.clone();
 
-        // Start dedicated reader thread (detached - JoinHandle is not stored)
-        // The thread will exit when stdout is closed (process termination) or on protocol error
+        // The reader thread runs on its own, and ends when the process closes its stdout or when
+        // it meets a protocol error.
         thread::spawn(move || {
             let mut reader = BufReader::new(stdout);
             loop {
@@ -286,7 +287,8 @@ impl LspClient {
         Ok(())
     }
 
-    /// Send LSP request
+    /// Send the request `method` with `params`, and hand back the id it was sent under, which the
+    /// response to it carries.
     pub fn send_request(&mut self, method: &str, params: Value) -> Result<u32, String> {
         let id = self.next_id;
         self.next_id += 1;
@@ -301,7 +303,7 @@ impl LspClient {
         Ok(id)
     }
 
-    /// Send LSP notification
+    /// Send the notification `method` with `params`, which the server answers nothing to.
     pub fn send_notification(&mut self, method: &str, params: Value) -> Result<(), String> {
         self.send_message(&json!({
             "jsonrpc": "2.0",
@@ -310,7 +312,7 @@ impl LspClient {
         }))
     }
 
-    /// Pop one message from the message queue
+    /// The oldest message the server sent that the queue still holds, taken out of it.
     pub fn pop_message(&mut self) -> Option<Value> {
         self.shared.message_queue.lock().unwrap().pop_front()
     }
@@ -458,12 +460,10 @@ impl LspClient {
         Ok(())
     }
 
-    /// Run the initialization handshake: send the `initialize` request, wait for its response,
-    /// then send the `initialized` notification the server starts its diagnostics on.
-    ///
-    /// # Arguments
-    /// * `root_path` - Project root directory path (can be relative or absolute)
-    /// * `timeout` - Maximum time to wait for initialize response
+    /// Run the initialization handshake: send the `initialize` request naming `root_path` as the
+    /// project root, wait up to `timeout` for its response, then send the `initialized`
+    /// notification the server starts its diagnostics on. `root_path` may itself be relative to
+    /// the directory the test runs in.
     pub fn initialize(&mut self, root_path: &Path, timeout: Duration) -> Result<(), String> {
         // Convert to absolute path
         let absolute_root = to_absolute_path(root_path)
@@ -499,13 +499,9 @@ impl LspClient {
         Ok((text, uri_of(absolute_path)))
     }
 
-    /// Send didOpen notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// and sends a didOpen notification to the language server.
-    /// Initializes the document version to 1.
-    ///
-    /// Returns an error if the document is already opened.
+    /// Tell the server that the client now holds `file_path`, whose content it reads from disk and
+    /// sends along. `file_path` is taken as relative to the project root, and the version the
+    /// client counts its changes from starts here.
     pub fn open_document(&mut self, file_path: &Path) -> Result<(), String> {
         /// The version the protocol counts an opened document from.
         const INITIAL_VERSION_NUMBER: i32 = 1;
@@ -536,11 +532,9 @@ impl LspClient {
         )
     }
 
-    /// Send didChange notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// increments the document version, and sends a didChange notification to the language server.
-    /// The document must have been opened with open_document first.
+    /// Tell the server that what the client holds for `file_path` is now the content on disk,
+    /// under the next version. `file_path` is taken as relative to the project root, and is
+    /// expected to have been opened by `open_document`.
     pub fn change_document(&mut self, file_path: &Path) -> Result<(), String> {
         let absolute_path = self.working_dir.join(file_path);
         let (text, uri) = Self::read_document(&absolute_path)?;
@@ -569,10 +563,8 @@ impl LspClient {
         )
     }
 
-    /// Send didSave notification for a document
-    ///
-    /// Takes a file path relative to the project root, reads the file content,
-    /// and sends a didSave notification to the language server.
+    /// Tell the server that `file_path` has been saved, along with the content on disk, which is
+    /// what asks it for a diagnostics pass. `file_path` is taken as relative to the project root.
     pub fn save_document(&mut self, file_path: &Path) -> Result<(), String> {
         let absolute_path = self.working_dir.join(file_path);
         let (text, uri) = Self::read_document(&absolute_path)?;
@@ -588,10 +580,8 @@ impl LspClient {
         )
     }
 
-    /// Ask the server to shut down and exit, and wait for its process to end.
-    ///
-    /// # Arguments
-    /// * `exit_timeout` - Maximum time to wait for the process to exit after sending exit notification
+    /// Ask the server to shut down and exit, and wait up to `exit_timeout` for its process to end
+    /// once the `exit` notification has been sent.
     pub fn shutdown(&mut self, exit_timeout: Duration) -> Result<(), String> {
         let id = self.send_request("shutdown", json!(null))?;
         let _ = self.wait_for_response(id, Self::RESPONSE_TIMEOUT);

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -130,7 +130,7 @@ mod tests {
 
         // Verify that all diagnostic errors have been resolved
         client
-            .verify_no_diagnostic_errors()
+            .verify_no_diagnostics()
             .expect("All diagnostic errors should be resolved after adding dependencies");
 
         // Shutdown
@@ -140,7 +140,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -225,7 +225,7 @@ mod tests {
 
         // Verify that all diagnostic errors have been resolved
         client
-            .verify_no_diagnostic_errors()
+            .verify_no_diagnostics()
             .expect("All diagnostic errors should be resolved after adding test dependencies");
 
         // Shutdown
@@ -235,7 +235,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -342,7 +342,7 @@ mod tests {
 
         // Check for reader thread errors
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -1,5 +1,6 @@
 // LSP integration tests module
 pub mod bench_completion;
+pub mod case_project;
 pub mod completion_harness;
 pub mod lsp_client;
 pub mod test_code_action;
@@ -21,34 +22,11 @@ pub mod test_workspace_symbol;
 
 #[cfg(test)]
 mod tests {
+    use super::case_project::setup_test_env;
     use super::lsp_client::LspClient;
     use crate::constants::LOCK_FILE_LSP_PATH;
-    use crate::tests::test_util::{copy_dir_recursive, fix_command};
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        time::Duration,
-    };
-    use tempfile::TempDir;
-
-    /// Path to the directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Create a temporary test environment with copied project files.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-
-        // Copy test case directory
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-
-        (temp_dir, test_case_dst)
-    }
+    use crate::tests::test_util::fix_command;
+    use std::{fs, path::Path, time::Duration};
 
     /// The LSP server automatically generates a lock file containing the
     /// project's dependencies, and diagnostics clear once a missing
@@ -134,9 +112,7 @@ mod tests {
             .expect("All diagnostic errors should be resolved after adding dependencies");
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client
@@ -229,9 +205,7 @@ mod tests {
             .expect("All diagnostic errors should be resolved after adding test dependencies");
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client
@@ -336,9 +310,7 @@ mod tests {
         );
 
         // Shutdown
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
 
         // Check for reader thread errors
         client

--- a/src/tests/test_lsp/mod.rs
+++ b/src/tests/test_lsp/mod.rs
@@ -16,8 +16,8 @@ pub mod test_semantic_tokens;
 pub mod test_stdin_eof;
 pub mod test_workspace_symbol;
 
-// LSP Integration Tests
-// Tests for automatic lock file management in language server mode
+// The lock file the language server writes for the project it is serving, and the report the
+// editor is shown when that project's dependencies cannot be resolved.
 
 #[cfg(test)]
 mod tests {

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::edit::edit_util::apply_text_edits;
     use lsp_types::TextEdit;
@@ -97,7 +97,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -156,9 +156,7 @@ mod tests {
 
         /// Ends the session and fails the test if the server's reader thread met an error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -160,7 +160,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_code_action.rs
+++ b/src/tests/test_lsp/test_code_action.rs
@@ -4,9 +4,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::edit::edit_util::apply_text_edits;
-    use crate::tests::test_util::copy_dir_recursive;
     use lsp_types::TextEdit;
     use serde_json::{json, Value};
     use std::{
@@ -65,27 +65,6 @@ mod tests {
             .collect()
     }
 
-    /// The directory holding the Fix projects these tests run the language server on.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copies the named case project into a temporary directory, so that tests editing their
-    /// project's files run beside one another, and returns that directory with the canonical path
-    /// of the copy inside it.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     /// A language server running on a copy of one case project, with its documents open and its
     /// first diagnostics published.
     struct LspQuickFixCtx {
@@ -131,7 +110,7 @@ mod tests {
 
         /// The URI the server names the project's `file` by, as the responses spell it.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Request code actions for a given range with the provided diagnostics.

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -1,6 +1,5 @@
-// LSP integration tests for "textDocument/completion" feature.
-//
-// Verifies that associated types appear in completion candidates.
+// LSP integration tests for the "textDocument/completion" feature: which candidates the server
+// offers, what a resolved candidate inserts, and the order the candidates are ranked in.
 
 #[cfg(test)]
 mod tests {
@@ -85,9 +84,8 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Snapshot of the completion *insertion* behavior. Pins down what
-    /// the server sends back for `completionItem/resolve` for the four
-    /// shapes that have so far been verified manually:
+    /// Snapshot of the completion *insertion* behavior. Pins down what the
+    /// server sends back for `completionItem/resolve` for four shapes:
     ///
     ///   typing            expected insert_text         notes
     ///   ----              --------------------         -----
@@ -237,9 +235,9 @@ mod tests {
             tags
         );
 
-        // Sanity: a non-deprecated symbol from the same fixture must NOT
-        // carry the deprecation markers, otherwise the test above would
-        // pass even if we accidentally tagged everything.
+        // A live symbol of the same fixture carries neither marker, which is
+        // what tells a server that marks the deprecated symbol from one that
+        // marks every symbol.
         let live_item = items
             .iter()
             .find(|it| it.get("label").and_then(|l| l.as_str()) == Some("Main::Hoge::new_func"))
@@ -306,9 +304,9 @@ mod tests {
         let mut ctx = LspCompletionCtx::setup("completion-dot-sort", &["main.fix"]);
 
         // Cursor right after the dot in `    42.` on line 13 (0-indexed),
-        // column 7 (= byte right after `.`).
-        // Use a polling wait — the dot-completion full re-elaborate can take
-        // longer than `complete`'s hard-coded 5s sleep on a cold cache.
+        // column 7 (= byte right after `.`). The dot-completion full
+        // re-elaborate can take longer than the five seconds `complete` waits
+        // on a cold cache, so the wait here is given longer.
         let items = ctx.complete_with_timeout("main.fix", 13, 7, Duration::from_secs(60));
 
         assert_myfunc2_outranks_myfunc1(&items);
@@ -921,12 +919,11 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Regression: `(a, a).<cursor>` inside a non-exhaustive `match`
-    /// arm. The scenario can crash the elaborator if the Match's
-    /// failed exhaustiveness check leaves the child subtree untyped
-    /// and `fix_types` then unwrap-panics on the missing `type_`; a
-    /// panic in the LSP process leaves the editor hung on the
-    /// completion request.
+    /// `(a, a).<cursor>` inside a non-exhaustive `match` arm. The scenario
+    /// can crash the elaborator if the Match's failed exhaustiveness check
+    /// leaves the child subtree untyped and `fix_types` then unwrap-panics on
+    /// the missing `type_`; a panic in the LSP process leaves the editor hung
+    /// on the completion request.
     ///
     /// This test asserts only "the server stays up and replies".
     /// `test_completion_dot_after_tuple_infers_tuple_receiver` checks
@@ -949,18 +946,18 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Stronger version of the regression above: when dot completion
-    /// fires at `(a, a).<cursor>` inside a structurally broken Match
-    /// arm, every sub-node still carries an inferred type, so the
-    /// dot-completion pipeline can read off `(I64, I64)` as the
-    /// receiver. Tuple field accessors should land in Tier 0;
-    /// unrelated methods on different TyCons (e.g. `Iterator::fold`)
-    /// should not.
+    /// Where `test_completion_dot_after_tuple_no_crash` asks only that the
+    /// server reply, this asks what the reply says: when dot completion fires
+    /// at `(a, a).<cursor>` inside a structurally broken Match arm, every
+    /// sub-node still carries an inferred type, so the dot-completion pipeline
+    /// can read off `(I64, I64)` as the receiver. Tuple field accessors should
+    /// land in Tier 0; unrelated methods on different TyCons (e.g.
+    /// `Iterator::fold`) should not.
     ///
-    /// A regression here signals that the tolerant elaborator is
-    /// discarding typed sub-trees (or `fix_types` is truncating the
-    /// substituted types) — a fresh tyvar at the receiver would put
-    /// every method into the catch-all Tier 2/3, not Tier 0.
+    /// A failure here signals that the tolerant elaborator is discarding
+    /// typed sub-trees (or `fix_types` is truncating the substituted types) —
+    /// a fresh tyvar at the receiver would put every method into the
+    /// catch-all Tier 2/3, not Tier 0.
     #[test]
     fn test_completion_dot_after_tuple_infers_tuple_receiver() {
         let mut ctx = LspCompletionCtx::setup("completion-dot-after-tuple", &["main.fix"]);
@@ -976,11 +973,10 @@ mod tests {
         );
 
         // `Std::Iterator::fold` is a typical receiver-of-different-TyCon
-        // method that, if the receiver were merely a fresh tyvar (the
-        // pre-refactor fallback shape), would still bucket-match and
-        // could be wrongly promoted. After the refactor, the receiver
-        // is `(I64, I64)`, which doesn't unify with `Iterator i`, so
-        // `fold` must stay out of Tier 0.
+        // method: were the receiver merely a fresh tyvar, it would
+        // bucket-match and could be wrongly promoted. The receiver here is
+        // `(I64, I64)`, which doesn't unify with `Iterator i`, so `fold` must
+        // stay out of Tier 0.
         let sort_fold = find_sort_text(&items, "Std::Iterator::fold")
             .expect("Std::Iterator::fold should appear in the completion list");
         assert!(
@@ -1133,10 +1129,9 @@ mod tests {
         //  11:     pure()
         //  12: );
         //
-        // Column 7 = byte just after `.` on `    42.`.
-        // Use a polling wait because the dot-context elaborate can
-        // take longer than `complete`'s hard-coded 5s sleep on a cold
-        // cache.
+        // Column 7 = byte just after `.` on `    42.`. The dot-context
+        // elaborate can take longer than the five seconds `complete` waits on
+        // a cold cache, so the wait here is given longer.
         let items = ctx.complete_with_timeout("main.fix", 10, 7, Duration::from_secs(60));
 
         let sort_live = find_sort_text(&items, "Main::live_func")

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -436,7 +436,7 @@ mod tests {
         );
 
         let _ = client.shutdown(Duration::from_millis(500));
-        let _ = client.finish();
+        let _ = client.verify_no_protocol_error();
         drop(temp_dir);
 
         // Assertion: myfunc2 should out-rank myfunc1 even when the

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -347,7 +347,7 @@ mod tests {
         let dot_added = fs::read_to_string(&abs_path)
             .expect("read main.fix")
             .replace("    42\n", "    42.\n");
-        let uri = format!("file://{}", abs_path.display());
+        let uri = client.file_uri(Path::new("main.fix"));
         client
             .send_notification(
                 "textDocument/didChange",
@@ -1308,7 +1308,7 @@ mod tests {
                 "    let _ = arr.",
                 "    let _ = /* \u{65e5}\u{672c}\u{8a9e} */ arr.",
             );
-        let uri = format!("file://{}", abs_path.display());
+        let uri = client.file_uri(Path::new("main.fix"));
         client
             .send_notification(
                 "textDocument/didChange",

--- a/src/tests/test_lsp/test_completion.rs
+++ b/src/tests/test_lsp/test_completion.rs
@@ -3,8 +3,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::case_project::setup_test_env;
     use super::super::completion_harness::{
-        find_sort_text, setup_test_env, wait_for_completion_items, LspCompletionCtx,
+        find_sort_text, wait_for_completion_items, LspCompletionCtx,
     };
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
@@ -433,7 +434,7 @@ mod tests {
             item_summary.join("\n")
         );
 
-        let _ = client.shutdown(Duration::from_millis(500));
+        let _ = client.shutdown();
         let _ = client.verify_no_protocol_error();
         drop(temp_dir);
 
@@ -1346,6 +1347,6 @@ mod tests {
             sort_push_back
         );
 
-        let _ = client.shutdown(Duration::from_millis(500));
+        let _ = client.shutdown();
     }
 }

--- a/src/tests/test_lsp/test_diagnostics.rs
+++ b/src/tests/test_lsp/test_diagnostics.rs
@@ -6,25 +6,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::case_project::setup_test_env;
     use super::super::completion_harness::LspCompletionCtx;
     use super::super::lsp_client::{poll, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::Duration;
     use tempfile::TempDir;
-
-    /// Copies the named case project into a temporary directory and returns it with the project's
-    /// path inside it.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cases_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/test_lsp/cases");
-        let project_dir = temp_dir.path().join(project_name);
-        copy_dir_recursive(&cases_dir.join(project_name), &project_dir)
-            .expect("Failed to copy test case");
-        (temp_dir, project_dir)
-    }
 
     /// The diagnostics the server publishes for `file` of the project, after opening and saving it.
     fn diagnostics_of(project_dir: &Path, file: &Path) -> Vec<Value> {

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -8,6 +8,7 @@ mod tests {
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -75,8 +76,7 @@ mod tests {
 
     /// Read the substring of `file` covered by an LSP range.
     fn read_text_at_range(file: &Path, range: &Value) -> String {
-        let content =
-            std::fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
+        let content = fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
         let lines: Vec<&str> = content.lines().collect();
         let sl = range["start"]["line"].as_u64().unwrap() as usize;
         let sc = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -37,7 +37,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -76,9 +76,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
@@ -87,7 +85,8 @@ mod tests {
 
     /// Read the substring of `file` covered by an LSP range.
     fn read_text_at_range(file: &Path, range: &Value) -> String {
-        let content = fs::read_to_string(file).expect(&format!("Failed to read file: {:?}", file));
+        let content =
+            fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read file: {:?}", file));
         let lines: Vec<&str> = content.lines().collect();
         let sl = range["start"]["line"].as_u64().unwrap() as usize;
         let sc = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -14,12 +14,20 @@ mod tests {
     };
     use tempfile::TempDir;
 
+    /// A running language server over a private copy of one fixture project, with that
+    /// project's files open.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the copy alive; dropping it deletes
+        /// the copy.
         _temp_dir: TempDir,
     }
 
     impl LspTestCtx {
+        /// Start a server over a fresh copy of `project_name` and open each of `files`, paths
+        /// relative to the project root, in the given order. Returns once the last of them has
+        /// been elaborated, so the program the jumps are answered from is in place.
         fn setup(project_name: &str, files: &[&str]) -> Self {
             let (temp_dir, project_dir) = setup_test_env(project_name);
             let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
@@ -39,6 +47,8 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
@@ -64,6 +74,7 @@ mod tests {
                 .expect("Response should have a result field")
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -202,21 +213,17 @@ mod tests {
         let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);
         // Use at line 52, col 4.
         let result = ctx.goto_definition("lib.fix", 52, 4);
-        // Inner binder at line 51, col 8 (NOT the outer at line 50).
+        // The inner binder at line 51, col 8, which shadows the one at line 50.
         assert_location(&result, &ctx, "lib.fix", 51, 8, "s");
         ctx.shutdown();
     }
 
-    // --- Repro: source span missing on `&&`-desugared `if` ---
+    // --- The `if` that `&&` desugars to ---
     //
-    // `parse_expr_and` (parser.rs:1342) builds the synthesized
-    // `expr_if(lhs, rhs, expr_bool_lit(false, None), None)` with
-    // `source: None`. `ExprNode::find_node_at` short-circuits on a
-    // None source, so anything underneath the synthesized If is
-    // unreachable — including the LHS and RHS sub-expressions of
-    // `&&`. Hover, goto-definition, and find-references all break
-    // there. The outer `if`'s THEN/ELSE branches are not affected
-    // because they sit on the outer (user-written) `if`.
+    // `parse_expr_and` builds a synthesized `expr_if` for each `&&`, and gives it the span
+    // uniting its two operands. `ExprNode::find_node_at` walks into a node only through its
+    // span, so that span is what keeps the operands of `&&` reachable — to
+    // goto-definition here, and to hover and find-references alike.
 
     /// Cursor on `b` of `b >= 0` (LHS of `&&`).
     #[test]
@@ -239,7 +246,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Sanity: cursor on `b` inside `{ b }` (outer If's THEN branch) — works.
+    /// Cursor on `b` inside `{ b }`, the THEN branch of the user-written `if`.
     #[test]
     fn test_goto_local_and_then_branch() {
         let mut ctx = LspTestCtx::setup("goto_local", &["lib.fix"]);

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -68,7 +68,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_goto_definition.rs
+++ b/src/tests/test_lsp/test_goto_definition.rs
@@ -4,8 +4,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
@@ -13,26 +13,8 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -52,13 +34,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/definition and return the result value (the LSP

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -7,8 +7,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         fs,
@@ -16,27 +16,6 @@ mod tests {
         time::Duration,
     };
     use tempfile::TempDir;
-
-    /// Absolute path to the LSP `cases/` directory.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test project into a fresh temp directory and
-    /// return both the temp dir handle (to keep it alive) and the
-    /// canonicalised path of the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// Per-test LSP harness: owns the running language server, the
     /// temp directory holding the copied project, and the project
@@ -73,7 +52,7 @@ mod tests {
 
         /// Build a `file://` URI for `file` relative to the project root.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/hover and return the result value (the LSP

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -83,7 +83,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -7,7 +7,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -43,7 +43,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -83,9 +83,7 @@ mod tests {
         /// Shut the server down; panics if it fails to exit or if its reader
         /// thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_hover.rs
+++ b/src/tests/test_lsp/test_hover.rs
@@ -21,8 +21,12 @@ mod tests {
     /// temp directory holding the copied project, and the project
     /// path itself.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// The copy of the fixture project the server was started on.
         project_dir: PathBuf,
+        /// Holds the temporary directory containing `project_dir` alive; dropping
+        /// it deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -76,8 +80,8 @@ mod tests {
                 .expect("Response should have a result field")
         }
 
-        /// Cleanly shut down the LSP server and join its reader
-        /// thread; panics if either step fails.
+        /// Shut the server down; panics if it fails to exit or if its reader
+        /// thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -133,7 +133,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
 

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -6,8 +6,9 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
+    use crate::misc::Set;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
@@ -15,34 +16,10 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    // -----------------------------------------------------------------------
-    // Helpers
-    // -----------------------------------------------------------------------
-
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        // Canonicalize to resolve symlinks (e.g., /tmp -> /private/tmp on macOS).
-        // This ensures the path matches the canonicalized rootUri sent to the LSP server.
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
-
     /// A convenience wrapper around `LspClient` that provides high-level
     /// helpers for common test patterns (find-refs, call hierarchy, etc.).
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -64,13 +41,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Send textDocument/references and return the result array.
@@ -209,7 +185,7 @@ mod tests {
                 Some(format!("{}:{}:{}", uri, line, ch))
             })
             .collect();
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = Set::default();
         for key in &keys {
             assert!(
                 seen.insert(key),

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use crate::misc::Set;
     use serde_json::{json, Value};
@@ -39,7 +39,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -136,9 +136,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
@@ -206,8 +204,8 @@ mod tests {
 
     /// Read the text at an LSP range from a source file.
     fn read_text_at_range(file_path: &Path, range: &Value) -> String {
-        let content =
-            fs::read_to_string(file_path).expect(&format!("Failed to read file: {:?}", file_path));
+        let content = fs::read_to_string(file_path)
+            .unwrap_or_else(|_| panic!("Failed to read file: {:?}", file_path));
         let lines: Vec<&str> = content.lines().collect();
         let start_line = range["start"]["line"].as_u64().unwrap() as usize;
         let start_char = range["start"]["character"].as_u64().unwrap() as usize;

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::misc::Set;
     use serde_json::{json, Value};
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -199,8 +200,8 @@ mod tests {
 
     /// Read the text at an LSP range from a source file.
     fn read_text_at_range(file_path: &Path, range: &Value) -> String {
-        let content = std::fs::read_to_string(file_path)
-            .expect(&format!("Failed to read file: {:?}", file_path));
+        let content =
+            fs::read_to_string(file_path).expect(&format!("Failed to read file: {:?}", file_path));
         let lines: Vec<&str> = content.lines().collect();
         let start_line = range["start"]["line"].as_u64().unwrap() as usize;
         let start_char = range["start"]["character"].as_u64().unwrap() as usize;
@@ -876,7 +877,7 @@ mod tests {
         let mut found_caret_x = false;
         for loc in &locs {
             let uri = loc["uri"].as_str().unwrap();
-            let file_path = std::path::PathBuf::from(uri.strip_prefix("file://").unwrap());
+            let file_path = PathBuf::from(uri.strip_prefix("file://").unwrap());
             let text = read_text_at_range(&file_path, loc.get("range").unwrap());
             if text == "^x" {
                 found_caret_x = true;

--- a/src/tests/test_lsp/test_references.rs
+++ b/src/tests/test_lsp/test_references.rs
@@ -1,8 +1,8 @@
 // LSP integration tests for "Find All References" and "Call Hierarchy" features.
 //
-// Each test case corresponds to a case in agents/test-refs.20260301/test_plan.md.
-// Each symbol-type group has its own Fix project under cases/ to keep tests simple
-// and resilient to line-number changes.
+// Each symbol kind has its own Fix project under cases/, which keeps the tests simple and
+// resilient to line-number changes. The tests of one kind carry that kind's label (`GV`, `Ty`,
+// `Tr`, `TrA`, `AT`, `IMP`, `FV`, `Loc`) and a number within it.
 
 #[cfg(test)]
 mod tests {
@@ -20,7 +20,10 @@ mod tests {
     /// A convenience wrapper around `LspClient` that provides high-level
     /// helpers for common test patterns (find-refs, call hierarchy, etc.).
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the project copy alive; dropping it
+        /// deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -46,6 +49,8 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
@@ -129,6 +134,7 @@ mod tests {
             result.as_array().unwrap().clone()
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -229,6 +235,7 @@ mod tests {
         text == full_name || full_name.ends_with(&format!("::{}", text))
     }
 
+    /// Assert that at least one of `locations` names a file whose URI contains `file_name`.
     fn assert_has_ref_in_file(locations: &[Value], file_name: &str) {
         assert!(
             locations.iter().any(|loc| loc
@@ -241,6 +248,8 @@ mod tests {
         );
     }
 
+    /// The name of the item at each call's `direction` end, `direction` being `"from"` for an
+    /// incoming call and `"to"` for an outgoing one.
     fn call_names(calls: &[Value], direction: &str) -> Vec<String> {
         calls
             .iter()
@@ -253,6 +262,8 @@ mod tests {
             .collect()
     }
 
+    /// Assert that one of the incoming `calls` comes from an item whose name contains
+    /// `name_fragment`.
     fn assert_has_caller(calls: &[Value], name_fragment: &str) {
         let names = call_names(calls, "from");
         assert!(
@@ -263,6 +274,8 @@ mod tests {
         );
     }
 
+    /// Assert that one of the outgoing `calls` goes to an item whose name contains
+    /// `name_fragment`.
     #[allow(dead_code)]
     fn assert_has_callee(calls: &[Value], name_fragment: &str) {
         let names = call_names(calls, "to");

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -8,12 +8,20 @@ mod tests {
     use std::{path::Path, time::Duration};
     use tempfile::TempDir;
 
+    /// A running language server over a private copy of one fixture project, with that
+    /// project's files open.
     struct LspTestCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// Holds the temporary directory containing the copy alive; dropping it deletes
+        /// the copy.
         _temp_dir: TempDir,
     }
 
     impl LspTestCtx {
+        /// Start a server over a fresh copy of `project_name` and open each of `files`, paths
+        /// relative to the project root, in the given order. Returns once the last of them has
+        /// been elaborated, so the program the renames are worked out from is in place.
         fn setup(project_name: &str, files: &[&str]) -> Self {
             let (temp_dir, project_dir) = setup_test_env(project_name);
             let mut client = LspClient::new(&project_dir).expect("Failed to start LSP");
@@ -33,12 +41,14 @@ mod tests {
             }
         }
 
+        /// The `file://` URI the server knows `file` by, `file` being a path relative to the
+        /// project root.
         fn file_uri(&self, file: &str) -> String {
             self.client.file_uri(Path::new(file))
         }
 
-        // Send `textDocument/rename` and return the response value (full
-        // JSON-RPC response object, including any error).
+        /// Send `textDocument/rename` and return the whole JSON-RPC response, an error
+        /// among its fields included.
         fn rename_raw(&mut self, file: &str, line: u32, col: u32, new_name: &str) -> Value {
             let uri = self.file_uri(file);
             let id = self
@@ -55,8 +65,8 @@ mod tests {
             self.client.expect_response(id)
         }
 
-        // Send `textDocument/rename` and unwrap the `result` (asserting it
-        // is a `WorkspaceEdit` rather than an error).
+        /// Send `textDocument/rename` and return the `WorkspaceEdit` of its `result`,
+        /// asserting that the server answered with one.
         fn rename(&mut self, file: &str, line: u32, col: u32, new_name: &str) -> Value {
             let resp = self.rename_raw(file, line, col, new_name);
             assert!(
@@ -69,8 +79,8 @@ mod tests {
                 .clone()
         }
 
-        // Send `textDocument/prepareRename` and return the full response
-        // value (so tests can inspect `result` and `error` independently).
+        /// Send `textDocument/prepareRename` and return the whole JSON-RPC response, so
+        /// that a test can read its `result` and its `error` each on its own.
         fn prepare_rename_raw(&mut self, file: &str, line: u32, col: u32) -> Value {
             let uri = self.file_uri(file);
             let id = self
@@ -86,8 +96,8 @@ mod tests {
             self.client.expect_response(id)
         }
 
-        // Send `textDocument/prepareRename` and return the `result`
-        // value; panics if the server returned a `ResponseError`.
+        /// Send `textDocument/prepareRename` and return the `result` value; panics if the
+        /// server answered with a `ResponseError`.
         fn prepare_rename(&mut self, file: &str, line: u32, col: u32) -> Value {
             let resp = self.prepare_rename_raw(file, line, col);
             assert!(
@@ -100,6 +110,7 @@ mod tests {
                 .clone()
         }
 
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -110,8 +121,7 @@ mod tests {
         }
     }
 
-    // Count the total number of TextEdits across every URI in a
-    // WorkspaceEdit `result` value.
+    /// The number of `TextEdit`s a `WorkspaceEdit` carries, over all the URIs it changes.
     fn count_edits(workspace_edit: &Value) -> usize {
         workspace_edit
             .get("changes")
@@ -124,7 +134,8 @@ mod tests {
             .unwrap_or(0)
     }
 
-    // Collect (uri suffix, count) pairs for the changes in a WorkspaceEdit.
+    /// The file name of each URI a `WorkspaceEdit` changes, paired with how many
+    /// `TextEdit`s it carries for that URI, sorted by file name.
     fn changes_per_file(workspace_edit: &Value) -> Vec<(String, usize)> {
         workspace_edit
             .get("changes")
@@ -144,6 +155,7 @@ mod tests {
             .unwrap_or_default()
     }
 
+    /// Assert that every `TextEdit` of `workspace_edit` writes `new_name` and nothing else.
     fn assert_all_edits_have_new_text(workspace_edit: &Value, new_name: &str) {
         let changes = workspace_edit
             .get("changes")
@@ -179,7 +191,7 @@ mod tests {
     //  11: );
     // =======================================================================
 
-    /// RB-1: rename a global value across files. Cursor on the declaration
+    /// Rename a global value across files. Cursor on the declaration
     /// LHS in lib.fix.
     #[test]
     fn test_rename_global_decl() {
@@ -202,7 +214,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-2: rename a global value, starting from a use site in lib.fix.
+    /// Rename a global value, starting from a use site in lib.fix.
     #[test]
     fn test_rename_global_from_use_same_file() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -212,7 +224,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-3: rename a global value, starting from a use site in main.fix.
+    /// Rename a global value, starting from a use site in main.fix.
     #[test]
     fn test_rename_global_from_use_other_file() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -222,7 +234,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-4: rename a global value, starting from the import statement.
+    /// Rename a global value, starting from the import statement.
     #[test]
     fn test_rename_global_from_import() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -260,7 +272,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-5: rename a local let-bound variable.
+    /// Rename a local let-bound variable.
     #[test]
     fn test_rename_local_let() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -274,7 +286,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-6: rename rejected on an invalid identifier (keyword).
+    /// Rename rejected on an invalid identifier (keyword).
     #[test]
     fn test_rename_reject_keyword() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -287,7 +299,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-7: rename rejected on an invalid identifier (uppercase start).
+    /// Rename rejected on an invalid identifier (uppercase start).
     #[test]
     fn test_rename_reject_uppercase() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -300,7 +312,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-8: prepareRename returns defaultBehavior for a global value.
+    /// `prepareRename` returns defaultBehavior for a global value.
     #[test]
     fn test_prepare_rename_global_value() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -317,7 +329,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-9: prepareRename returns defaultBehavior for a local variable.
+    /// `prepareRename` returns defaultBehavior for a local variable.
     #[test]
     fn test_prepare_rename_local() {
         let mut ctx = LspTestCtx::setup("rename_basic", &["lib.fix", "main.fix"]);
@@ -333,7 +345,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RB-10: prepareRename returns defaultBehavior on a struct type.
+    /// `prepareRename` returns defaultBehavior on a struct type.
     #[test]
     fn test_prepare_rename_struct_type() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -372,7 +384,7 @@ mod tests {
     //   4: bump : MyInt -> MyInt;           (cols 7, 16)
     // =======================================================================
 
-    /// RT-1: rename a type alias from its declaration.
+    /// Rename a type alias from its declaration.
     #[test]
     fn test_rename_type_alias_decl() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -388,7 +400,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-2: rename a trait.
+    /// Rename a trait.
     #[test]
     fn test_rename_trait() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -400,7 +412,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-3: rename a struct field. Auto-method occurrences (`@x`,
+    /// Rename a struct field. Auto-method occurrences (`@x`,
     /// `[^x]`) must switch to `@new_name` / `^new_name`, and the bare
     /// field-name (decl + MakeStruct) edits must use just `new_name`.
     #[test]
@@ -441,7 +453,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-4: rename a union variant. Pattern::Union and bare-name
+    /// Rename a union variant. Pattern::Union and bare-name
     /// occurrences both update.
     #[test]
     fn test_rename_union_variant() {
@@ -454,7 +466,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-5: rename a type alias from a use site in another file.
+    /// Rename a type alias from a use site in another file.
     #[test]
     fn test_rename_type_alias_from_other_file() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -464,7 +476,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-6: renaming a struct type renames every bare-name occurrence
+    /// Renaming a struct type renames every bare-name occurrence
     /// (declaration, MakeStruct, type sigs, impl blocks).
     #[test]
     fn test_rename_struct_type() {
@@ -479,7 +491,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-7: renaming a union type renames every bare-name occurrence.
+    /// Renaming a union type renames every bare-name occurrence.
     #[test]
     fn test_rename_union_type() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -491,7 +503,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-8: renaming a struct field to `@y` is rejected by the
+    /// Renaming a struct field to `@y` is rejected by the
     /// `type_field_name` rule (no leading `@`).
     #[test]
     fn test_rename_field_reject_at_prefix() {
@@ -505,7 +517,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-9: renaming a type alias to a lowercase name is rejected by the
+    /// Renaming a type alias to a lowercase name is rejected by the
     /// `capital_name` rule.
     #[test]
     fn test_rename_type_alias_reject_lowercase() {
@@ -519,7 +531,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-10: prepareRename returns defaultBehavior for a type alias.
+    /// `prepareRename` returns defaultBehavior for a type alias.
     #[test]
     fn test_prepare_rename_type_alias() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -535,7 +547,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-11: prepareRename returns defaultBehavior for a trait.
+    /// `prepareRename` returns defaultBehavior for a trait.
     #[test]
     fn test_prepare_rename_trait() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -551,7 +563,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RT-12: prepareRename returns defaultBehavior for a struct field.
+    /// `prepareRename` returns defaultBehavior for a struct field.
     #[test]
     fn test_prepare_rename_field() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -572,7 +584,7 @@ mod tests {
     // stale-buffer rejection.
     // =======================================================================
 
-    /// RG-1: rename rejected on `@x` (auto-generated getter).
+    /// Rename rejected on `@x` (auto-generated getter).
     #[test]
     fn test_rename_reject_at_accessor() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -591,7 +603,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-2: rename rejected on `[^x]` index syntax (the Var the parser
+    /// Rename rejected on `[^x]` index syntax (the Var the parser
     /// generates is `Point::act_x`, also auto-generated).
     #[test]
     fn test_rename_reject_index_syntax() {
@@ -606,7 +618,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-3: prepareRename returns a ResponseError with an explanatory
+    /// `prepareRename` returns a ResponseError with an explanatory
     /// message on an auto-generated accessor (so the editor can surface
     /// a useful message instead of the generic "can't be renamed").
     #[test]
@@ -626,7 +638,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-4: rename rejected on a Std symbol (defined outside the project).
+    /// Rename rejected on a Std symbol (defined outside the project).
     /// The cursor on `I64` in `type MyInt = I64;` resolves to `Std::I64`,
     /// which is not in the diagnostics result's `user_source_contents`.
     #[test]
@@ -647,7 +659,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-5: prepareRename returns a ResponseError on an external symbol.
+    /// `prepareRename` returns a ResponseError on an external symbol.
     #[test]
     fn test_prepare_rename_reject_external() {
         let mut ctx = LspTestCtx::setup("rename_types", &["lib.fix", "main.fix"]);
@@ -665,7 +677,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-6: rename rejected after the buffer drifts from the AST.
+    /// Rename rejected after the buffer drifts from the AST.
     /// We send a didChange with modified text but don't trigger a rebuild,
     /// so the recorded `user_source_contents[lib.fix]` is now out of sync.
     #[test]
@@ -699,7 +711,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RG-7: prepareRename returns a ResponseError when the buffer is
+    /// `prepareRename` returns a ResponseError when the buffer is
     /// stale, so the editor can show the actionable message ("save and
     /// wait for diagnostics").
     #[test]
@@ -754,7 +766,7 @@ mod tests {
     //  13: qualified_idx = |p| p[^Point::x].iset(0);  (col 23 = inline `Point`)
     // =======================================================================
 
-    /// RD-1: rename a struct type and observe that all bare uses, the
+    /// Rename a struct type and observe that all bare uses, the
     /// auto-namespace component in the all-auto import, and the inline
     /// qualified Var references are all rewritten.
     #[test]
@@ -793,9 +805,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-2: the user-defined namespace block in lib.fix
-    /// (`namespace Point { ... }`) must NOT be touched, because its
-    /// `Point` is a user-written namespace name, independent of the type.
+    /// The user-defined namespace block in lib.fix (`namespace Point { ... }`) is left as
+    /// it stands when the type is renamed, because its `Point` is a user-written namespace
+    /// name, independent of the type.
     #[test]
     fn test_rename_struct_type_skips_user_namespace_block() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -818,9 +830,8 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-3: the inline qualified reference `Point::@x` in main.fix has
-    /// just its `Point` sub-span rewritten to `Pixel`, leaving `::@x`.
-    /// We verify by reading the post-edit text at the reported range.
+    /// The inline qualified reference `Point::@x` in main.fix has just its `Point` sub-span
+    /// rewritten to `Pixel`, leaving `::@x` as it stands.
     #[test]
     fn test_rename_struct_type_inline_qualified_var() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -858,7 +869,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-4: the qualified index syntax `[^Point::x]` has its `Point`
+    /// The qualified index syntax `[^Point::x]` has its `Point`
     /// sub-span rewritten too — Var.source covers `^Point::x`, so the
     /// `^` is skipped during sub-span extraction.
     #[test]
@@ -896,7 +907,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-5: prepareRename returns defaultBehavior on a struct type.
+    /// `prepareRename` returns defaultBehavior on a struct type.
     #[test]
     fn test_prepare_rename_struct_type_phase_d() {
         let mut ctx = LspTestCtx::setup("rename_struct_type", &["lib.fix", "main.fix"]);
@@ -912,11 +923,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-6 regression: a qualified call to a user-defined helper
-    /// (`MinCostFlowGraph::create(...)`) sitting in the type's
-    /// namespace must NOT have its `MinCostFlowGraph::` prefix rewritten
-    /// when the type is renamed. Only auto-generated accessors travel
-    /// with the type.
+    /// A qualified call to a user-defined helper (`MinCostFlowGraph::create(...)`) sitting
+    /// in the type's namespace keeps its `MinCostFlowGraph::` prefix when the type is
+    /// renamed. Only auto-generated accessors travel with the type.
     #[test]
     fn test_rename_struct_type_skips_user_helper_qualified_call() {
         let mut ctx = LspTestCtx::setup("rename_user_helper_qualified", &["lib.fix", "main.fix"]);
@@ -957,7 +966,7 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// RD-7: a mixed import (`Lib::{Point::{act_x, user_helper}}`) is
+    /// A mixed import (`Lib::{Point::{act_x, user_helper}}`) is
     /// rebuilt as a single TextEdit covering the entire import statement.
     /// The new text must contain both `Pixel::` (for the auto-method
     /// half) and `Point::` (for the user-defined half).

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{path::Path, time::Duration};
@@ -31,7 +31,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -112,9 +112,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -105,7 +105,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }

--- a/src/tests/test_lsp/test_rename.rs
+++ b/src/tests/test_lsp/test_rename.rs
@@ -2,39 +2,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
-    use std::{
-        path::{Path, PathBuf},
-        time::Duration,
-    };
+    use std::{path::Path, time::Duration};
     use tempfile::TempDir;
-
-    // -----------------------------------------------------------------------
-    // Helpers
-    // -----------------------------------------------------------------------
-
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     struct LspTestCtx {
         client: LspClient,
-        project_dir: PathBuf,
         _temp_dir: TempDir,
     }
 
@@ -54,13 +29,12 @@ mod tests {
             client.save_and_wait_for_the_program(Path::new(trigger_file));
             Self {
                 client,
-                project_dir,
                 _temp_dir: temp_dir,
             }
         }
 
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         // Send `textDocument/rename` and return the response value (full

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -97,9 +97,7 @@ mod tests {
         // the message above sends no progress, and the wait times out.
         client.save_and_wait_for_the_program(lib_fix);
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
@@ -187,9 +185,7 @@ mod tests {
             decodable
         );
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
@@ -220,9 +216,7 @@ mod tests {
             "a uri naming no file on disk is expected to be answered with no symbols"
         );
 
-        client
-            .shutdown(Duration::from_millis(500))
-            .expect("Failed to shutdown LSP");
+        client.shutdown().expect("Failed to shutdown LSP");
         client
             .verify_no_protocol_error()
             .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_request_handling.rs
+++ b/src/tests/test_lsp/test_request_handling.rs
@@ -101,7 +101,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -191,7 +191,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 
@@ -224,7 +224,7 @@ mod tests {
             .shutdown(Duration::from_millis(500))
             .expect("Failed to shutdown LSP");
         client
-            .finish()
+            .verify_no_protocol_error()
             .expect("Reader thread should not have errors");
     }
 }

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -80,7 +80,6 @@ mod tests {
 
         /// Request semantic tokens and return the flat list of per-token type
         /// indices (the 4th element of each 5-tuple in the delta-encoded data).
-        /// Polls for the response rather than sleeping a fixed time.
         fn token_types(&mut self, file: &str) -> Vec<u64> {
             self.token_data(file)
                 .chunks_exact(5)
@@ -158,7 +157,7 @@ mod tests {
                 .expect("Failed to send didChange");
         }
 
-        /// Shut the server down cleanly and join its reader thread.
+        /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -234,8 +233,8 @@ mod tests {
     }
 
     /// Verifies that on a broken / drifted buffer the server still responds with
-    /// the base lexical layer, and does NOT emit the AST overlay (which would be
-    /// misaligned), so no variable/function tokens appear.
+    /// the base lexical layer, and withholds the AST overlay, which would be
+    /// misaligned there: the answer carries base-layer token types alone.
     #[test]
     fn test_semantic_tokens_base_layer_survives_broken_buffer() {
         let mut ctx = LspSemanticTokensCtx::setup();

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,8 +9,8 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::{poll_every, LspClient};
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::json;
     use std::{
         path::{Path, PathBuf},
@@ -32,27 +32,6 @@ mod tests {
     const T_STRUCT: u64 = 12;
     const T_ENUM: u64 = 13;
     const T_INTERFACE: u64 = 14;
-
-    /// The directory holding the LSP test-case projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test-case project into a fresh temp directory so tests can
-    /// run in parallel. Returns the temp dir (kept alive for cleanup) and the
-    /// canonical path to the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// A running language server connected to a copied test project.
     struct Ctx {
@@ -95,7 +74,7 @@ mod tests {
 
         /// The `file://` URI for a project-relative file path.
         fn file_uri(&self, file: &str) -> String {
-            format!("file://{}", self.project_dir.join(file).display())
+            self.client.file_uri(Path::new(file))
         }
 
         /// Request semantic tokens and return the flat list of per-token type

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -9,7 +9,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::{
@@ -159,9 +159,7 @@ mod tests {
 
         /// Shut the server down, and fail the test if its reader thread met a protocol error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not error");
@@ -310,7 +308,7 @@ mod tests {
     /// elaboration completed and the overlay never appears.
     #[test]
     fn test_semantic_tokens_refresh_sent_after_diagnostics() {
-        let mut ctx = LspSemanticTokensCtx::setup();
+        let ctx = LspSemanticTokensCtx::setup();
 
         let mut saw_refresh = false;
         while let Some(msg) = ctx.client.pop_message() {

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -34,7 +34,7 @@ mod tests {
     const T_INTERFACE: u64 = 14;
 
     /// A running language server connected to a copied test project.
-    struct Ctx {
+    struct LspSemanticTokensCtx {
         /// The client driving the `fix language-server` subprocess.
         client: LspClient,
         /// The copied project's root directory.
@@ -50,7 +50,7 @@ mod tests {
     /// of that wait asks the server for the tokens again, so the gap is sized for a round trip.
     const OVERLAY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-    impl Ctx {
+    impl LspSemanticTokensCtx {
         /// Start a server on a fresh copy of the `semantic_tokens` project, open
         /// `main.fix`, and wait for an initial elaboration.
         fn setup() -> Self {
@@ -163,7 +163,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not error");
         }
     }
@@ -174,8 +174,8 @@ mod tests {
     /// colors the namespace and the type separately, so an overlay token spanning the path lands on
     /// top of the base layer's.
     #[test]
-    fn semantic_tokens_do_not_overlap() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_do_not_overlap() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         // Wait for the overlay, which is the layer that can produce a token spanning a whole path.
         ctx.token_types_with_overlay("main.fix");
         let positions = ctx.token_positions("main.fix");
@@ -201,8 +201,8 @@ mod tests {
     /// union variants and field accessors — while the base layer keeps coloring
     /// comments, strings, keywords and built-in types.
     #[test]
-    fn semantic_tokens_overlay_precise_classification() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_overlay_precise_classification() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         let types = ctx.token_types_with_overlay("main.fix");
 
         let want = [
@@ -236,8 +236,8 @@ mod tests {
     /// the base lexical layer, and does NOT emit the AST overlay (which would be
     /// misaligned), so no variable/function tokens appear.
     #[test]
-    fn semantic_tokens_base_layer_survives_broken_buffer() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_base_layer_survives_broken_buffer() {
+        let mut ctx = LspSemanticTokensCtx::setup();
 
         // Drift the buffer away from the elaborated snapshot, with broken
         // syntax (unbalanced paren, unterminated string).
@@ -272,8 +272,8 @@ mod tests {
     /// from the elaborated snapshot, even though the buffer no longer matches it
     /// exactly.
     #[test]
-    fn semantic_tokens_overlay_survives_single_line_edit() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_overlay_survives_single_line_edit() {
+        let mut ctx = LspSemanticTokensCtx::setup();
         // Apply the overlay first.
         let _ = ctx.token_types_with_overlay("main.fix");
 
@@ -310,8 +310,8 @@ mod tests {
     /// otherwise the client keeps the base-layer-only result it fetched before
     /// elaboration completed and the overlay never appears.
     #[test]
-    fn semantic_tokens_refresh_sent_after_diagnostics() {
-        let mut ctx = Ctx::setup();
+    fn test_semantic_tokens_refresh_sent_after_diagnostics() {
+        let mut ctx = LspSemanticTokensCtx::setup();
 
         let mut saw_refresh = false;
         while let Some(msg) = ctx.client.pop_message() {

--- a/src/tests/test_lsp/test_semantic_tokens.rs
+++ b/src/tests/test_lsp/test_semantic_tokens.rs
@@ -13,6 +13,7 @@ mod tests {
     use super::super::lsp_client::{poll_every, LspClient};
     use serde_json::json;
     use std::{
+        fs,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -279,8 +280,7 @@ mod tests {
 
         // Edit a single body line; the type/trait/struct definitions on other
         // lines are untouched.
-        let original =
-            std::fs::read_to_string(ctx.project_dir.join("main.fix")).expect("read main.fix");
+        let original = fs::read_to_string(ctx.project_dir.join("main.fix")).expect("read main.fix");
         let edited = original.replace("let n = p.size;", "let n = p.size; // tweak");
         assert_ne!(original, edited, "the edit should change the buffer");
         ctx.change_text("main.fix", &edited);

--- a/src/tests/test_lsp/test_stdin_eof.rs
+++ b/src/tests/test_lsp/test_stdin_eof.rs
@@ -7,27 +7,9 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::test_util::{copy_dir_recursive, fix_command, wait_within};
-    use std::{path::PathBuf, process::Stdio, thread::sleep, time::Duration};
-    use tempfile::TempDir;
-
-    /// Absolute path to the LSP `cases/` directory.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copy the named test project into a fresh temp directory and
-    /// return both the temp dir handle (to keep it alive) and the path
-    /// of the copied project.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        (temp_dir, test_case_dst)
-    }
+    use super::super::case_project::setup_test_env;
+    use crate::tests::test_util::{fix_command, wait_within};
+    use std::{process::Stdio, thread::sleep, time::Duration};
 
     /// Verifies that the language server terminates promptly once its
     /// stdin reaches EOF (parent editor closed the pipe).

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -7,7 +7,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion_harness::setup_test_env;
+    use super::super::case_project::setup_test_env;
     use super::super::lsp_client::LspClient;
     use serde_json::{json, Value};
     use std::{
@@ -41,7 +41,7 @@ mod tests {
             for f in files {
                 client
                     .open_document(Path::new(f))
-                    .expect(&format!("Failed to open {}", f));
+                    .unwrap_or_else(|_| panic!("Failed to open {}", f));
             }
             let trigger_file = files.last().unwrap();
             client.save_and_wait_for_the_program(Path::new(trigger_file));
@@ -74,9 +74,7 @@ mod tests {
         /// Shuts the server down, and fails the test if its reader thread met a protocol
         /// error.
         fn shutdown(mut self) {
-            self.client
-                .shutdown(Duration::from_millis(500))
-                .expect("Failed to shutdown LSP");
+            self.client.shutdown().expect("Failed to shutdown LSP");
             self.client
                 .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -19,8 +19,12 @@ mod tests {
     /// Test fixture that owns an initialized `LspClient` together with
     /// the temporary project directory it operates on.
     struct LspWorkspaceSymbolCtx {
+        /// The connection to the running server.
         client: LspClient,
+        /// The copy of the fixture project the server was started on.
         _project_dir: PathBuf,
+        /// Holds the temporary directory containing `_project_dir` alive; dropping it
+        /// deletes the copy.
         _temp_dir: TempDir,
     }
 
@@ -67,7 +71,8 @@ mod tests {
             result.as_array().cloned().unwrap_or_default()
         }
 
-        /// Performs a clean LSP shutdown and joins the reader thread.
+        /// Shuts the server down, and fails the test if its reader thread met a protocol
+        /// error.
         fn shutdown(mut self) {
             self.client
                 .shutdown(Duration::from_millis(500))
@@ -188,8 +193,9 @@ mod tests {
         ctx.shutdown();
     }
 
-    /// Each returned symbol's `location.uri` should point into the
-    /// project directory (not into std lib or dependency caches).
+    /// Each returned symbol's `location.uri` points into the project
+    /// directory, which leaves out the std library and the dependency
+    /// caches.
     #[test]
     fn test_workspace_symbol_locations_are_in_project() {
         let mut ctx = LspWorkspaceSymbolCtx::setup("completion", &["lib.fix", "main.fix"]);

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -7,34 +7,14 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::completion_harness::setup_test_env;
     use super::super::lsp_client::LspClient;
-    use crate::tests::test_util::copy_dir_recursive;
     use serde_json::{json, Value};
     use std::{
         path::{Path, PathBuf},
         time::Duration,
     };
     use tempfile::TempDir;
-
-    /// Absolute path to the directory containing LSP test fixture projects.
-    fn get_test_cases_dir() -> PathBuf {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/tests/test_lsp/cases");
-        path
-    }
-
-    /// Copies the named fixture project into a fresh temporary directory
-    /// and returns the temp dir handle plus the canonicalized project path.
-    fn setup_test_env(project_name: &str) -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let test_case_src = get_test_cases_dir().join(project_name);
-        let test_case_dst = temp_dir.path().join(project_name);
-        copy_dir_recursive(&test_case_src, &test_case_dst).expect("Failed to copy test case");
-        let test_case_dst = test_case_dst
-            .canonicalize()
-            .expect("Failed to canonicalize test case path");
-        (temp_dir, test_case_dst)
-    }
 
     /// Test fixture that owns an initialized `LspClient` together with
     /// the temporary project directory it operates on.

--- a/src/tests/test_lsp/test_workspace_symbol.rs
+++ b/src/tests/test_lsp/test_workspace_symbol.rs
@@ -73,7 +73,7 @@ mod tests {
                 .shutdown(Duration::from_millis(500))
                 .expect("Failed to shutdown LSP");
             self.client
-                .finish()
+                .verify_no_protocol_error()
                 .expect("Reader thread should not have errors");
         }
     }


### PR DESCRIPTION
Refs #614 の隣の清掃。#614 が触った `src/tests/test_lsp/` の、hunk の外にあった分である。コードレビューが挙げた findings のうち、スイートが是非を判定できるものもここに入っている。base は #614 のブランチなので、これ自身は issue を閉じない。

全体 (1869 本) は緑。`cargo test --release tests::test_lsp` は 185 本 11.4 秒で、#614 のブランチと同じである。

## 1. 重複を 1 か所に寄せた (DRY)

**テストプロジェクトの写し**が 4 か所にあった。[`case_project`](https://github.com/tttmmmyyyy/fixlang/blob/f32eb35a48752f6ccb60569a747c3e8cb01ad97b/src/tests/test_lsp/case_project.rs) が唯一の場所になり、`mod.rs` / `test_diagnostics.rs` / `test_stdin_eof.rs` の私的な版は消えた。

この統合は**振る舞いを変える**。消えた 3 つは copy 先を `canonicalize` せず、残った 1 つはする。一時ディレクトリは macOS で `/var` -> `/private/var` のリンクを通るので、正規化しないパスから作った URI はサーバが publish する URI と食い違う。つまり 3 つの版は、この食い違いを踏みうる形だった。

置き場も変えた。唯一 canonicalize する版は `completion_harness` にあり、補完と関係の無い 8 ファイルがそこから import していた。

**`file://` の URI の組み立て**が 12 か所にあった。#614 が入れた `LspClient::file_uri` に全部寄せ、各テストファイルの `Ctx::file_uri` はその委譲になった。3 つのファイルではそれで `project_dir` フィールドを読む者がいなくなったので、フィールドごと消した。

**メッセージの送出**が `send_request` と `send_notification` に写しで入っていた (JSON 化 -> `Content-Length` ヘッダ -> 書き込み -> flush)。[`send_message`](https://github.com/tttmmmyyyy/fixlang/blob/f32eb35a48752f6ccb60569a747c3e8cb01ad97b/src/tests/test_lsp/lsp_client.rs) に切り出した。

**`bench_completion.rs` の `get_test_cases_dir` / `setup_test_env`** は共有版の逐語の写しだったので消した。

## 2. 語を揃えた (naming)

- `get_response` -> `take_response` — `remove` でエントリを取り除くのに、読むだけに見えていた。`take_warnings` / `take_new_tycons` が先例。
- `finish` -> `verify_no_protocol_error` — 何も終わらせない。返すのは reader thread が出会ったプロトコルエラーの有無である。
- `verify_no_diagnostic_errors` -> `verify_no_diagnostics` — 述語は「どの重大度の診断も無い」で、`errors` は述語より狭かった。
- `count_progress_end_messages` -> `ended_pass_count`、`wait_for_progress_end_count` -> `wait_for_ended_passes` — #614 が入れた語 (`PASS_TIMEOUT`、`wait_for_one_more_pass`) と、サーバ側の語 (`run_diagnostics_pass`) が「pass」と呼ぶ事象を、client だけ別の語で呼んでいた。`$/progress` の end は `run_diagnostics_pass` の末尾 1 か所からしか出ないので、1 通知 = 1 パスが成り立つ。
- `struct Ctx` -> `LspSemanticTokensCtx`、`test_semantic_tokens.rs` のテスト 5 本に `test_` 接頭辞 — 兄弟ファイルの形に合わせた。
- `bench_one` -> `bench_position` — 1 回に見えるが、実際は 1 つの位置で `WARMUP + ITERS + 1` 回まわす。

## 3. スイートが判定できた findings

**時間の名前**: `shutdown(Duration::from_millis(500))` が 17 か所にリテラルで書かれていた。`LspClient::EXIT_TIMEOUT` を置き、`shutdown` は引数を取らなくなった。`RESPONSE_TIMEOUT` と `PASS_TIMEOUT` も impl の先頭に移して、時間の定数が 1 か所で読める。

**借用**: `pop_message` / `take_response` / `wait_for_response` / `expect_response` が `&mut self` を取っていた。実体は `Arc<Mutex<_>>` のロックなので `&self` で足りる。呼び出し側の借用の制約が緩む。

**panic のメッセージ**: `expect(&format!(...))` が 9 か所にあり、成功する経路でも毎回 `String` を確保していた。`unwrap_or_else(|_| panic!(...))` にした。

**サーバ側の注記**: `src/commands/lsp/server.rs` のメインループは、パスの結果をループ先頭の `try_recv` で取り込む。これは `stdin` のブロック読みの手前なので、パスが終わった時点ではまだ取り込まれておらず、メッセージが 1 通届いて初めて取り込まれる。#614 の `save_and_wait_for_the_program` はその配置に合わせて書かれている。順序を変えると harness は静かに早く返り、テストは落ちるのでなく flaky になるので、ループの側にも 1 行置いた。**この変更で実行時の振る舞いは変わらない** (コメントだけ)。

## 4. コメントと doc

`comment-style` の規約に沿って、11 ファイルの doc を直した。主なものは次のとおり。

- 名前を言い直すだけの doc (`send_request` の "Send LSP request" など) を、何をするものかに書き換えた。
- `# Arguments` が名前の言い換えだけだったもの (`initialize` / `shutdown`) を、引数の意味を述べる散文にした。
- 経緯の記述を消した。`bench_completion.rs` の「The user considers this initial cost acceptable」、`test_completion.rs` の「the pre-refactor fallback shape ... After the refactor」、`test_semantic_tokens.rs` の「Polls for the response rather than sleeping a fixed time」。
- 事実と違う記述を直した。`shutdown` の doc 3 か所が「reader thread を join する」と述べていたが、join しない (`Drop` がプロセスを kill し、スレッドは stdout が閉じたところで終わる)。
- 存在しないファイルへの参照を消した。`test_references.rs` の冒頭が `agents/test-refs.20260301/test_plan.md` を指していた。
- 計画の段階名を消した。`test_rename.rs` のテスト doc 36 本が `RB-n` / `RT-n` / `RG-n` / `RD-n` を持っていたが、関数名はそれを持っていない。
- 否定形を肯定形にした。

## 5. import

`std::fs::read_to_string` / `std::env::var` / `std::path::PathBuf::from` の 6 か所を、モジュールを import した短い形にした。`test_references.rs` の `std::collections::HashSet` は、`crate::misc` の `Set` を使う規約に反していたので直した。

## 残した findings

この清掃に入れていないもの。

- **`Ctx` 構造体 7 個がほぼ写し**である (`LspCompletionCtx` / `LspQuickFixCtx` / `LspSemanticTokensCtx` / `LspWorkspaceSymbolCtx` と、4 ファイルが同じ名前で持つ `LspTestCtx`)。`setup` と `shutdown` は全て同一。1 つに畳むのは呼び出し側の作り直しになる。
- **reader thread の黙った取りこぼし**。`publishDiagnostics` の `params` / `uri` / `diagnostics` が欠けたとき、応答の `id` が整数でないとき、どれも黙って捨てる。プロトコル違反なので fail loud にする価値はあるが、reader thread で panic するとテストは timeout 経由の分かりにくい失敗になる。
- **`poll` と、「時間切れなら最後の値を返す」形の 2 つの待ち**をもう 1 段共通化する案。2 か所のために 4 引数の高階 generic を足すことになるので、設計判断として置いた。
- **`LspTestCtx` が 4 ファイルで別々に定義されている**件。各ファイル内では 1 つしか無いので誤解は生まないが、他の 4 ファイルは機能名を付けている。
