### PR TITLE
レビュー清掃 (#621): 宣言を実体と突き合わせ、述語を問いとして読ませる

### DIFF
--- a/src/ast/inline_llvm.rs
+++ b/src/ast/inline_llvm.rs
@@ -250,18 +250,23 @@ pub fn clone_path_rc_targets(check: Option<UniqueCheckOperand>) -> Vec<RcTarget>
     }
 }
 
+/// An inline-LLVM builtin operation as it stands in an expression: the operation to emit, and the
+/// type the expression was declared at.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVM {
+    /// The operation this expression emits.
     pub generator: Box<dyn LLVMGen>,
-    // The type of this LLVM expression.
-    //
-    // For example, in `@ : I64 -> Array a -> a = |i, arr| LLVM<Array::@(i, arr)>;`, the `generic_ty` of the InlineLLVM `LLVM<arr.Array::@(i, arr)>` is `a`.
-    // Note that `generic_ty` may contain type variables, and it is not changed in type instantiation.
+    /// The type of this LLVM expression.
+    ///
+    /// For example, in `@ : I64 -> Array a -> a = |i, arr| LLVM<Array::@(i, arr)>;`, the
+    /// `generic_ty` of the InlineLLVM `LLVM<arr.Array::@(i, arr)>` is `a`.
+    ///
+    /// `generic_ty` may contain type variables, and type instantiation leaves it as it is.
     pub generic_ty: Arc<TypeNode>,
 }
 
 impl InlineLLVM {
-    // Convert all global FullNames to absolute paths.
+    /// This expression with every global `FullName` in its type made absolute.
     pub fn global_to_absolute(&self) -> Arc<InlineLLVM> {
         Arc::new(InlineLLVM {
             generator: self.generator.clone(),

--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -920,6 +920,8 @@ impl LLVMGen for InlineLLVMIntLit {
         vec![]
     }
 
+    /// An integer literal evaluates to a value held in a register, so a copy of it where the value
+    /// is named costs what naming it costs.
     fn is_free_to_duplicate(&self) -> bool {
         true
     }
@@ -974,6 +976,8 @@ impl LLVMGen for InlineLLVMFloatLit {
         vec![]
     }
 
+    /// A floating-point literal evaluates to a value held in a register, so a copy of it where the
+    /// value is named costs what naming it costs.
     fn is_free_to_duplicate(&self) -> bool {
         true
     }
@@ -1016,6 +1020,8 @@ impl LLVMGen for InlineLLVMNullPtrLit {
         vec![]
     }
 
+    /// A null pointer evaluates to a value held in a register, so a copy of it where the value is
+    /// named costs what naming it costs.
     fn is_free_to_duplicate(&self) -> bool {
         true
     }

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -86,7 +86,7 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
             continue;
         }
 
-        // If the new symbol has no free variables, it cannot be inlined furthermore.
+        // If the new symbol has no free variables, it cannot be inlined further.
         if sym.expr.as_ref().unwrap().free_vars().is_empty() {
             stable_symbols.insert(name.clone());
             new_symbols.insert(name.clone(), sym);
@@ -102,11 +102,11 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
             sym.expr = Some(res.expr);
             application_inlining::run_on_symbol(&mut sym);
         } else {
-            // If inlining was not done, it cannot be inlined furthermore.
+            // If inlining was not done, it cannot be inlined further.
             stable_symbols.insert(name.clone());
         }
 
-        // If the new symbol has no free variables, it cannot be inlined furthermore.
+        // If the new symbol has no free variables, it cannot be inlined further.
         if sym.expr.as_ref().unwrap().free_vars().is_empty() {
             stable_symbols.insert(name.clone());
         }
@@ -119,6 +119,8 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
     changed
 }
 
+/// Measure every symbol of the program: how large its expression is, how many times the program
+/// names it, and the shapes of that expression which decide where it may be inlined.
 fn calculate_inline_costs(prg: &Program) -> InlineCosts {
     let mut costs = InlineCosts::new();
     for (name, sym) in &prg.symbols {
@@ -157,30 +159,28 @@ fn calculate_inline_costs(prg: &Program) -> InlineCosts {
 /// What one symbol costs to inline, and the shapes of its expression that decide where it may
 /// be inlined at all.
 struct InlineCost {
-    // The number of times the program names the symbol.
+    /// The number of times the program names the symbol.
     use_count: usize,
-    // The complexity of the expression.
+    /// The size of the symbol's expression: one for each node that generates code. A local
+    /// variable, a type annotation, an `eval`, and a `let` or a `match` that only renames a local
+    /// count nothing.
     complexity: usize,
-    // Does the symbol's expression name the symbol itself?
+    /// Does the symbol's expression name the symbol itself?
     is_self_recursive: bool,
-    // Is the top-level construct a lambda expression?
+    /// Is the top-level construct a lambda expression?
     is_lambda: bool,
-    // Is the expression of the form `|x, y, ...| {llvm}`?
+    /// Is the expression of the form `|x, y, ...| {llvm}`?
     is_llvm_lam: bool,
     /// Does a copy of the expression cost no more than the expression itself?
     is_free_to_duplicate: bool,
-    // Is this expression an alias to another value?
-    //
-    // Example:
-    // ```
-    // x = y;
-    // ```
+    /// Is this expression an alias to another value, as in `x = y;`?
     is_alias: bool,
-    // Is the expression instantiated by Std::fix?
+    /// Is the expression instantiated by `Std::fix`?
     is_std_fix: bool,
 }
 
 impl InlineCost {
+    /// A cost with nothing counted and every flag false, for the walks to fill in.
     fn new() -> Self {
         InlineCost {
             use_count: 0,
@@ -252,6 +252,7 @@ struct InlineCosts {
 }
 
 impl InlineCosts {
+    /// A table holding no cost yet.
     fn new() -> Self {
         InlineCosts {
             costs: Map::default(),
@@ -308,20 +309,26 @@ impl InlineCosts {
     }
 }
 
+/// Walks the expression of one symbol and measures it: how large it is, which global names it
+/// uses and how often, whether it names the symbol itself, and whether its top-level construct is
+/// a lambda.
 struct InlineCostCalculator {
-    // The name of the symbol.
+    /// The name of the symbol whose expression is walked.
     name: FullName,
-    // For each global name, how many times the symbol names it.
+    /// For each global name, how many times the symbol names it.
     use_count: Map<FullName, usize>,
-    // The cost of the symbol.
+    /// The size of the part of the expression walked so far: one for each node that generates
+    /// code.
     complexity: usize,
-    // Does the symbol name itself?
+    /// Does the symbol name itself?
     is_self_recursive: bool,
-    // Is the top-level construct a lambda expression?
+    /// Is the construct visited last a lambda expression? The walk ends at the top-level
+    /// construct, so this answers for that one.
     is_lambda: bool,
 }
 
 impl InlineCostCalculator {
+    /// A calculator that has measured nothing, for the symbol named `name`.
     fn new(name: FullName) -> Self {
         InlineCostCalculator {
             name,
@@ -332,6 +339,8 @@ impl InlineCostCalculator {
         }
     }
 
+    /// Record one use of the global name `used_name` by the symbol being walked, and note a
+    /// symbol that names itself.
     fn on_find_usage_of_global_name(&mut self, used_name: &FullName) {
         // Count one use of the global symbol.
         assert!(used_name.is_global());
@@ -420,7 +429,7 @@ impl ExprVisitor for InlineCostCalculator {
     }
 
     fn end_visit_let(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
-        // If the let binding is of the form `let {local_var0} = {local_var1} in (...)`, does not increase the complexity.
+        // A `let` of the form `let {local_var0} = {local_var1} in (...)` counts nothing.
         self.complexity += 1;
         let pat = expr.get_let_pat();
         if pat.is_var() && pat.get_var().name.is_local() {
@@ -455,7 +464,7 @@ impl ExprVisitor for InlineCostCalculator {
     fn end_visit_match(&mut self, expr: &Arc<ExprNode>, _state: &mut VisitState) -> EndVisitResult {
         self.is_lambda = false;
 
-        // If the match is of the form `match {local_var0} { {local_var1} -> (...) }`, does not increase the complexity.
+        // A `match` of the form `match {local_var0} { {local_var1} -> (...) }` counts nothing.
         self.complexity += 1;
         let match_cond = expr.get_match_cond();
         if match_cond.is_var() && match_cond.get_var().name.is_local() {
@@ -486,7 +495,7 @@ impl ExprVisitor for InlineCostCalculator {
     ) -> EndVisitResult {
         self.is_lambda = false;
 
-        // Does not increase the complexity.
+        // A type annotation counts nothing.
         EndVisitResult::unchanged(expr)
     }
 
@@ -558,10 +567,12 @@ impl ExprVisitor for InlineCostCalculator {
     }
 }
 
+/// Walks an expression and puts the body of a global at each place the expression names it, where
+/// the cost of that global allows.
 struct Inliner<'c> {
-    // The cost of inlining.
+    /// What each global of the program costs to inline, and where it may be inlined.
     costs: &'c InlineCosts,
-    // All symbols.
+    /// The symbols of the program, holding the bodies to put at the names.
     symbols: Map<FullName, Symbol>,
 }
 

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -123,6 +123,7 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
 /// names it, and the shapes of that expression which decide where it may be inlined.
 fn calculate_inline_costs(prg: &Program) -> InlineCosts {
     let mut costs = InlineCosts::new();
+    let type_env = prg.type_env();
     for (name, sym) in &prg.symbols {
         let expr = sym.expr.as_ref().unwrap();
 
@@ -141,7 +142,19 @@ fn calculate_inline_costs(prg: &Program) -> InlineCosts {
         // If a copy of the expression costs no more than the expression, set as
         // `is_free_to_duplicate`.
         if expr.is_llvm() {
-            cost.is_free_to_duplicate = expr.get_llvm().generator.is_free_to_duplicate();
+            let generator = &expr.get_llvm().generator;
+            let is_free_to_duplicate = generator.is_free_to_duplicate();
+            // An operation whose result holds a boxed part allocates that part, so a copy of it
+            // allocates once more. The declaration and the operation agree only where the type of
+            // what it answers with is unboxed throughout.
+            assert!(
+                !is_free_to_duplicate || sym.ty.is_fully_unboxed(&type_env),
+                "the inline-LLVM operation `{}` declares a copy of itself free while it answers \
+                 with `{}`, which holds a boxed part",
+                generator.name(),
+                sym.ty.to_string()
+            );
+            cost.is_free_to_duplicate = is_free_to_duplicate;
         }
 
         // If the expression is instantiated by `Std::fix`, set as `is_std_fix`.
@@ -200,7 +213,7 @@ impl InlineCost {
     /// What qualifies is what costs nothing to hold in several places: an operation a copy of
     /// which costs no more than itself, a lambda whose body is one inline-LLVM operation, and a
     /// name that stands for another name.
-    fn inline_at_non_call_site(&self) -> bool {
+    fn may_be_inlined_at_non_call_site(&self) -> bool {
         if self.is_std_fix {
             return false;
         }
@@ -214,7 +227,7 @@ impl InlineCost {
         if self.is_llvm_lam {
             return true;
         }
-        if !self.is_self_recursive && self.is_alias {
+        if self.is_alias {
             return true;
         }
         return false;
@@ -228,7 +241,7 @@ impl InlineCost {
     /// A body that calls itself is left alone, since substituting it leaves the call it makes to
     /// itself; so is `Std::fix`, whose defunctionalization matches the shape it is written in. What
     /// is left is judged by size, against `INLINE_COST_THRESHOLD`.
-    fn inline_at_call_site(&self) -> bool {
+    fn may_be_inlined_at_call_site(&self) -> bool {
         if self.is_std_fix {
             return false;
         }
@@ -264,7 +277,7 @@ impl InlineCosts {
     fn get(&self, name: &FullName) -> &InlineCost {
         self.costs
             .get(name)
-            .unwrap_or_else(|| Self::no_cost_recorded(name))
+            .unwrap_or_else(|| Self::panic_no_cost_recorded(name))
     }
 
     /// The cost recorded for the symbol named `name`, to write to. Every name the program defines
@@ -272,11 +285,11 @@ impl InlineCosts {
     fn get_mut(&mut self, name: &FullName) -> &mut InlineCost {
         self.costs
             .get_mut(name)
-            .unwrap_or_else(|| Self::no_cost_recorded(name))
+            .unwrap_or_else(|| Self::panic_no_cost_recorded(name))
     }
 
     /// Fail, naming the symbol whose cost was asked for and not found.
-    fn no_cost_recorded(name: &FullName) -> ! {
+    fn panic_no_cost_recorded(name: &FullName) -> ! {
         panic!("no inline cost is recorded for `{}`", name.to_string())
     }
 
@@ -592,7 +605,7 @@ impl<'c> ExprVisitor for Inliner<'c> {
             return EndVisitResult::unchanged(expr);
         }
 
-        if !self.costs.get(var_name).inline_at_non_call_site() {
+        if !self.costs.get(var_name).may_be_inlined_at_non_call_site() {
             return EndVisitResult::unchanged(expr);
         }
 
@@ -631,7 +644,7 @@ impl<'c> ExprVisitor for Inliner<'c> {
         if func_name.is_local() {
             return EndVisitResult::unchanged(expr);
         }
-        if !self.costs.get(func_name).inline_at_call_site() {
+        if !self.costs.get(func_name).may_be_inlined_at_call_site() {
             return EndVisitResult::unchanged(expr);
         }
         let func_expr = self.symbols.get(func_name).unwrap().expr.as_ref().unwrap();

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -45,9 +45,9 @@ const MAX_ROUNDS: usize = 10;
 /// name occurs; a lambda small enough (`INLINE_COST_THRESHOLD`) and one wrapping an inline-LLVM
 /// operation go into the calls of it. A body that calls itself stays where it is.
 pub fn run(prg: &mut Program) {
-    let mut skip_symbols = Set::default();
+    let mut stable_symbols = Set::default();
     for _ in 0..MAX_ROUNDS {
-        if !run_one(prg, &mut skip_symbols) {
+        if !run_one(prg, &mut stable_symbols) {
             break;
         }
     }
@@ -73,8 +73,9 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
     let root_value_names = prg.root_value_names();
 
     for (name, mut sym) in symbols {
-        // If call count of the symbol is 0, and it is neither of entry point nor exported value, discard it.
-        if costs.get_call_count(&name) == 0 && !root_value_names.contains(&name) {
+        // If nothing in the program names the symbol, and it is neither the entry point nor an
+        // exported value, discard it.
+        if costs.get_use_count(&name) == 0 && !root_value_names.contains(&name) {
             changed = true;
             continue;
         }
@@ -156,11 +157,11 @@ fn calculate_inline_costs(prg: &Program) -> InlineCosts {
 /// What one symbol costs to inline, and the shapes of its expression that decide where it may
 /// be inlined at all.
 struct InlineCost {
-    // The number of times the symbol is called.
-    call_count: usize,
+    // The number of times the program names the symbol.
+    use_count: usize,
     // The complexity of the expression.
     complexity: usize,
-    // Is the function calling itself?
+    // Does the symbol's expression name the symbol itself?
     is_self_recursive: bool,
     // Is the top-level construct a lambda expression?
     is_lambda: bool,
@@ -182,7 +183,7 @@ struct InlineCost {
 impl InlineCost {
     fn new() -> Self {
         InlineCost {
-            call_count: 0,
+            use_count: 0,
             complexity: 0,
             is_self_recursive: false,
             is_lambda: false,
@@ -286,36 +287,36 @@ impl InlineCosts {
     }
 
     /// How many times the program names the symbol, counted over every expression the walk covered.
-    fn get_call_count(&self, name: &FullName) -> usize {
-        self.get(name).call_count
+    fn get_use_count(&self, name: &FullName) -> usize {
+        self.get(name).use_count
     }
 
-    /// Take in what the walk of one symbol found: every global name that symbol uses has its call
+    /// Take in what the walk of one symbol found: every global name that symbol uses has its use
     /// count raised, and the symbol itself gets the size, the self-reference and the lambda shape the
     /// walk measured.
-    fn add_cost_calculation_result(&mut self, cost: InlineCostCalculator) {
-        // For each global symbol called from the symbol where `InlineCostCalculator` has been executed, add the call count.
-        for (sym, count) in cost.call_count {
-            self.get_or_insert(sym).call_count += count;
+    fn add_cost_calculation_result(&mut self, calculator: InlineCostCalculator) {
+        // Raise the use count of each global name the walked symbol uses.
+        for (sym, count) in calculator.use_count {
+            self.get_or_insert(sym).use_count += count;
         }
 
         // Set other fields for the symbol itself that `InlineCostCalculator` has traversed.
-        let inline_cost = self.get_or_insert(cost.name);
-        inline_cost.complexity = cost.complexity;
-        inline_cost.is_self_recursive = cost.is_refer_self;
-        inline_cost.is_lambda = cost.is_lambda;
+        let inline_cost = self.get_or_insert(calculator.name);
+        inline_cost.complexity = calculator.complexity;
+        inline_cost.is_self_recursive = calculator.is_self_recursive;
+        inline_cost.is_lambda = calculator.is_lambda;
     }
 }
 
 struct InlineCostCalculator {
     // The name of the symbol.
     name: FullName,
-    // For each global symbol, the count of calls.
-    call_count: Map<FullName, usize>,
+    // For each global name, how many times the symbol names it.
+    use_count: Map<FullName, usize>,
     // The cost of the symbol.
     complexity: usize,
-    // Is the symbol referring itself?
-    is_refer_self: bool,
+    // Does the symbol name itself?
+    is_self_recursive: bool,
     // Is the top-level construct a lambda expression?
     is_lambda: bool,
 }
@@ -324,21 +325,21 @@ impl InlineCostCalculator {
     fn new(name: FullName) -> Self {
         InlineCostCalculator {
             name,
-            call_count: Map::default(),
+            use_count: Map::default(),
             complexity: 0,
-            is_refer_self: false,
+            is_self_recursive: false,
             is_lambda: false,
         }
     }
 
     fn on_find_usage_of_global_name(&mut self, used_name: &FullName) {
-        // If calling a global symbol, increase the call count.
+        // Count one use of the global symbol.
         assert!(used_name.is_global());
-        *self.call_count.entry(used_name.clone()).or_insert(0) += 1;
+        *self.use_count.entry(used_name.clone()).or_insert(0) += 1;
 
-        // If it calls itself, set `is_call_self`.
+        // If the symbol names itself, set `is_self_recursive`.
         if used_name == &self.name {
-            self.is_refer_self = true;
+            self.is_self_recursive = true;
         }
     }
 }

--- a/src/optimization/inline.rs
+++ b/src/optimization/inline.rs
@@ -121,33 +121,33 @@ fn run_one(prg: &mut Program, stable_symbols: &mut Set<FullName>) -> bool {
 fn calculate_inline_costs(prg: &Program) -> InlineCosts {
     let mut costs = InlineCosts::new();
     for (name, sym) in &prg.symbols {
+        let expr = sym.expr.as_ref().unwrap();
+
         let mut cost_calculator = InlineCostCalculator::new(name.clone());
-        cost_calculator.traverse(&sym.expr.as_ref().unwrap());
+        cost_calculator.traverse(expr);
         costs.add_cost_calculation_result(cost_calculator);
 
-        let expr = sym.expr.as_ref().unwrap();
+        let cost = costs.get_mut(name);
+
         // If the expression is of the form `|x, y, ...| {llvm}`, then set as `is_llvm_lam`. An
         // expression that takes no parameter is the operation itself, and a copy of it costs what
         // the operation costs, which `is_free_to_duplicate` answers.
         let (params, body) = expr.destructure_lam_sequence();
-        let is_llvm_lam = !params.is_empty() && body.is_llvm();
-        costs.costs.get_mut(name).unwrap().is_llvm_lam = is_llvm_lam;
+        cost.is_llvm_lam = !params.is_empty() && body.is_llvm();
 
         // If a copy of the expression costs no more than the expression, set as
         // `is_free_to_duplicate`.
         if expr.is_llvm() {
-            let is_free_to_duplicate = expr.get_llvm().generator.is_free_to_duplicate();
-            costs.costs.get_mut(name).unwrap().is_free_to_duplicate = is_free_to_duplicate;
+            cost.is_free_to_duplicate = expr.get_llvm().generator.is_free_to_duplicate();
         }
 
         // If the expression is instantiated by `Std::fix`, set as `is_std_fix`.
-        costs.costs.get_mut(name).unwrap().is_std_fix = is_std_fix(name);
+        cost.is_std_fix = is_std_fix(name);
 
         // If the expression is an alias to another global value, set as `is_alias`.
         if expr.is_var() {
-            let var_name = &expr.get_var().name;
-            assert!(var_name.is_global());
-            costs.costs.get_mut(name).unwrap().is_alias = true;
+            assert!(expr.get_var().name.is_global());
+            cost.is_alias = true;
         }
     }
     costs
@@ -257,20 +257,32 @@ impl InlineCosts {
         }
     }
 
-    /// Give `name` an entry of its own if it has none yet, with nothing counted and every flag
-    /// false, for the walks to fill in as they meet the name.
-    fn insert_cost_if_absent(&mut self, name: &FullName) {
-        if !self.costs.contains_key(name) {
-            self.costs.insert(name.clone(), InlineCost::new());
-        }
-    }
-
     /// The cost recorded for the symbol named `name`. `calculate_inline_costs` records one for
     /// every symbol of the program it walks, so every name of that program has one.
     fn get(&self, name: &FullName) -> &InlineCost {
         self.costs
             .get(name)
-            .unwrap_or_else(|| panic!("no inline cost is recorded for `{}`", name.to_string()))
+            .unwrap_or_else(|| Self::no_cost_recorded(name))
+    }
+
+    /// The cost recorded for the symbol named `name`, to write to. Every name the program defines
+    /// has one, as `get` says.
+    fn get_mut(&mut self, name: &FullName) -> &mut InlineCost {
+        self.costs
+            .get_mut(name)
+            .unwrap_or_else(|| Self::no_cost_recorded(name))
+    }
+
+    /// Fail, naming the symbol whose cost was asked for and not found.
+    fn no_cost_recorded(name: &FullName) -> ! {
+        panic!("no inline cost is recorded for `{}`", name.to_string())
+    }
+
+    /// The cost recorded for the symbol named `name`, given an entry of its own with nothing
+    /// counted and every flag false if it has none yet, for the walks to fill in as they meet the
+    /// name.
+    fn get_or_insert(&mut self, name: FullName) -> &mut InlineCost {
+        self.costs.entry(name).or_insert_with(InlineCost::new)
     }
 
     /// How many times the program names the symbol, counted over every expression the walk covered.
@@ -284,13 +296,11 @@ impl InlineCosts {
     fn add_cost_calculation_result(&mut self, cost: InlineCostCalculator) {
         // For each global symbol called from the symbol where `InlineCostCalculator` has been executed, add the call count.
         for (sym, count) in cost.call_count {
-            self.insert_cost_if_absent(&sym);
-            self.costs.get_mut(&sym).unwrap().call_count += count;
+            self.get_or_insert(sym).call_count += count;
         }
 
         // Set other fields for the symbol itself that `InlineCostCalculator` has traversed.
-        self.insert_cost_if_absent(&cost.name);
-        let inline_cost = self.costs.get_mut(&cost.name).unwrap();
+        let inline_cost = self.get_or_insert(cost.name);
         inline_cost.complexity = cost.complexity;
         inline_cost.is_self_recursive = cost.is_refer_self;
         inline_cost.is_lambda = cost.is_lambda;
@@ -324,11 +334,7 @@ impl InlineCostCalculator {
     fn on_find_usage_of_global_name(&mut self, used_name: &FullName) {
         // If calling a global symbol, increase the call count.
         assert!(used_name.is_global());
-        if let Some(count) = self.call_count.get_mut(used_name) {
-            *count += 1;
-        } else {
-            self.call_count.insert(used_name.clone(), 1);
-        }
+        *self.call_count.entry(used_name.clone()).or_insert(0) += 1;
 
         // If it calls itself, set `is_call_self`.
         if used_name == &self.name {
@@ -574,8 +580,7 @@ impl<'c> ExprVisitor for Inliner<'c> {
             return EndVisitResult::unchanged(expr);
         }
 
-        let cost = self.costs.costs.get(var_name).unwrap();
-        if !cost.inline_at_non_call_site() {
+        if !self.costs.get(var_name).inline_at_non_call_site() {
             return EndVisitResult::unchanged(expr);
         }
 
@@ -614,13 +619,7 @@ impl<'c> ExprVisitor for Inliner<'c> {
         if func_name.is_local() {
             return EndVisitResult::unchanged(expr);
         }
-        if !self
-            .costs
-            .costs
-            .get(func_name)
-            .unwrap()
-            .inline_at_call_site()
-        {
+        if !self.costs.get(func_name).inline_at_call_site() {
             return EndVisitResult::unchanged(expr);
         }
         let func_expr = self.symbols.get(func_name).unwrap().expr.as_ref().unwrap();

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -14023,8 +14023,8 @@ main = (
     test_source(source, Configuration::develop_mode());
 }
 
-/// Verifies the other direction: a trait implemented for a type written as a type alias, whose
-/// associated type line names the type the alias stands for.
+/// Verifies that a trait may be implemented for a type written as a type alias, with the
+/// associated type line naming the type the alias stands for.
 #[test]
 pub fn test_trait_impl_head_written_as_type_alias() {
     let source = r#"

--- a/src/tests/test_basic.rs
+++ b/src/tests/test_basic.rs
@@ -14058,8 +14058,7 @@ main = (
 /// array to every reader and a write to it clones. The test reads both bytes, so a wrong answer
 /// fails it as loudly as a write that never landed.
 ///
-/// The behavior it holds is shared with its neighbours: a global whose every reader got a buffer of
-/// its own would answer the same. What it refuses is a write through one reader reaching another.
+/// What it refuses is a write through one reader of a global reaching another reader of it.
 #[test]
 pub fn test_a_write_to_the_bytes_of_a_global_string_leaves_the_global_alone() {
     let source = r#"

--- a/src/tests/test_global_accessor.rs
+++ b/src/tests/test_global_accessor.rs
@@ -136,11 +136,30 @@ fn stays_out_of_its_callers(ir: &str, name: &str) -> bool {
     attributes.contains("noinline")
 }
 
-/// How many times `ir` calls the function whose name starts with `name`.
-fn count_calls_to(ir: &str, name: &str) -> usize {
+/// The lines of `ir` that call the function whose name starts with `name`.
+fn calls_to<'a>(ir: &'a str, name: &str) -> Vec<&'a str> {
     ir.lines()
         .filter(|line| line.contains("call") && line.contains(name))
-        .count()
+        .collect()
+}
+
+/// How many times `ir` calls the function whose name starts with `name`.
+fn count_calls_to(ir: &str, name: &str) -> usize {
+    calls_to(ir, name).len()
+}
+
+/// Assert that the optimized IR of the build in `dir` holds no call to `accessor`, the accessor of
+/// the global named `global`.
+fn assert_reading_costs_no_call(dir: &Path, accessor: &str, global: &str) {
+    let optimized_ir = emitted_llvm_ir(dir, EmittedIr::AfterOptimization);
+    let remaining_calls = calls_to(&optimized_ir, accessor);
+    assert!(
+        remaining_calls.is_empty(),
+        "reading `{}` should cost no call, and the optimized IR holds {}:\n{}",
+        global,
+        remaining_calls.len(),
+        remaining_calls.join("\n")
+    );
 }
 
 /// The initializer of a global read from many places is a function of its own, which is left there.
@@ -253,17 +272,7 @@ pub fn test_reading_a_global_in_a_loop_costs_no_call() {
         "the program should read `table` through its accessor"
     );
 
-    let optimized_ir = emitted_llvm_ir(dir, EmittedIr::AfterOptimization);
-    let remaining_calls: Vec<_> = optimized_ir
-        .lines()
-        .filter(|line| line.contains("call") && line.contains(TABLE_ACCESSOR))
-        .collect();
-    assert!(
-        remaining_calls.is_empty(),
-        "reading `table` should cost no call, and the optimized IR holds {}:\n{}",
-        remaining_calls.len(),
-        remaining_calls.join("\n")
-    );
+    assert_reading_costs_no_call(dir, TABLE_ACCESSOR, "table");
 }
 
 /// A global read from a compilation unit that does not own it is read without a call.
@@ -291,17 +300,7 @@ pub fn test_a_global_read_from_another_unit_costs_no_call() {
          exported C function"
     );
 
-    let optimized_ir = emitted_llvm_ir(dir, EmittedIr::AfterOptimization);
-    let remaining_calls: Vec<_> = optimized_ir
-        .lines()
-        .filter(|line| line.contains("call") && line.contains(COUNTER_ACCESSOR))
-        .collect();
-    assert!(
-        remaining_calls.is_empty(),
-        "reading `counter` should cost no call, and the optimized IR holds {}:\n{}",
-        remaining_calls.len(),
-        remaining_calls.join("\n")
-    );
+    assert_reading_costs_no_call(dir, COUNTER_ACCESSOR, "counter");
 }
 
 /// Assert that the RC IR dump opens no global of its own under `name`.

--- a/src/tests/test_global_accessor.rs
+++ b/src/tests/test_global_accessor.rs
@@ -231,20 +231,24 @@ pub fn test_a_reader_of_a_global_sees_every_write_to_it() {
     let accessor = sole_body(&ir, TABLE_ACCESSOR);
 
     for variable in [TABLE_STORAGE, TABLE_FLAG] {
-        let writes = |text: &str| {
+        let count_writes_in = |text: &str| {
             text.lines()
                 .filter(|line| line.trim_start().starts_with("store") && line.contains(variable))
                 .count()
         };
-        let in_module = writes(&ir);
-        assert!(in_module > 0, "the program should write `{}`", variable);
+        let writes_in_module = count_writes_in(&ir);
+        assert!(
+            writes_in_module > 0,
+            "the program should write `{}`",
+            variable
+        );
         assert_eq!(
-            writes(&accessor),
-            in_module,
+            count_writes_in(&accessor),
+            writes_in_module,
             "every write to `{}` should be in the accessor, and {} of the {} are:\n{}",
             variable,
-            writes(&accessor),
-            in_module,
+            count_writes_in(&accessor),
+            writes_in_module,
             accessor
         );
     }

--- a/src/tests/test_global_accessor.rs
+++ b/src/tests/test_global_accessor.rs
@@ -33,14 +33,22 @@ const TWO_GLOBALS_SOURCE: &str = r#"
     );
 "#;
 
-/// The names the compiler gives the parts of `table`, as the emitted LLVM IR quotes them.
+/// The accessor of `table`, as the emitted LLVM IR quotes its name.
 const TABLE_ACCESSOR: &str = "@\"Get#Main::table#";
+
+/// The function computing the value of `table`, as the emitted LLVM IR quotes its name.
 const TABLE_INITIALIZER: &str = "@\"InitValue#Main::table#";
+
+/// The storage holding the value of `table`, as the emitted LLVM IR quotes its name.
 const TABLE_STORAGE: &str = "@\"GlobalVar#Main::table#";
+
+/// The flag saying whether `table` has been initialized, as the emitted LLVM IR quotes its name.
 const TABLE_FLAG: &str = "@\"InitFlag#Main::table#";
 
-/// The same, for `read_once`.
+/// The accessor of `read_once`, as the emitted LLVM IR quotes its name.
 const READ_ONCE_ACCESSOR: &str = "@\"Get#Main::read_once#";
+
+/// The function computing the value of `read_once`, as the emitted LLVM IR quotes its name.
 const READ_ONCE_INITIALIZER: &str = "@\"InitValue#Main::read_once#";
 
 /// A program whose global is read by the C function an `FFI_EXPORT` statement builds.
@@ -260,9 +268,8 @@ pub fn test_a_reader_of_a_global_sees_every_write_to_it() {
 /// length and the element read reads the pointer. The property is read off the emitted LLVM IR: it
 /// is about the code the build emits, and a program cannot observe a call it does not make.
 ///
-/// This is the requirement. `test_the_initializer_of_a_shared_global_sits_outside_the_accessor` and
-/// `test_a_reader_of_a_global_sees_every_write_to_it` pin the two properties this compiler reaches
-/// it by, and another mechanism would keep this test green and turn those red.
+/// This is the requirement itself, stated apart from the mechanism that meets it: a compiler
+/// reaching `table` some other way would keep this test green.
 #[test]
 pub fn test_reading_a_global_in_a_loop_costs_no_call() {
     let temp_dir = build_emitting_llvm_ir(TWO_GLOBALS_SOURCE);

--- a/src/tests/test_global_accessor.rs
+++ b/src/tests/test_global_accessor.rs
@@ -121,7 +121,7 @@ fn sole_body(ir: &str, name: &str) -> String {
 }
 
 /// Whether the function whose name starts with `name` carries the `noinline` attribute.
-fn stays_out_of_its_callers(ir: &str, name: &str) -> bool {
+fn is_kept_out_of_its_callers(ir: &str, name: &str) -> bool {
     let signature = sole_body(ir, name)
         .lines()
         .next()
@@ -198,7 +198,7 @@ pub fn test_the_initializer_of_a_shared_global_sits_outside_the_accessor() {
         accessor
     );
     assert!(
-        stays_out_of_its_callers(&ir, TABLE_INITIALIZER),
+        is_kept_out_of_its_callers(&ir, TABLE_INITIALIZER),
         "the initializer of `table` should stay out of the accessor"
     );
 }
@@ -221,7 +221,7 @@ pub fn test_the_initializer_of_a_global_read_once_stays_where_its_reader_sees_it
     );
 
     assert!(
-        !stays_out_of_its_callers(&ir, READ_ONCE_INITIALIZER),
+        !is_kept_out_of_its_callers(&ir, READ_ONCE_INITIALIZER),
         "the initializer of `read_once` should be free to join the accessor"
     );
 }
@@ -318,7 +318,7 @@ pub fn test_a_global_read_from_another_unit_costs_no_call() {
 ///
 /// A body put at each of the names that read it leaves the program nothing left to keep, so the
 /// dump declares no global there.
-fn assert_no_global_stands_for(dump: &str, name: &str) {
+fn assert_no_global_is_kept_for(dump: &str, name: &str) {
     let standing_globals: Vec<_> = dump
         .lines()
         .filter(|line| line.starts_with("global ") && line.contains(name))
@@ -459,7 +459,7 @@ fn test_a_global_scalar_literal_is_put_at_every_name() {
             dump
         );
 
-        assert_no_global_stands_for(&dump, global);
+        assert_no_global_is_kept_for(&dump, global);
     }
 }
 
@@ -502,5 +502,5 @@ fn test_an_iostate_is_made_where_it_is_used() {
         dump
     );
 
-    assert_no_global_stands_for(&dump, IOSTATE_GLOBAL);
+    assert_no_global_is_kept_for(&dump, IOSTATE_GLOBAL);
 }


### PR DESCRIPTION
Refs #618

このブランチのレビューが、変更の周りで見つけたものを直す。**振る舞いを保つもの**と、**黙って続いていたところで止まるようになるもの**の 2 種類が入っている。

## 黙って続いていたところで止まる

### 宣言が実体と食い違っていたら、宣言を読む場所で止まる

`is_free_to_duplicate` は演算が自分について申告する事実で、その正しさは doc の散文にしかなかった。**#618 のバグはその食い違いそのものだった** — `InlineLLVMStringBuf` が「複製はただ」と申告しながら、実体は確保と写しを行っていた。

[`calculate_inline_costs`](https://github.com/tttmmmyyyy/fixlang/blob/30ebf35a9e3008458be2cdd5353960e2f25c75bd/src/optimization/inline.rs#L128-L173) が、申告した演算の答える型が隅々まで unbox であることを検査する。確保される部分を持つ型は、レジスタに載せて持ち回ることができないので、両者が食い違うのは申告が誤っているときだけである。

`InlineLLVMStringBuf` に再び `true` と答えさせると、コンパイラは宣言を読む場所で止まる。

```
the inline-LLVM operation `string_buf("hello")` declares a copy of itself free
while it answers with `Std::Array Std::U8`, which holds a boxed part
```

正しいプログラムが計算するものは変わらない。変わるのは、破られた不変条件がそこで止まるようになることである。

費用は無条件の `assert!` で足りる。短絡評価により、型を歩くのは申告した演算についてだけで、プログラムはそれを一握りしか持たない。`LLVMGen` の兄弟の申告 `applies_a_function_operand` も、`apply_lambda` で同じように検査されている。

## 振る舞いを保つ

### 費用表に、それが備えるメソッドから触れる

`Inliner` の 2 か所が `self.costs.costs.get(name).unwrap()` と内部の `Map` を直に叩いており、同じ構造体が持つ `InlineCosts::get` (名前を出して panic する) を通していなかった。`calculate_inline_costs` は同じ `get_mut(name).unwrap()` を 1 つのループ本体で 4 回繰り返していた。`insert_cost_if_absent` とその直後の `get_mut(..).unwrap()` は二度引きだった。

private な `InlineCosts` に `get_mut` / `get_or_insert` / `panic_no_cost_recorded` を足し、すべての読み書きをそこへ通した。

### 名前が、数えているものを言う

```
call_count / get_call_count  ->  use_count / get_use_count
```

`end_visit_var` はグローバル名の出現をすべて数えており、呼び出しに限らない。doc 自身が "How many times the program names the symbol" と書いていた。

```
is_refer_self          ->  is_self_recursive     文法が崩れており、値が入る欄は既にこの名前
skip_symbols           ->  stable_symbols        渡す先の引数も # Arguments もこの名前
引数 cost              ->  calculator            型は InlineCostCalculator で InlineCost ではない
inline_at_call_site    ->  may_be_inlined_at_call_site
inline_at_non_call_site->  may_be_inlined_at_non_call_site
no_cost_recorded       ->  panic_no_cost_recorded
```

`inline_at_non_call_site` は bool を返すのに命令形の動詞句で、`if !cost.inline_at_non_call_site()` は「非呼び出し位置に展開せよ」と読めた。doc 自身は "Whether the symbol's expression may be substituted ..." と書いている。`panic_no_cost_recorded` は `-> !` を返すので、`error.rs` の `panic_notrace` / `panic_with_msg` に倣う。

存在しない識別子 `is_call_self` を名指していたコメントも直した。

### 既に答えの出ている条件を落とす

[`may_be_inlined_at_non_call_site`](https://github.com/tttmmmyyyy/fixlang/blob/30ebf35a9e3008458be2cdd5353960e2f25c75bd/src/optimization/inline.rs#L221-L241) の `if !self.is_self_recursive && self.is_alias` は、その 3 行上の `if self.is_self_recursive { return false; }` で既に保証されている。

### 項目が自分の doc を持つ

`InlineCost` / `InlineCostCalculator` / `Inliner` の全フィールドを `//` から `///` へ。doc の無かった `calculate_inline_costs`、両構造体の本体、3 つの `new`、`count_use_of_global_name` に doc を付けた。visitor の各メソッドに散っていた complexity の加算規則を、`complexity` の欄の doc に集約した。

`inline_llvm.rs` の `InlineLLVM` 本体・`generator` の欄・`global_to_absolute` にも doc を付けた。差分が追加した 4 つの `is_free_to_duplicate` のうち doc が 1 つにしか付いていなかった不揃いも揃えた。

テストの側では、同形の「最適化後の IR から accessor への call 行を集めて空を表明する」ブロック 2 つを 1 つの関数に括り出し、同じ filter 述語を持っていた `count_calls_to` も同じ土台に載せた (3 か所の重複が 1 つに)。定数 6 つが 2 つの doc を分け合っていたのを各自の doc にし、兄弟テストを名指していた doc から列挙を外した。

## 作者へ回した指摘

このブランチでは直していない。スイートが答えられないか、答えが安全性の話ではないもの。

- **`inline_at_non_call_site` が一つの問いを 3 つの形フラグの論理和で答えている。** 「この本体の複製はただか」という一つの問いを、`is_free_to_duplicate` / `is_llvm_lam` / `is_alias` で答えており、そのうち 2 つの定義域が「本体が裸の inline-LLVM 演算」という形で重なっていた。#618 の修正が 2 か所に分かれたのはこのためである。本体の式に対する一つの述語にまとめられるが、閾値の当たり方が動くので測り直しが要る。
- **`ExprVisitor` に default 実装が無い。** 実装側は関心の無いノード種別についても `VisitChildren` / `unchanged(expr)` を書き下ろす必要があり、実装 19 個、プロジェクト全体で約 250 個の自明な本体がある。
- **`expr_float_lit` だけ `global_to_absolute()` を呼んでいない。** `expr_int_lit` と `expr_nullptr_lit` は呼ぶ。結果として整数リテラルの型は `::Std::I64`、浮動小数リテラルの型は `Std::F64` (相対) のまま下流へ渡る。どちらが正しいかは名前解決側の判断。
- `run_one` が毎ラウンドシンボル表全体を clone する (最大 10 回)。
- `InlineLLVMIOStateUnsafeCreate::generate` が引数の結果型を捨てて `make_iostate_ty()` を自前で作る。現状は正しいが、その不変条件がコード上に書かれていない。

## 確かめたこと

全テスト通過 (lib 185 + bin 1694、失敗 0)。assert は、#618 のバグを再導入して発火することを確認した。
