### PR TITLE
レビュー清掃 (#623): 計数の 4 つを 1 つの型にまとめ、飲み込んでいた失敗を出す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 before_opt.ll
 after_opt.ll
 benchmark/data_copied.csv
-cachegrind.out.*
 *.symbols.fix
 /test.log
 /llvm_passes_tmp.txt

--- a/benchmark/crosslang/allocations.c
+++ b/benchmark/crosslang/allocations.c
@@ -16,15 +16,31 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static long n_malloc, n_realloc, n_aligned;
+// Every entry the C library offers, since a language reaches the allocator through whichever
+// one its runtime picked: Rust's `vec![0; n]` arrives as `calloc` by way of
+// `__rust_alloc_zeroed`, and a counterpart counted through `malloc` alone reads as allocating
+// half as often as the case beside it.
+//
+// `dlsym` resolves the real entry on the first call. Where a C library reaches for the allocator
+// while it resolves, that first call recurses; glibc does not, and a library that does would
+// need the real entries resolved from a constructor into a static buffer instead.
+static long n_malloc, n_calloc, n_realloc, n_aligned, n_posix_memalign;
 static void *(*real_malloc)(size_t);
+static void *(*real_calloc)(size_t, size_t);
 static void *(*real_realloc)(void *, size_t);
 static void *(*real_aligned_alloc)(size_t, size_t);
+static int (*real_posix_memalign)(void **, size_t, size_t);
 
 void *malloc(size_t size) {
     if (!real_malloc) real_malloc = dlsym(RTLD_NEXT, "malloc");
     n_malloc++;
     return real_malloc(size);
+}
+
+void *calloc(size_t count, size_t size) {
+    if (!real_calloc) real_calloc = dlsym(RTLD_NEXT, "calloc");
+    n_calloc++;
+    return real_calloc(count, size);
 }
 
 void *realloc(void *ptr, size_t size) {
@@ -39,7 +55,13 @@ void *aligned_alloc(size_t alignment, size_t size) {
     return real_aligned_alloc(alignment, size);
 }
 
+int posix_memalign(void **out, size_t alignment, size_t size) {
+    if (!real_posix_memalign) real_posix_memalign = dlsym(RTLD_NEXT, "posix_memalign");
+    n_posix_memalign++;
+    return real_posix_memalign(out, alignment, size);
+}
+
 __attribute__((destructor)) static void report(void) {
-    fprintf(stderr, "malloc=%ld realloc=%ld aligned_alloc=%ld\n",
-            n_malloc, n_realloc, n_aligned);
+    fprintf(stderr, "malloc=%ld calloc=%ld realloc=%ld aligned_alloc=%ld posix_memalign=%ld\n",
+            n_malloc, n_calloc, n_realloc, n_aligned, n_posix_memalign);
 }

--- a/benchmark/crosslang/build.sh
+++ b/benchmark/crosslang/build.sh
@@ -29,6 +29,7 @@ echo "== building with $FIX"
 
 for name in $(comparable_cases); do
     is_wanted "$name" || continue
+    # `../speedtest/reference.py` spells the same two counterpart recipes for its own question.
     (cd "$CASES/$name" \
         && "$FIX" build -f main.fix -O experimental -o "$BIN/${name}_fix" >/dev/null \
         && gcc -O3 -march=native ref.c -o "$BIN/${name}_c" -lm \

--- a/benchmark/speedtest/cases/startup/main.fix
+++ b/benchmark/speedtest/cases/startup/main.fix
@@ -2,8 +2,8 @@ module Main;
 
 import Std::{IO, Monad::pure};
 
-// A program that does nothing, measured like every other case. Cachegrind counts the
-// dynamic loader and the runtime's own start-up along with the work, so this column is what
-// a case's figure holds before any of its work: the micro-benchmarks are mostly this, and a
-// change to the runtime moves every case together with it.
+// A program that does nothing, measured like every other case. The counters run from the
+// first instruction of the dynamic loader, so this column is what a case's figure holds
+// before any of its work: the micro-benchmarks are mostly this, and a change to the runtime
+// moves every case together with it.
 main : IO () = pure();

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -113,19 +113,21 @@ def build_data(log_path, history_path, latest_n):
 
     commits = []
     for row in body:
-        raw = row[0].strip()
-        dirty = raw.endswith("(dirty)")
-        h = raw[: -len("(dirty)")] if dirty else raw
-        entry = history.get(h)
+        recorded = row[0].strip()
+        dirty = recorded.endswith("(dirty)")
+        commit_hash = recorded[: -len("(dirty)")] if dirty else recorded
+        entry = history.get(commit_hash)
         if entry is None:
             # An entry may be keyed by a short hash. Take the longest key that matches, so
             # two entries sharing a prefix resolve to the more specific one.
-            matches = [k for k in history if h.startswith(k) or k.startswith(h)]
+            matches = [k for k in history
+                       if commit_hash.startswith(k) or k.startswith(commit_hash)]
             entry = history[max(matches, key=len)] if matches else None
         cpu = row[cpu_col].strip() if cpu_col is not None and cpu_col < len(row) else ""
         contention = (row[contention_col].strip()
                       if contention_col is not None and contention_col < len(row) else "")
-        commits.append({"hash": h, "short": h[:8], "dirty": dirty, "history": entry,
+        commits.append({"hash": commit_hash, "short": commit_hash[:8], "dirty": dirty,
+                        "history": entry,
                         "cpu": cpu, "contention": contention})
 
     # Split each "<case>-<metric>" column apart, and each "<case>-<metric>-<language>"
@@ -136,6 +138,9 @@ def build_data(log_path, history_path, latest_n):
         series, refs = {}, {}
         for name, i in index.items():
             column = [row[i].strip() if i < len(row) else "" for row in body]
+            # A cell a run left empty reads as no measurement, and so does a cell of a column
+            # that holds something else: the loop walks every column of the log, and `cpu` and
+            # `contention` are among them.
             numbers = [int(c) if c.isdigit() else None for c in column]
             if not any(v is not None for v in numbers):
                 continue

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -52,7 +52,9 @@ METRICS = [
      "Loads and stores that crossed a cache-line boundary, from the hardware counters. An "
      "instruction count has no notion of these, and they cost real time; the count is "
      "deterministic and reaches zero once the data is aligned, so it is plotted as an absolute "
-     "count.", "absolute"),
+     "count. A handful of it belongs to where the path of the program put its stack rather than "
+     "to the program, so two languages whose counts differ by a few are not two programs that "
+     "differ.", "absolute"),
 ]
 
 
@@ -392,6 +394,12 @@ function scaleY(series, kind) {
   for (const s of series) {
     if (!isVisible(s)) continue;
     for (const v of s.values) if (v !== null && v > 0) { lo = Math.min(lo, v); hi = Math.max(hi, v); }
+    // The counterpart lines are drawn on this axis as well, so a counterpart outside the range
+    // the case itself covers would be clamped to the floor and read as a value it is not.
+    for (const value of Object.values(s.refs)) {
+      const v = kind === "ratio" ? value / s.base : value;
+      if (v > 0) { lo = Math.min(lo, v); hi = Math.max(hi, v); }
+    }
   }
   if (!isFinite(lo)) { lo = 1; hi = 1; }
   if (kind === "ratio") { lo = Math.min(lo, 0.8); hi = Math.max(hi, 1.25); }

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -13,6 +13,7 @@ import csv
 import html
 import json
 import re
+import sys
 import tempfile
 from pathlib import Path
 
@@ -56,19 +57,24 @@ METRICS = [
 
 
 def parse_history(path):
-    """Map each commit hash in `history.md` to the HTML of its entry.
+    """The HTML of what stands before the first entry, and each commit hash mapped to the HTML
+    of its own entry.
 
-    An entry runs from a `## <hash>` heading to the next one.
+    An entry runs from a `## <hash>` heading to the next one. What stands before the first
+    heading says which rows are comparable with which, which belongs to no one commit and so is
+    returned beside them.
     """
     if not path.exists():
-        return {}
+        return "", {}
     entries = {}
     current_hash, buf = None, []
+    preamble = []
 
     def flush():
-        if current_hash is None:
-            return
         text = "\n".join(buf).strip()
+        if current_hash is None:
+            preamble.append(text)
+            return
         entries[current_hash] = render_markdown(text) if text else ""
 
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -76,10 +82,10 @@ def parse_history(path):
         if m:
             flush()
             current_hash, buf = m.group(1), []
-        elif current_hash is not None:
+        else:
             buf.append(line)
     flush()
-    return entries
+    return render_markdown(preamble[0]) if preamble and preamble[0] else "", entries
 
 
 def render_markdown(text):
@@ -104,14 +110,20 @@ def read_log(path):
 def build_data(log_path, history_path, latest_n):
     header, body = read_log(log_path)
     body = body[-latest_n:]
-    history = parse_history(history_path)
+    preamble, history = parse_history(history_path)
 
     index = {name.strip(): i for i, name in enumerate(header)}
     cpu_col = index.get("cpu")
-    # Rows taken before the counters were judged by contention carry a `load` column instead.
-    contention_col = index.get("contention", index.get("load"))
+    contention_col = index.get("contention")
+    # Rows taken before the counters were judged by contention carry a `load` column instead,
+    # and the two are read row by row: the column exists from the row it was introduced on, so a
+    # log holding both has an empty `contention` cell exactly where a `load` one is filled.
+    load_col = index.get("load")
 
     commits = []
+    # A note whose heading names no row of the log reaches nobody, and the heading of one that
+    # does is the only thing that carries it there.
+    matched = set()
     for row in body:
         recorded = row[0].strip()
         dirty = recorded.endswith("(dirty)")
@@ -122,13 +134,20 @@ def build_data(log_path, history_path, latest_n):
             # two entries sharing a prefix resolve to the more specific one.
             matches = [k for k in history
                        if commit_hash.startswith(k) or k.startswith(commit_hash)]
-            entry = history[max(matches, key=len)] if matches else None
+            if matches:
+                key = max(matches, key=len)
+                entry, _ = history[key], matched.add(key)
+            else:
+                entry = None
+        else:
+            matched.add(commit_hash)
         cpu = row[cpu_col].strip() if cpu_col is not None and cpu_col < len(row) else ""
-        contention = (row[contention_col].strip()
-                      if contention_col is not None and contention_col < len(row) else "")
+        def cell(column):
+            return row[column].strip() if column is not None and column < len(row) else ""
+
         commits.append({"hash": commit_hash, "short": commit_hash[:8], "dirty": dirty,
-                        "history": entry,
-                        "cpu": cpu, "contention": contention})
+                        "history": entry, "cpu": cpu, "contention": cell(contention_col),
+                        "load": cell(load_col)})
 
     # Split each "<case>-<metric>" column apart, and each "<case>-<metric>-<language>"
     # reference beside it. A reference does not move with a Fix commit, so the last value
@@ -156,7 +175,8 @@ def build_data(log_path, history_path, latest_n):
             metrics[suffix] = {"label": label, "note": note, "kind": kind,
                                "series": series, "refs": refs}
 
-    return {"commits": commits, "metrics": metrics}
+    return {"commits": commits, "metrics": metrics, "preamble": preamble,
+            "orphan_notes": sorted(set(history) - matched)}
 
 
 def self_check():
@@ -170,18 +190,24 @@ def self_check():
     with tempfile.TemporaryDirectory() as tmp:
         log = Path(tmp) / "log.csv"
         log.write_text(
-            "commit,cpu,contention,a-inst,a-mem,a-ram,a-splits,a-cycles,b-inst,a-inst-c,"
-            "a-inst-rust,a-mem-c\n"
-            "1111111111111111111111111111111111111111,Zen,0.10,100,200,3,4,7,50,90,,210\n"
-            "2222222222222222222222222222222222222222(dirty),Zen,,150,,5,0,,,90,120,\n",
+            "commit,cpu,load,contention,a-inst,a-mem,a-ram,a-splits,a-cycles,b-inst,a-inst-c,"
+            "a-inst-rust,a-mem-c,a-ram-c,a-splits-rust,a-cycles-c\n"
+            "1111111111111111111111111111111111111111,Zen,,0.10,100,200,3,4,7,50,90,,210,6,,11\n"
+            "2222222222222222222222222222222222222222(dirty),Zen,1.25,,150,,5,0,,,90,120,,,8,\n",
             encoding="utf-8",
         )
         history = Path(tmp) / "history.md"
-        history.write_text("# Benchmark History\n\n## 2222222\n\nsecond commit\n", encoding="utf-8")
+        history.write_text("# Benchmark History\n\nRows above `2222222` are not comparable"
+                           " with rows below it.\n\n## 2222222\n\nsecond commit\n"
+                           "\n## 3333333\n\na commit the log has no row for\n",
+                           encoding="utf-8")
         data = build_data(log, history, 40)
 
     first, second = data["commits"]
     assert first["cpu"] == "Zen" and first["contention"] == "0.10" and not first["dirty"], first
+    # A row taken before the counters were judged by contention carries a load average instead,
+    # and each is read from its own column rather than from whichever column the log has.
+    assert (first["load"], second["load"]) == ("", "1.25"), (first["load"], second["load"])
     assert second["contention"] == "", second
     assert second["dirty"] and "second commit" in second["history"], second
     assert first["history"] is None, first
@@ -196,7 +222,15 @@ def self_check():
     assert "mem" not in data["metrics"], sorted(data["metrics"])
     assert data["metrics"]["splits"]["kind"] == "absolute"
     assert data["metrics"]["inst"]["refs"] == {"a": {"c": 90, "rust": 120}}, data["metrics"]["inst"]["refs"]
-    assert data["metrics"]["ram"]["refs"] == {}, data["metrics"]["ram"]["refs"]
+    # Every metric reads its own reference columns, and each takes the last value measured.
+    assert data["metrics"]["ram"]["refs"] == {"a": {"c": 6}}, data["metrics"]["ram"]["refs"]
+    assert data["metrics"]["splits"]["refs"] == {"a": {"rust": 8}}, data["metrics"]["splits"]["refs"]
+    assert data["metrics"]["cycles"]["refs"] == {"a": {"c": 11}}, data["metrics"]["cycles"]["refs"]
+    # What `history.md` says before its first entry belongs to no one commit, and says which rows
+    # are comparable with which, so it reaches the page on its own.
+    assert "not comparable" in data["preamble"], data["preamble"]
+    # A note whose heading names no row reaches nobody, and nothing else says so.
+    assert data["orphan_notes"] == ["3333333"], data["orphan_notes"]
 
 
 def main():
@@ -208,6 +242,13 @@ def main():
     ap.add_argument("--out", default=here / "graph.html", type=Path)
     ap.add_argument("--latest-n", default=40, type=int)
     args = ap.parse_args()
+
+    # Every row of the log is read for this, not just the ones the page draws, so a note is
+    # called orphaned only where the log has no row for it at all.
+    every_row = build_data(args.log, args.history, len(read_log(args.log)[1]))
+    for orphan in every_row["orphan_notes"]:
+        print(f"{args.history}: the note headed {orphan} names no row of {args.log.name}",
+              file=sys.stderr)
 
     data = build_data(args.log, args.history, args.latest_n)
     page = TEMPLATE.replace("__DATA__", json.dumps(data, ensure_ascii=False))
@@ -295,6 +336,9 @@ aside h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .06em;
     <div class="legend" id="legend"></div>
   </div>
   <aside>
+    <details id="comparability"><summary>What is comparable with what</summary>
+      <div id="preamble"></div>
+    </details>
     <h2>Commit notes</h2>
     <div id="history"><p class="placeholder">Click a commit on the axis.</p></div>
   </aside>
@@ -495,7 +539,8 @@ function showHistory(i) {
   const c = DATA.commits[i];
   document.getElementById("history").innerHTML =
     `<p class="commit">${c.hash}${c.dirty ? " (dirty)" : ""}${c.cpu ? "<br>" + c.cpu : ""}`
-    + `${c.contention ? ` with ${c.contention} cores of other work` : ""}</p>`
+    + `${c.contention ? ` with ${c.contention} cores of other work` : ""}`
+    + `${!c.contention && c.load ? ` at a load average of ${c.load}` : ""}</p>`
     + (c.history || `<p class="placeholder">No note recorded for this commit.</p>`);
 }
 
@@ -529,6 +574,15 @@ function renderTabs() {
     b.addEventListener("click", () => { metricKey = key; renderTabs(); render(); });
     box.appendChild(b);
   }
+}
+
+// What `history.md` says before its first entry: which rows are comparable with which. It
+// belongs to no one commit, so it sits beside the notes rather than among them.
+const comparability = document.getElementById("comparability");
+if (DATA.preamble) {
+  document.getElementById("preamble").innerHTML = DATA.preamble;
+} else {
+  comparability.hidden = true;
 }
 
 renderTabs();

--- a/benchmark/speedtest/graph_html.py
+++ b/benchmark/speedtest/graph_html.py
@@ -38,8 +38,11 @@ METRICS = [
     ("ram", "perf main-memory accesses",
      "Accesses that missed the last level cache and so came from main memory, from the hardware "
      "counters. What else was in the cache moves this count, so the lowest reading of several "
-     "runs is taken as the program's own. It is what decides whether that program's cycle count "
-     "survives a machine with other work on it.", "ratio"),
+     "runs is taken as the program's own, and even that moves: two runs of one binary read 859 "
+     "and 2,927 for `startup`. A swing of a few times between one commit and the next is the "
+     "machine rather than the program, which the instruction column does not do. It is what "
+     "decides whether that program's cycle count survives a machine with other work on it.",
+     "ratio"),
     ("cycles", "perf cycles",
      "Core cycles the program spent in user mode, from the hardware counters, as the lowest of "
      "several windows of runs. Other work reaches it two ways: over the core the run shares with "

--- a/benchmark/speedtest/history.md
+++ b/benchmark/speedtest/history.md
@@ -285,7 +285,7 @@ implementation that #227 and #229 replaced it read 64,037,014 -> 35,921,169, a s
 here it reads 49,703,021 -> 18,895,019, a saving of 30,808,002. The five other sort cases entered the
 corpus with those two changes, so this is the first row that reads them with the chain followed.
 
-## 4052838995f52c3d8a2ba2ac82fc0e6cb3c02b8a
+## 4052838928fd76e7ddab3d0fc15d2e7fa18d1db6
 
 `Array::sort` spends its recursion budget only on a split that leaves under an eighth of the range
 on one side, instead of on every split, and a split that found nothing less than the pivot gathers

--- a/benchmark/speedtest/main.fix
+++ b/benchmark/speedtest/main.fix
@@ -25,6 +25,11 @@ _REFERENCE_LANGUAGES = ["c", "rust"];
 _PROGRAM_FAILED : U8;
 _PROGRAM_FAILED = 2_U8;
 
+// What `reference.py` exits with when the case carries no counterpart in the language asked for.
+// Every other non-zero status of it is something that went wrong.
+_NO_COUNTERPART : U8;
+_NO_COUNTERPART = 2_U8;
+
 // The columns a `perf_counters.py` line fills, in the order it prints them. The contention it
 // prints after them belongs to the row rather than to any one case.
 _COUNTER_COLUMN_SUFFIXES : Array String;
@@ -217,7 +222,13 @@ main = (
         };
         command.ez_run_o(config);;
         _REFERENCE_LANGUAGES.to_iter.fold_m((), |lang, _|
-            ["python3", "../../reference.py", "build", lang].ez_run_oec(config);;
+            let (_, _, build_code) = *["python3", "../../reference.py", "build", lang].ez_run_oec(config);
+            // A counterpart that does not compile would otherwise reach the measurement as a
+            // language this case does not carry, and leave the row short of its columns.
+            when(build_code != 0_U8 && build_code != _NO_COUNTERPART,
+                eprintln("error: the " + lang + " counterpart of " + dir + " does not build");;
+                exit(1)
+            );;
             pure()
         );;
         ez_cd(config, "..")
@@ -256,15 +267,15 @@ main = (
             exit(1)
         };
         let (log, case_contention) = if perf_code != 0_U8 { (log, 0.0) } else {
-            let perf = perf.strip_spaces.split(",").to_array;
-            if perf.@size != _COUNTER_COLUMN_SUFFIXES.@size + 1 {
-                undefined("error: perf_counters.py reported \"" + perf.to_iter.join(",")
+            let perf_fields = perf.strip_spaces.split(",").to_array;
+            if perf_fields.@size != _COUNTER_COLUMN_SUFFIXES.@size + 1 {
+                undefined("error: perf_counters.py reported \"" + perf_fields.to_iter.join(",")
                     + "\" for " + dir)
             };
-            let log = log.set_latest_counts(case_name, "", perf);
+            let log = log.set_latest_counts(case_name, "", perf_fields);
             // A figure the harness cannot make out leaves the row's `contention` at whatever
             // the other cases reported, which is the honest reading: this case said nothing.
-            (log, perf.@(_COUNTER_COLUMN_SUFFIXES.@size).read_number)
+            (log, perf_fields.@(_COUNTER_COLUMN_SUFFIXES.@size).read_number)
         };
         let max_contention = max(max_contention, case_contention);
         // A case may carry `ref.c` and `ref.rs`: the same program on the same input, read
@@ -274,6 +285,12 @@ main = (
         // with a pass sequence, so it has no business in what the pass search compares.
         let (log, max_contention) = *_REFERENCE_LANGUAGES.to_iter.fold_m((log, max_contention), |lang, (log, max_contention)|
             let (ref_out, _, ref_code) = *["python3", "../../reference.py", "measure", lang, "--windows", _WINDOWS].ez_run_oec(config);
+            // The counterpart checks its own answer too, and `reference.py` stops on that rather
+            // than letting it become a number on the chart.
+            if ref_code != 0_U8 && ref_code != _NO_COUNTERPART {
+                eprintln("error: the " + lang + " counterpart of " + dir + " failed its own check");;
+                exit(1)
+            };
             if ref_code != 0_U8 { (log, max_contention).pure };
             let ref_out = ref_out.strip_spaces.split(",").to_array;
             if ref_out.@size < _COUNTER_COLUMN_SUFFIXES.@size + 1 { (log, max_contention).pure };

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -44,6 +44,7 @@ import resource
 import subprocess
 import sys
 import time
+from typing import NamedTuple
 
 # Keeping the list short matters -- asking for more events than the PMU has counters makes perf
 # time-slice them and report scaled estimates, which `read_counters` refuses. Cycles and
@@ -191,6 +192,23 @@ def lower_of(best, reading):
     return reading if best is None or reading < best else best
 
 
+class Counts(NamedTuple):
+    """What the counters read, in the order this program prints them.
+
+    One of these describes a run, a window of runs, or a whole measurement, since the four are
+    folded together the same way at every level.
+    """
+
+    instructions: int
+    ram_accesses: int
+    splits: int
+    cycles: int
+
+    def lowest_with(self, other):
+        """Each count of the two, whichever of the pair is lower."""
+        return Counts(*(lower_of(a, b) for a, b in zip(self, other)))
+
+
 def read_counters(argv):
     """Event name -> count for every event of `ALL_EVENTS`.
 
@@ -216,11 +234,14 @@ def read_counters(argv):
         # what it prints is an estimate that looks like any other measurement.
         if len(fields) >= 5 and fields[4].strip():
             try:
-                if float(fields[4]) < 100.0:
-                    sys.exit(f"perf could keep {name} on a counter for only "
-                             f"{fields[4].strip()}% of the run, so its count is an estimate")
+                on_a_counter = float(fields[4])
             except ValueError:
-                pass
+                sys.exit(f"perf reported \"{fields[4].strip()}\" for how much of the run it kept "
+                         f"{name} on a counter, which is what says whether the count is an "
+                         f"estimate")
+            if on_a_counter < 100.0:
+                sys.exit(f"perf could keep {name} on a counter for only "
+                         f"{fields[4].strip()}% of the run, so its count is an estimate")
         found[name] = int(fields[0])
     # Which of the two went wrong is read from the counts rather than from the status: perf exits
     # with the measured program's status where that program ran, and an event this processor does
@@ -239,8 +260,7 @@ def read_counters(argv):
 
 
 def read_window(argv):
-    """The lowest cycle, split, instruction and RAM-access counts over a window of runs, and how
-    busy the sibling thread was through it.
+    """The lowest `Counts` over a window of runs, and how busy the sibling thread was through it.
 
     A window holds as many runs as `MINIMUM_WINDOW_SECONDS` needs, so that the sibling reading covers
     enough ticks of `/proc/stat` to mean something.
@@ -250,49 +270,48 @@ def read_window(argv):
     """
     sibling_before = sibling_cpu_seconds()
     started = time.monotonic()
-    cycles = splits = instructions = ram_accesses = None
+    lowest = None
     while True:
         found = read_counters(argv)
-        cycles = lower_of(cycles, found[event_name(CYCLE_EVENT)])
-        splits = lower_of(splits, sum(found[e] for e in SPLIT_EVENTS))
-        instructions = lower_of(instructions, found[event_name(INSTRUCTION_EVENT)])
-        ram_accesses = lower_of(ram_accesses, found[event_name(RAM_EVENT)])
+        run = Counts(instructions=found[event_name(INSTRUCTION_EVENT)],
+                     ram_accesses=found[event_name(RAM_EVENT)],
+                     splits=sum(found[e] for e in SPLIT_EVENTS),
+                     cycles=found[event_name(CYCLE_EVENT)])
+        lowest = run if lowest is None else lowest.lowest_with(run)
         elapsed = time.monotonic() - started
         if elapsed >= MINIMUM_WINDOW_SECONDS:
             break
     sibling_busy = (sibling_cpu_seconds() - sibling_before) / elapsed
-    return cycles, sibling_busy, splits, instructions, ram_accesses
+    return lowest, sibling_busy
 
 
 def measure(argv, windows):
-    """The instruction count, the main-memory access count, the split count, the lowest cycle
-    count over the windows the sibling thread left alone, and the CPU other work took over the
-    whole of it, in cores.
+    """The `Counts` of the measurement, and the CPU other work took over the whole of it, in cores.
 
-    The cycle count comes back as `None` where the sibling was busy through every window, since
-    a core the program had only half of gives a figure about the sharing rather than about the
-    program. The other three are the lowest readings of every window, busy or not: other work
-    raises them and cannot lower them.
+    Three of the four counts are the lowest readings of every window, busy or not: other work
+    raises them and cannot lower them. The cycle count is the lowest of the windows the sibling
+    thread left alone, and `None` where it left none, since a core the program had only half of
+    gives a figure about the sharing rather than about the program.
     """
     assert windows >= 1, windows
     machine_before = cpu_seconds("cpu")
     own_before = own_cpu_seconds()
     started = time.monotonic()
-    cycles = splits = instructions = ram_accesses = None
+    lowest = None
+    cycles = None
     for _ in range(windows):
-        window_cycles, sibling_busy, window_splits, window_instructions, window_ram_accesses = \
-            read_window(argv)
-        splits = lower_of(splits, window_splits)
-        instructions = lower_of(instructions, window_instructions)
-        ram_accesses = lower_of(ram_accesses, window_ram_accesses)
+        window, sibling_busy = read_window(argv)
+        lowest = window if lowest is None else lowest.lowest_with(window)
         if sibling_busy <= SIBLING_BUSY_LIMIT:
-            cycles = lower_of(cycles, window_cycles)
+            cycles = lower_of(cycles, window.cycles)
     elapsed = time.monotonic() - started
     others = (cpu_seconds("cpu") - machine_before) - (own_cpu_seconds() - own_before)
     # `/proc/stat` counts in whole ticks and the rusage clocks round, so a short measurement
-    # can put the difference slightly below zero.
+    # can put the difference slightly below zero. The span itself is positive for a measurement
+    # of a program, whose every window runs for at least `MINIMUM_WINDOW_SECONDS`; it is `0.0`
+    # only for the canned windows of `self_check`, which return without a clock running.
     contention = max(0.0, others) / elapsed if elapsed > 0 else 0.0
-    return instructions, ram_accesses, splits, cycles, contention
+    return lowest._replace(cycles=cycles), contention
 
 
 def cpu_model():
@@ -307,7 +326,7 @@ def cpu_model():
     return "unknown"
 
 
-def cycles_are_comparable(cycles, contention, ram_accesses, instructions):
+def cycles_are_comparable(counts, contention):
     """Whether a cycle count read under this much competition says more about the program than
     about the competition.
 
@@ -321,17 +340,28 @@ def cycles_are_comparable(cycles, contention, ram_accesses, instructions):
     reaches the count at all.
 
     # Arguments
-    * `cycles` - what `measure` returned, `None` where no window was the measurement's own.
-    * `ram_accesses`, `instructions` - the counts `measure` returned beside it, each the lowest
-      reading of its windows. Other work raises either count and lowers neither, so the rate they
-      give is the closest to the program's own that a busy machine offers.
+    * `counts` - what `measure` returned, whose `cycles` is `None` where no window was the
+      measurement's own. Its other counts are each the lowest reading of the windows, and other
+      work raises them and lowers none, so the rate they give is the closest to the program's own
+      that a busy machine offers.
     """
-    if cycles is None:
+    if counts.cycles is None:
         return False
     if contention <= QUIET_CONTENTION:
         return True
-    assert instructions > 0, instructions
-    return ram_accesses / instructions <= RAM_RATE_LIMIT
+    assert counts.instructions > 0, counts
+    return counts.ram_accesses / counts.instructions <= RAM_RATE_LIMIT
+
+
+def counter_line(counts, contention):
+    """The line this program prints for a measurement.
+
+    Every count reaches it whatever the machine was doing, and the cycle count only where nothing
+    else could have moved it; the field left empty there is what says so.
+    """
+    reported_cycles = str(counts.cycles) if cycles_are_comparable(counts, contention) else ""
+    return (f"{counts.instructions},{counts.ram_accesses},{counts.splits},{reported_cycles},"
+            f"{contention:.2f}")
 
 
 def take_options(argv):
@@ -373,14 +403,22 @@ def self_check():
     busy = QUIET_CONTENTION * 2
     below = int(RAM_RATE_LIMIT * 10 ** 9 / 2)
     above = int(RAM_RATE_LIMIT * 10 ** 9 * 2)
-    assert cycles_are_comparable(1, QUIET_CONTENTION / 2, above, 10 ** 9)
-    assert cycles_are_comparable(1, busy, below, 10 ** 9)
-    assert not cycles_are_comparable(1, busy, above, 10 ** 9)
+    def counted(cycles, ram_accesses):
+        return Counts(instructions=10 ** 9, ram_accesses=ram_accesses, splits=0, cycles=cycles)
+
+    assert cycles_are_comparable(counted(1, above), QUIET_CONTENTION / 2)
+    assert cycles_are_comparable(counted(1, below), busy)
+    assert not cycles_are_comparable(counted(1, above), busy)
     # Each limit is the most a reading may carry and still be kept.
-    assert cycles_are_comparable(1, QUIET_CONTENTION, above, 10 ** 9)
-    assert cycles_are_comparable(1, busy, int(RAM_RATE_LIMIT * 10 ** 9), 10 ** 9)
+    assert cycles_are_comparable(counted(1, above), QUIET_CONTENTION)
+    assert cycles_are_comparable(counted(1, int(RAM_RATE_LIMIT * 10 ** 9)), busy)
     # A count no window gave is no count, however little the program asks of main memory.
-    assert not cycles_are_comparable(None, QUIET_CONTENTION / 2, below, 10 ** 9)
+    assert not cycles_are_comparable(counted(None, below), QUIET_CONTENTION / 2)
+
+    # The line carries every count whatever the machine was doing, and withholds the cycle count
+    # where other work could have moved it.
+    assert counter_line(counted(7, below), busy) == f"1000000000,{below},0,7,{busy:.2f}"
+    assert counter_line(counted(7, above), busy) == f"1000000000,{above},0,,{busy:.2f}"
 
     # The options are the ones standing in front of the program; what follows the program is the
     # program's own, however it is spelled.
@@ -416,9 +454,8 @@ def self_check():
     real_monotonic, time.monotonic = time.monotonic, lambda: next(clock_readings)
     try:
         canned_runs[:] = [canned_run(70, 4, 5, 11, 8), canned_run(90, 3, 4, 10, 5)]
-        cycles, _sibling_busy, splits, instructions, ram_accesses = read_window(None)
-        assert (cycles, splits, instructions, ram_accesses) == (70, 7, 10, 5), \
-            (cycles, splits, instructions, ram_accesses)
+        window, _sibling_busy = read_window(None)
+        assert window == Counts(instructions=10, ram_accesses=5, splits=7, cycles=70), window
     finally:
         read_counters, time.monotonic = real_counters, real_monotonic
 
@@ -427,20 +464,24 @@ def self_check():
     # of. The window left out below carries the lowest count of the three, so `measure` letting it
     # through would show up here as that count. The other three counts are the lowest of every
     # window, including the ones the sibling was busy through.
-    canned = []
-    real, read_window = read_window, lambda argv: canned.pop(0)
+    canned_windows = []
+    real_window, read_window = read_window, lambda argv: canned_windows.pop(0)
     try:
-        canned[:] = [(90, 0.0, 9, 11, 5), (70, 1.0, 7, 10, 3),
-                     (80, SIBLING_BUSY_LIMIT, 4, 12, 6)]
-        instructions, ram_accesses, splits, cycles, _contention = measure(None, 3)
-        assert (instructions, ram_accesses, splits, cycles) == (10, 3, 4, 80), \
-            (instructions, ram_accesses, splits, cycles)
-        canned[:] = [(90, 1.0, 9, 11, 5), (70, 1.0, 7, 10, 3)]
-        instructions, ram_accesses, splits, cycles, _contention = measure(None, 2)
-        assert (instructions, ram_accesses, splits, cycles) == (10, 3, 7, None), \
-            (instructions, ram_accesses, splits, cycles)
+        canned_windows[:] = [
+            (Counts(instructions=11, ram_accesses=5, splits=9, cycles=90), 0.0),
+            (Counts(instructions=10, ram_accesses=3, splits=7, cycles=70), 1.0),
+            (Counts(instructions=12, ram_accesses=6, splits=4, cycles=80), SIBLING_BUSY_LIMIT),
+        ]
+        counts, _contention = measure(None, 3)
+        assert counts == Counts(instructions=10, ram_accesses=3, splits=4, cycles=80), counts
+        canned_windows[:] = [
+            (Counts(instructions=11, ram_accesses=5, splits=9, cycles=90), 1.0),
+            (Counts(instructions=10, ram_accesses=3, splits=7, cycles=70), 1.0),
+        ]
+        counts, _contention = measure(None, 2)
+        assert counts == Counts(instructions=10, ram_accesses=3, splits=7, cycles=None), counts
     finally:
-        read_window = real
+        read_window = real_window
 
 
 def main():
@@ -453,11 +494,8 @@ def main():
     if not argv:
         sys.exit("usage: perf_counters.py [--windows N] <program> [args...]\n"
                  "       perf_counters.py --cpu")
-    instructions, ram_accesses, splits, cycles, contention = measure(argv, windows)
-    # Only the cycle count is the machine's to move; the rest are reported whatever it was doing.
-    comparable = cycles_are_comparable(cycles, contention, ram_accesses, instructions)
-    reported_cycles = str(cycles) if comparable else ""
-    print(f"{instructions},{ram_accesses},{splits},{reported_cycles},{contention:.2f}")
+    counts, contention = measure(argv, windows)
+    print(counter_line(counts, contention))
 
 
 main()

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -8,7 +8,10 @@ than this measurement took while it ran, in cores.
 The instruction and split counts are decided by the program and its input, which is what makes
 them the columns a change to the compiler is read on. The runs here take a fixed environment with
 address-space randomization off, and under those eight runs of `nbody` read one split count and six
-of `iter_flatten` read one. A line-crossing access costs real time and an instruction count has no
+of `iter_flatten` read one. A handful of the split count belongs to where the path of the program
+put its stack rather than to the program: the same binary measured as `./ref_r`, `./ref_rust` and
+`./ref_rustxxxxx` read 461,525, 461,527 and 461,523, each of those three times over. Two languages
+whose split counts differ by a few are not two programs that differ. A line-crossing access costs real time and an instruction count has no
 notion of one -- an array whose elements start 8 bytes into a 16-byte-aligned allocation splits
 half of its 32-byte accesses. The RAM count moves with what else was in the cache. The cycle
 count is the one figure here that says how fast the machine gets through the work, which is where

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -49,7 +49,7 @@ from typing import NamedTuple
 # Keeping the list short matters -- asking for more events than the PMU has counters makes perf
 # time-slice them and report scaled estimates, which `read_counters` refuses. Cycles and
 # instructions sit on fixed counters, so three of these five compete for the general-purpose ones.
-SPLIT_EVENTS = ["mem_inst_retired.split_loads", "mem_inst_retired.split_stores"]
+SPLIT_EVENTS = ["mem_inst_retired.split_loads:u", "mem_inst_retired.split_stores:u"]
 CYCLE_EVENT = "cycles:u"
 INSTRUCTION_EVENT = "instructions:u"
 # Accesses that missed the last level cache, so their data came from main memory. This counts what
@@ -275,7 +275,7 @@ def read_window(argv):
         found = read_counters(argv)
         run = Counts(instructions=found[event_name(INSTRUCTION_EVENT)],
                      ram_accesses=found[event_name(RAM_EVENT)],
-                     splits=sum(found[e] for e in SPLIT_EVENTS),
+                     splits=sum(found[event_name(e)] for e in SPLIT_EVENTS),
                      cycles=found[event_name(CYCLE_EVENT)])
         lowest = run if lowest is None else lowest.lowest_with(run)
         elapsed = time.monotonic() - started
@@ -394,6 +394,10 @@ def self_check():
     assert event_name(CYCLE_EVENT) == "cycles", event_name(CYCLE_EVENT)
     assert event_name("mem_inst_retired.split_loads") == "mem_inst_retired.split_loads"
     assert len({event_name(e) for e in ALL_EVENTS}) == len(ALL_EVENTS), ALL_EVENTS
+    # Every event asks for user space alone. A machine whose `kernel.perf_event_paranoid` lets a
+    # program read the kernel's counts would otherwise answer one of them with a count of both,
+    # and nothing in the row would say which machine it came from.
+    assert all(e.endswith(":u") for e in ALL_EVENTS), ALL_EVENTS
 
     assert lower_of(None, 3) == 3
     assert lower_of(5, 3) == 3 and lower_of(3, 5) == 3

--- a/benchmark/speedtest/perf_counters.py
+++ b/benchmark/speedtest/perf_counters.py
@@ -80,6 +80,15 @@ QUIET_CONTENTION = 0.5
 # costs a row one figure where a case kept wrongly puts a figure in the log that reads like every
 # other one. What `cache-misses` counts belongs to the processor that counted it, so a machine
 # with a cache of another size is applying a number measured elsewhere.
+#
+# This numerator is the least steady figure the program reads: over the suite, six runs of a case
+# moved its instruction count by at most 0.0010% and its split count not at all, while its
+# `cache-misses` moved by as much as 4.6 times. The case that sits nearest the limit, `fib`, read
+# 7.44e-06 to 1.906e-05 over eight measurements at the five windows the harness uses -- on one
+# side of the limit, with 5% to spare. Read at one window it straddles, since fewer windows raise
+# the minimum: `--windows` moves this rate as well as the cycle count it gates. Narrowing that
+# would mean reading the rate from the window whose cycles are kept, which is a different
+# numerator and wants its own calibration on a machine with nothing else running.
 RAM_RATE_LIMIT = 0.00002
 
 # How much of a run the other thread of the measurement's core may be busy for. The two threads

--- a/benchmark/speedtest/reference.py
+++ b/benchmark/speedtest/reference.py
@@ -36,7 +36,8 @@ NO_COUNTERPART = 2
 
 # The Fix case is built for this host with every feature it has. The counterparts get the same
 # deal, so the comparison is between the languages rather than between the instruction sets they
-# were allowed to use.
+# were allowed to use. `../crosslang/build.sh` builds the same three programs for its own
+# question, and spells the same two recipes.
 BUILD = {
     "c": (["gcc", "-O3", "-march=native", "ref.c", "-o", "ref_c", "-lm"], "ref.c", "ref_c"),
     "rust": (["rustc", "-O", "-C", "target-cpu=native", "ref.rs", "-o", "ref_rust"],

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -85,7 +85,7 @@ ADDED_PASSES_NUM = 10
 
 # The measured command gets a fixed environment, so that start-up costs the same whatever shell the
 # search was launched from.
-MEASURE_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C"}
+MEASUREMENT_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C"}
 
 # Candidate passes, from `opt --print-passes`. See also:
 # https://gist.github.com/gingerBill/d889ae03d429653a4a9081ad6dc2a6c3
@@ -253,7 +253,7 @@ def cycles(binary):
     arch = subprocess.check_output(["uname", "-m"]).decode().strip()
     result = subprocess.run(
         ["setarch", arch, "-R", "perf", "stat", "-x,", "-e", "cycles:u", "--", str(binary)],
-        env=MEASURE_ENV, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+        env=MEASUREMENT_ENV, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
     for line in result.stderr.decode().splitlines():
         field = line.split(",")[0]
         if re.fullmatch(r"\d+", field):

--- a/passes_optimizer.py
+++ b/passes_optimizer.py
@@ -49,6 +49,11 @@ CASES_DIR = REPO / "benchmark/speedtest/cases"
 FIX = REPO / "target/release/fix"
 LOG_FILE = REPO / "passes_optimizer.log"
 
+# How long one run of a case may take before the search gives up on the pipeline that built it.
+# The cases return in under two seconds, and a candidate that miscompiles one into a loop that
+# never ends would otherwise hold the search there.
+RUN_TIMEOUT_SECONDS = 120
+
 # Where the best sequence found so far is recorded.
 LLVM_PASSES_BEST_FILE = REPO / "llvm_passes_best.txt"
 
@@ -249,11 +254,26 @@ def build(passes, cases, out_dir):
 
 
 def cycles(binary):
-    """User-mode core cycles for one run of `binary`, with ASLR off."""
+    """User-mode core cycles for one run of `binary`, with ASLR off, or `None` where the run
+    itself failed.
+
+    A candidate pipeline can build a program that dies when it runs or never returns -- the
+    `PASSES` list above holds three such passes, found that way -- and a search that carried the
+    failure out of here would end on that candidate instead of dropping it. `perf` exits with the
+    program's status, so a non-zero one is the program's.
+    """
     arch = subprocess.check_output(["uname", "-m"]).decode().strip()
-    result = subprocess.run(
-        ["setarch", arch, "-R", "perf", "stat", "-x,", "-e", "cycles:u", "--", str(binary)],
-        env=MEASUREMENT_ENV, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+    try:
+        result = subprocess.run(
+            ["setarch", arch, "-R", "perf", "stat", "-x,", "-e", "cycles:u", "--", str(binary)],
+            env=MEASUREMENT_ENV, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+            timeout=RUN_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        print(f"    {binary} did not return within {RUN_TIMEOUT_SECONDS}s", flush=True)
+        return None
+    if result.returncode != 0:
+        print(f"    {binary} exited with {result.returncode}", flush=True)
+        return None
     for line in result.stderr.decode().splitlines():
         field = line.split(",")[0]
         if re.fullmatch(r"\d+", field):
@@ -262,7 +282,8 @@ def cycles(binary):
 
 
 def compare(candidate, incumbent, rounds=ROUNDS):
-    """Cycles of `candidate` against `incumbent`, per case and as a geometric mean.
+    """Cycles of `candidate` against `incumbent`, per case and as a geometric mean, or `None`
+    where a program failed to run.
 
     The two are run alternately within each round, so a change in what else the machine is doing
     reaches both; each case's figure is its minimum over the rounds.
@@ -272,7 +293,10 @@ def compare(candidate, incumbent, rounds=ROUNDS):
     for _ in range(rounds):
         for case in cases:
             for label, binaries in (("candidate", candidate), ("incumbent", incumbent)):
-                best[case][label] = min(best[case][label], cycles(binaries[case]))
+                run = cycles(binaries[case])
+                if run is None:
+                    return None
+                best[case][label] = min(best[case][label], run)
     ratios = {case: best[case]["candidate"] / best[case]["incumbent"] for case in cases}
     geomean = math.exp(sum(math.log(r) for r in ratios.values()) / len(ratios))
     return geomean, ratios
@@ -296,7 +320,10 @@ def measure_noise(work_dir):
     second = build(INITIAL_PASSES, SEARCH_CASES, work_dir / "noise_b")
     if first is None or second is None:
         sys.exit("the shipped pipeline failed to build")
-    geomean, ratios = compare(first, second)
+    measured = compare(first, second)
+    if measured is None:
+        sys.exit("the shipped pipeline built a program that would not run")
+    geomean, ratios = measured
     print(f"  noise floor over {ROUNDS} rounds (two builds of one pipeline):")
     report(geomean, ratios, threshold=0.0)
     print(f"  IMPROVEMENT is {IMPROVEMENT}, i.e. {(IMPROVEMENT - 1) * 100:+.2f}%")
@@ -347,13 +374,23 @@ def optimize(work_dir, start):
             shutil.rmtree(candidate_dir, ignore_errors=True)
             continue
 
-        geomean, ratios = compare(candidate_binaries, optimum_binaries)
+        measured = compare(candidate_binaries, optimum_binaries)
+        if measured is None:
+            print("  the candidate built a program that would not run", flush=True)
+            shutil.rmtree(candidate_dir, ignore_errors=True)
+            continue
+        geomean, ratios = measured
         report(geomean, ratios)
         # A dropped pass is kept out on a tie: a shorter pipeline that measures the same is the
         # better one, and it gives the next add phase room.
         accepted = geomean < IMPROVEMENT if phase % 2 == 1 else geomean <= 1.0
         if accepted and phase % 2 == 1:
-            confirm_geomean, confirm_ratios = compare(candidate_binaries, optimum_binaries)
+            confirmed = compare(candidate_binaries, optimum_binaries)
+            if confirmed is None:
+                print("  the candidate built a program that would not run", flush=True)
+                shutil.rmtree(candidate_dir, ignore_errors=True)
+                continue
+            confirm_geomean, confirm_ratios = confirmed
             print("  confirming:")
             report(confirm_geomean, confirm_ratios)
             accepted = confirm_geomean < IMPROVEMENT
@@ -365,9 +402,13 @@ def optimize(work_dir, start):
         holdout = build(candidate, HOLDOUT_CASES, candidate_dir / "holdout")
         holdout_incumbent = build(optimum, HOLDOUT_CASES, optimum_dir / "holdout")
         if holdout is not None and holdout_incumbent is not None:
-            holdout_geomean, holdout_ratios = compare(holdout, holdout_incumbent)
-            print("  held-out cases (not used to choose):")
-            report(holdout_geomean, holdout_ratios)
+            held = compare(holdout, holdout_incumbent)
+            if held is None:
+                print("  a held-out case would not run", flush=True)
+            else:
+                holdout_geomean, holdout_ratios = held
+                print("  held-out cases (not used to choose):")
+                report(holdout_geomean, holdout_ratios)
 
         shutil.rmtree(optimum_dir, ignore_errors=True)
         optimum, optimum_dir, optimum_binaries = candidate, candidate_dir, candidate_binaries


### PR DESCRIPTION
#623 のレビューが ring 2 に置いた候補と、指摘のうちスイートが決着させられるものを片付ける。base は #623 のブランチ。対応する issue は無い。

この清掃が運ぶのは 2 種類の変更で、どちらに属するかを下に書き分けてある。

## 振る舞いを保つもの

### 4 つの計数を 1 つの型にまとめる (`refactor-scope` の指摘 4、`design-fit` の F6)

`read_window` と `measure` が 5 要素の位置タプルで計数を運び、その並びが 3 つの関数に書き写されていた。`measure` の呼び出しは行継続を要していた。6 本目のカウンタを足すには 6 か所を直す必要があった。

`Counts` という NamedTuple (フィールドは印字される順に `instructions` / `ram_accesses` / `splits` / `cycles`) に `lowest_with` を持たせ、両関数の畳み込みをそこへ寄せた。`read_window` の戻りは 2 つ、`measure` の戻りも 2 つになる。カウンタの追加は `ALL_EVENTS` の 1 行と `Counts` の 1 フィールドと `read_window` の 1 行で済む。

### 印字する行を関数にする (変異が赤にできなかった軸)

`main` が組み立てていた 1 行を `counter_line` に出した。変異で確かめると、この形になって初めて「門を通さずに cycles を印字する」と「欄の並びを入れ替える」の 2 つが `self_check` で赤くなる。行の並びを知る場所が 1 つ減るという `refactor-scope` の指摘 2 の一部でもある。

### 局所名 (`naming` の ring-2 候補)

`canned` -> `canned_windows`、`real` -> `real_window` (新設の `real_counters` / `real_monotonic` と揃える)、`main.fix` の `perf` -> `perf_fields` (stdout そのものと分割後の配列が同名だった)、`graph_html.py` の `h` -> `commit_hash`、`raw` -> `recorded`。

### item 名

`passes_optimizer.py` の `MEASURE_ENV` -> `MEASUREMENT_ENV`。`perf_counters.py` の同一内容の dict がその名である。

### 消したツールの名残 (`refactor-scope` の指摘 5、`design-fit` の F7)

`.gitignore` の `cachegrind.out.*` — この出力を作るものがリポジトリから無くなった。`benchmark/speedtest/cases/startup/main.fix` の「Cachegrind counts the dynamic loader ...」— ケースの存在理由を述べる文が、走らなくなったツールの名前で述べていた。中身は今も真なので、主語を計数器に替えた。

### 写しに互いを指す印 (`code-quality` の F7)

`reference.py` の `BUILD` と `benchmark/crosslang/build.sh` が、avx512 の除外が消えたことで同じ 2 つのレシピを綴るようになった。どちらにも相手を指すコメントが無かったので、双方に 1 行ずつ足した。

### 説明 (`code-quality` の指摘)

`graph_html.py` の `build_data` が、log の全列を歩いて「数でないセルは測定なし」として飛ばすことを書いた。`cpu` と `contention` の列がこれで落ちるので、この既定値は防御ではなく仕組みの一部である。

## 続けていたところで止まるもの

有効な入力に対して何が計算されるかは変わらない。変わるのは、破れた不変条件がそこで止まるようになることである。

### `reference.py` の失敗を飲んでいた 3 か所 (`code-quality` の F2 / F4、ring-2 候補 3・4)

1. **counterpart がコンパイルできないとき** — `main.fix` がビルドの終了コードを捨てていた。gcc や rustc の無い機械と、壊れた `ref.c` が区別できていなかった。`reference.py` が「この言語の counterpart が無い」に使う 2 と、それ以外を分けて止まるようにした。
2. **counterpart が自分の答えの検査に落ちたとき** — `reference.py` が「チャートの数字にならず失敗になる」と言って出す終了コードを、`main.fix` が `ref_code != 0` で握り潰していた。同じ分け方で止まる。
3. **perf が「カウンタに載っていた割合」に数でないものを返したとき** — `except ValueError: pass` が、そのすぐ上のコードが拒否している *scaled estimate* を黙って受け入れていた。何が返ったかを言って落ちるようにした。

## 確かめたこと

- `perf_counters.py --cpu` と `graph_html.py` の `self_check`、`fix build`、`bash -n` (2 つの shell script) が通る。
- ケースを 2 つに絞ってハーネスを端から端まで走らせた。この清掃を当てた状態でも同じ数字が出る。走らせた機械が忙しかった (11.08 コア) ので両方のサイクル数が withhold され、警告がそう述べる — 門が働いていることも見えた。
- **変異 10 種類のすべてが `self_check` を赤にする。**この清掃で畳み込みの形が変わったので、#623 で測った 8 つを測り直し、`counter_line` の 2 つを足した。
