### PR TITLE
符号付き整数の溢れを未定義にし、nsw を渡す (#477)

### DIFF
--- a/src/fixstd/builtin.rs
+++ b/src/fixstd/builtin.rs
@@ -10161,6 +10161,13 @@ pub fn add_trait_id() -> TraitId {
     }
 }
 
+/// Whether Fix promises that arithmetic on `ty` does not wrap, which lets the generated
+/// instruction carry `nsw`. A signed integer operation whose mathematical result leaves the range
+/// of its type is undefined; an unsigned one wraps around.
+fn arithmetic_never_wraps(ty: &Arc<TypeNode>) -> bool {
+    ty.toplevel_tycon().unwrap().is_signed_integer()
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InlineLLVMIntAddBody {
     lhs_name: FullName,
@@ -10174,10 +10181,15 @@ impl LLVMGen for InlineLLVMIntAddBody {
         let rhs = gc.get_scoped_obj(&self.rhs_name);
         let lhs_val = lhs.extract_field(gc, 0).into_int_value();
         let rhs_val = rhs.extract_field(gc, 0).into_int_value();
-        let value = gc
-            .builder()
-            .build_int_add(lhs_val, rhs_val, ADD_TRAIT_ADD_NAME)
-            .unwrap();
+        let value = if arithmetic_never_wraps(&lhs.ty) {
+            gc.builder()
+                .build_int_nsw_add(lhs_val, rhs_val, ADD_TRAIT_ADD_NAME)
+                .unwrap()
+        } else {
+            gc.builder()
+                .build_int_add(lhs_val, rhs_val, ADD_TRAIT_ADD_NAME)
+                .unwrap()
+        };
         let obj = create_obj(
             lhs.ty.clone(),
             &vec![],
@@ -10315,10 +10327,15 @@ impl LLVMGen for InlineLLVMIntSubBody {
         let rhs = gc.get_scoped_obj(&self.rhs_name);
         let lhs_val = lhs.extract_field(gc, 0).into_int_value();
         let rhs_val = rhs.extract_field(gc, 0).into_int_value();
-        let value = gc
-            .builder()
-            .build_int_sub(lhs_val, rhs_val, SUBTRACT_TRAIT_SUBTRACT_NAME)
-            .unwrap();
+        let value = if arithmetic_never_wraps(&lhs.ty) {
+            gc.builder()
+                .build_int_nsw_sub(lhs_val, rhs_val, SUBTRACT_TRAIT_SUBTRACT_NAME)
+                .unwrap()
+        } else {
+            gc.builder()
+                .build_int_sub(lhs_val, rhs_val, SUBTRACT_TRAIT_SUBTRACT_NAME)
+                .unwrap()
+        };
         let obj = create_obj(
             lhs.ty.clone(),
             &vec![],
@@ -10456,10 +10473,15 @@ impl LLVMGen for InlineLLVMIntMulBody {
         let rhs = gc.get_scoped_obj(&self.rhs_name);
         let lhs_val = lhs.extract_field(gc, 0).into_int_value();
         let rhs_val = rhs.extract_field(gc, 0).into_int_value();
-        let value = gc
-            .builder()
-            .build_int_mul(lhs_val, rhs_val, MULTIPLY_TRAIT_MULTIPLY_NAME)
-            .unwrap();
+        let value = if arithmetic_never_wraps(&lhs.ty) {
+            gc.builder()
+                .build_int_nsw_mul(lhs_val, rhs_val, MULTIPLY_TRAIT_MULTIPLY_NAME)
+                .unwrap()
+        } else {
+            gc.builder()
+                .build_int_mul(lhs_val, rhs_val, MULTIPLY_TRAIT_MULTIPLY_NAME)
+                .unwrap()
+        };
         let obj = create_obj(
             lhs.ty.clone(),
             &vec![],
@@ -10826,10 +10848,15 @@ impl LLVMGen for InlineLLVMIntNegBody {
     fn generate<'c, 'm>(&self, gc: &mut Generator<'c, 'm>, _ty: &Arc<TypeNode>) -> Object<'c> {
         let rhs = gc.get_scoped_obj(&self.rhs_name);
         let rhs_val = rhs.extract_field(gc, 0).into_int_value();
-        let value = gc
-            .builder()
-            .build_int_neg(rhs_val, NEGATE_TRAIT_NEGATE_NAME)
-            .unwrap();
+        let value = if arithmetic_never_wraps(&rhs.ty) {
+            gc.builder()
+                .build_int_nsw_neg(rhs_val, NEGATE_TRAIT_NEGATE_NAME)
+                .unwrap()
+        } else {
+            gc.builder()
+                .build_int_neg(rhs_val, NEGATE_TRAIT_NEGATE_NAME)
+                .unwrap()
+        };
         let obj = create_obj(
             rhs.ty.clone(),
             &vec![],

--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -335,7 +335,7 @@ namespace Array {
     find_by = |cond, arr| (
         let len = arr.@size;
         loop(0, |idx| (
-            if idx == len { break $ Option::none $ () };
+            if idx >= len { break $ Option::none $ () };
             if cond(arr.@(idx)) { break $ Option::some $ idx };
             continue $ idx + 1
         ))
@@ -570,7 +570,7 @@ namespace Array {
         range(start + 1, start + n).fold(arr, |i, arr| (
             let v = arr.@(i);
             loop((arr, i), |(arr, j)|
-                if j == start { 
+                if j <= start { 
                     break $ arr.set(start, v)
                 };
                 let w = arr.@(j-1);
@@ -710,8 +710,8 @@ namespace Array {
     // - `into`: The array to write the merged elements into.
     _merge_runs : ((a, a) -> Bool) -> I64 -> I64 -> I64 -> I64 -> I64 -> Array a -> Array a -> Array a;
     _merge_runs = |less_than, former_pos, former_end, latter_pos, latter_end, into_pos, from, into| (
-        if former_pos == former_end { into._unsafe_copy_range_bounds_unchecked(from, latter_pos, latter_end, into_pos) };
-        if latter_pos == latter_end { into._unsafe_copy_range_bounds_unchecked(from, former_pos, former_end, into_pos) };
+        if former_pos >= former_end { into._unsafe_copy_range_bounds_unchecked(from, latter_pos, latter_end, into_pos) };
+        if latter_pos >= latter_end { into._unsafe_copy_range_bounds_unchecked(from, former_pos, former_end, into_pos) };
         let former_elem = from.@(former_pos);
         let latter_elem = from.@(latter_pos);
         if !less_than((latter_elem, former_elem)) { // Essential for stability.
@@ -738,7 +738,7 @@ namespace Array {
     // - `dst`: The array to write the elements into.
     _unsafe_copy_range_bounds_unchecked : Array a -> I64 -> I64 -> I64 -> Array a -> Array a;
     _unsafe_copy_range_bounds_unchecked = |src, begin, end, dst_begin, dst| (
-        if begin == end { dst };
+        if begin >= end { dst };
         dst.unsafe_set_bounds_unchecked(dst_begin, src._unsafe_get_bounds_unchecked(begin))
            ._unsafe_copy_range_bounds_unchecked(src, begin + 1, end, dst_begin + 1)
     );
@@ -843,7 +843,7 @@ impl [a : Eq] Array a : Eq {
         if lhs.@size != rhs.@size { false };
         let len = lhs.@size;
         loop(0, |idx| (
-            if idx == len { break $ true };
+            if idx >= len { break $ true };
             if lhs.@(idx) != rhs.@(idx) { break $ false };
             continue $ idx + 1
         ))
@@ -856,9 +856,9 @@ impl [a : Eq] Array a : Eq {
 impl [a : Eq, a : LessThan] Array a : LessThan {
     less_than = |lhs, rhs| (
         loop(0, |i| (
-            if i == lhs.@size && i == rhs.@size { break $ false };
-            if i == lhs.@size { break $ true };
-            if i == rhs.@size { break $ false };
+            if i >= lhs.@size && i >= rhs.@size { break $ false };
+            if i >= lhs.@size { break $ true };
+            if i >= rhs.@size { break $ false };
             let l = lhs.@(i);
             let r = rhs.@(i);
             if l != r { break $ l < r };
@@ -873,9 +873,9 @@ impl [a : Eq, a : LessThan] Array a : LessThan {
 impl [a : Eq, a : LessThanOrEq] Array a : LessThanOrEq {
     less_than_or_eq = |lhs, rhs| (
         loop(0, |i| (
-            if i == lhs.@size && i == rhs.@size { break $ true };
-            if i == lhs.@size { break $ true };
-            if i == rhs.@size { break $ false };
+            if i >= lhs.@size && i >= rhs.@size { break $ true };
+            if i >= lhs.@size { break $ true };
+            if i >= rhs.@size { break $ false };
             let l = lhs.@(i);
             let r = rhs.@(i);
             if l != r { break $ l <= r };
@@ -889,7 +889,7 @@ impl Array : Functor {
         let n = arr.@size;
         let res = Array::empty(n);
         loop((0, res), |(i, res)| (
-            if i == n { break $ res };
+            if i >= n { break $ res };
             let e = f $ arr.@(i);
             continue $ (i+1, res.push_back(e))
         ))
@@ -902,7 +902,7 @@ impl Array : Monad {
         let size = arr.@size;
         let arr_arr = Array::empty(size);
         let (arr_arr, count) = loop((0, arr_arr, 0), |(idx, arr_arr, count)| (
-            if idx == size { break $ (arr_arr, count) };
+            if idx >= size { break $ (arr_arr, count) };
             let inner = f $ arr.@(idx);
             let count = count + inner.@size;
             let arr_arr = arr_arr.push_back(inner);
@@ -910,10 +910,10 @@ impl Array : Monad {
         ));
         let ret = Array::empty(count);
         loop((0, ret), |(i, ret)| (
-            if i == size { break $ ret };
+            if i >= size { break $ ret };
             let inner = arr_arr.@(i);
             continue $ loop((0, ret), |(j, ret)|(
-                if j == inner.@size {
+                if j >= inner.@size {
                     break $ (i + 1, ret)
                 } else {
                     let ret = ret.push_back(inner.@(j));
@@ -1357,7 +1357,7 @@ namespace IO {
         let argc = *get_arg_count;
         let args = Array::empty(argc);
         loop_m((args, 0), |(args, idx)| (
-            if idx == argc { break_m $ args };
+            if idx >= argc { break_m $ args };
             let arg = (*get_arg(idx)).as_some;
             continue_m $ (args.push_back(arg), idx + 1)
         ))
@@ -3037,7 +3037,7 @@ namespace String {
         type Item StringBytesIterator = U8;
         advance = |it| (
             let i = it.@_i;
-            if i == it.@_s.@size { none() };
+            if i >= it.@_s.@size { none() };
             let c = it.@_s[i].iget;
             let it = it[^_i].imod(add(1));
             (it, c).some
@@ -3158,7 +3158,7 @@ namespace String {
         advance = |iter| (
             let StringSplitIterator { idx: idx, str: str, strlen: strlen, sep: sep, sep_len: sep_len } = iter;
             if sep_len == 0 {
-                if idx == strlen { none() };
+                if idx >= strlen { none() };
                 let c_str = String::from_U8 $ str.get_bytes.@(idx);
                 some $ (iter.set_idx(idx + 1), c_str)
             };
@@ -3195,7 +3195,7 @@ namespace String {
         let len = str.@size;
         let bytes = str.get_bytes;
         let n = loop(0, |i| (
-            if i == len { break $ i };
+            if i >= len { break $ i };
             if !cond(bytes.@(i)) { break $ i };
             continue $ i + 1
         ));
@@ -3274,7 +3274,7 @@ namespace String {
         let end = template.@size - 1;
         let out = [];
         let (out, vi) = loop((out, 0, 0), |(out, i, vi)|
-            if i == end { break $ (out, vi) };
+            if i >= end { break $ (out, vi) };
             let c = template.@(i);
 
             // replace "{{" to "{"

--- a/src/object.rs
+++ b/src/object.rs
@@ -334,9 +334,11 @@ impl ObjectFieldType {
             .build_load(counter_type, counter_ptr, "counter_val")
             .unwrap()
             .into_int_value();
+        // A count the caller computed as a difference can come out negative, and `SGE` ends the
+        // loop at once there; `EQ` would step past it and walk the heap without bound.
         let is_end = gc
             .builder()
-            .build_int_compare(IntPredicate::EQ, counter_val, size, "is_end")
+            .build_int_compare(IntPredicate::SGE, counter_val, size, "is_end")
             .unwrap();
         gc.builder()
             .build_conditional_branch(is_end, after_loop_bb, loop_body_bb)


### PR DESCRIPTION
Closes #477
Refs #470

**この PR は 3 つの独立した梃子を 1 commit ずつ持っています。**どれを採るかは別々に決められます。#470 が 8 候補を測って `nsw` を落としたとき、「利用者に見える `+` に付けるかは Fix の整数演算で折り返しをどう決めるかという言語の判断」として保留した部分が、1 つ目です。

| commit | 何をするか | 命令数 (幾何平均) |
| --- | --- | --- |
| [`dfd751cb`](https://github.com/tttmmmyyyy/fixlang/commit/dfd751cb) | 符号付き整数の `Add`/`Sub`/`Mul`/`Neg` に `nsw` | **-0.49%** |
| [`536614f3`](https://github.com/tttmmmyyyy/fixlang/commit/536614f3) | Std の数える 16 ループを `==` -> `>=` | +0.01% (中立) |
| [`feb808f2`](https://github.com/tttmmmyyyy/fixlang/commit/feb808f2) | `loop_over_array_buf` を `EQ` -> `SGE` (#477) | **+0.07%** |

参考: 境界検査を全部消す (`--no-runtime-check`) と -3.38% です。つまり `nsw` が取れるのは、境界検査が持っている余地の **1/7** です。

## 言語の契約が変わります

**符号付き整数の演算が、その型の範囲を出たときの結果を未定義にします。**`I64::maximum + 1` に答えがなくなり、それを含むプログラムはコンパイラが何を出しても正しいことになります。符号なし (`U8`..`U64`) は今までどおり折り返します。

これが判断の中心で、作者が「I64 は UB にしていい」と決めたので実装しました。**この branch はまだその契約をマニュアルに書いていません** — 下の「持っていないもの」を参照してください。

## 測り方

perf の `instructions:u`、`env -i PATH=/usr/bin:/bin LC_ALL=C setarch x86_64 -R` の下で 3 回の最小値。speedtest 56 ケース、`-O max --emit-symbols --disable-cpu-feature avx512.*`。

**この数字は cachegrind ではなく perf です。**測った当時 `main` のハーネスは cachegrind で測っており、その `Ir` は実行していない命令を数えることがあると分かったので (#623)、自前の perf スクリプトで測り直したものです。今の `main` のハーネスと同じ指標ですが、**ケースの建て方が違います**: 当時は avx512 を切っており、#623 がそれをやめたので、今日このコーパスを測れば全部の数字が動きます。相対の比較としては有効です。

## `nsw` が実際に落とすもの

### 境界検査 — 291 個中 3 個

`-O max` の最適化後 IR に残る `fixruntime_index_out_of_range` の呼び出しを数えました。

| ケース | before | after | 命令数 |
| --- | --- | --- | --- |
| `levenshtein` | 4 | **3** | **-7.09%** |
| `sort_stable` | 14 | **13** | +0.38% |
| `sort_stable_ordered` | 14 | **13** | +0.73% |
| 合計 (56 ケース) | 291 | 288 | |

**`levenshtein` の機構**: 内側の DP ループは `i` を 1 から `m` まで進め、`prev.@(i)` / `cur.@(i-1)` / `prev.@(i-1)` / `a.@(i-1)` を読み `cur.set(i, d)` を書きます。`i-1` と `i+1` が折り返さないと分かると `1 <= i <= m` が出て、`prev` の大きさ `m+1` に収まると証明できます。残る 3 件はループ外へ巻き上げられた冷たい検査で、うち 1 件はループ脱出条件と融合しています。

### 境界検査ではない、最大の勝ち

**`push_back` -19.92%。**`Array::reserve` の早期 return が消えます。

```
reserve = |cap, arr| (
    if cap <= arr.@capacity { arr };        // <- これが到達不能になる
    arr._unsafe_set_capacity_bounds_unchecked(cap)
);
```

呼び手の `push_back` は `arr.@capacity < len + 1` の枝で `reserve(2*(len+1))` を呼びます。`2*(len+1)` が折り返さないなら `2*(len+1) > @capacity` は必ず成り立つので、この早期 return には到達しません。合流ブロックの前任者が 1 つ減り、**熱いループが x86 で 9 命令から 7 命令**になります (callgrind の番地別計数、9 つの番地 x 100,000 周 -> 7 つ)。

### Std が書いた見張りが 1 つ死にます

`cp_lib_prime_list` で「配列の大きさが負」の abort が **2 個から 1 個**に減りました。溢れを見張るために書かれた検査が、溢れが UB になったことで到達不能になる、という契約の帰結です。`fixruntime_array_size_overflow` の 33 件は 56 ケース全体で変わりません。

### 退行 4 件 (4 回測って再現)

`sort_few_values` +1.30%、`cp_lib_dijkstra` +0.68%、`sort` +0.44%、`sort_stable` +0.38%。`sort` は 19,597,126 対 19,684,010 で安定しています。追っていません。

## 2 つ目と 3 つ目の梃子

**Std の `==` -> `>=`** は、このコーパスでは中立でした (nsw だけ -0.49% に対し、足して -0.48%)。個別には `sort_ordered` -0.84% と `cp_lib_unionfind` +0.46% が並びます。2026-07-18 に `ArrayIterator` / `RangeIterator` / `RangeStepIterator` を `>=` にしたときは -67% から -80% でしたが、そこで取り残されていた 16 か所は、このコーパスがあまり通らない関数でした。**性能ではなく、行き過ぎたカウンタでも止まるという頑健さの側の変更**と読むのが正しいと思います。

**`loop_over_array_buf` の `SGE`** は #477 が求めている直しそのもので、代償は **+0.07%** (最悪 `cp_lib_lsegtree` +3.28%、`fannkuch` +1.12%) でした。#477 は「コーパスの計測が要る」と書いており、これがその数字です。**この commit を落とすなら #477 は閉じません。**

## 触った item

**[`arithmetic_never_wraps`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/builtin.rs#L10167-L10169)** (追加)

- **役割**: その型の演算が折り返さないと Fix が約束しているか。約束しているとき、生成する命令に `nsw` が載る。
- **呼び手**: 下の 4 つの `generate`。

**[`InlineLLVMIntAddBody`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/builtin.rs#L10178-L10227) / [`Sub`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/builtin.rs#L10324-L10373) / [`Mul`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/builtin.rs#L10470-L10519) / [`Neg`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/builtin.rs#L10847-L10890) の `generate`** (変更)

- **役割**: `Std::Add::add` などのトレイトメンバの本体を生成する。
- **変更**: 同じ 1 つの機械的な変更が 4 つに入る。`build_int_add` を、符号付きなら `build_int_nsw_add` に、そうでなければ元のままに分ける。同じファイルの `InlineLLVMIntDivBody` が `is_signed` で `signed_div` と `unsigned_div` を分けているのと同じ形。
- **目的**: 契約を LLVM に渡すこと。

**[`ObjectFieldType::loop_over_array_buf`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/object.rs#L282-L379)** (変更)

- **役割**: 配列の要素バッファを 0 から要素数まで歩き、要素ごとに本体を生成する。解放・複製・穴あきの走査がここを通る。
- **変更**: 終了条件が `EQ` から `SGE` へ。
- **目的**: `array_buf_after_hole` が `size - hole - 1` を、`release_or_mark_array_slice` が `end - begin` を渡すので、要素数は負になり得る。`EQ` では等しくなる瞬間が来ず、ループが 0 から上へ回り続けてヒープを際限なく舐める。

**`src/fixstd/std.fix` の 16 か所** (変更)

数える反復が終わる条件を `==` から `>=` (下へ数える 1 か所は `<=`) へ。同じ 1 つの変更が次の item に入ります: [`Array::find_by`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L335)、[`Array::_insertion_sort_by_ranged`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L567) (`<=` の 1 か所)、[`Array::_merge_runs`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L712) (2 か所)、[`Array::_unsafe_copy_range_bounds_unchecked`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L740)、[`Array : Eq`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L842)、[`Array : LessThan`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L857) (3 か所)、[`Array : LessThanOrEq`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L874) (3 か所)、[`Array : Functor`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L888)、[`Array : Monad`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L901) (3 か所)、[`IO::get_args`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L1357)、[`StringBytesIterator::advance`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L3038)、[`StringSplitIterator::advance`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L3158)、[`String::strip_first_bytes`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L3194)、[`String::populate`](https://github.com/tttmmmyyyy/fixlang/blob/feb808f2f563f4e8eded25e4fca504403cdc13de/src/fixstd/std.fix#L3272)。

どれもカウンタが 1 ずつ動くので `>=` は同じ場所で止まり、加えて**行き過ぎたカウンタでも止まります**。`String::populate` だけはカウンタが 2 進む枝を持ちますが、その枝は `i + 1 < end` を確かめてから入るので、今でも行き過ぎません。

## テスト

**この branch はテストを 1 本も足していません。**全スイート **1,690 + 185、0 failed** (3 commit すべて当てた状態、release) を確認しただけです。

契約そのもの (「折り返した結果は未定義」) は、未定義な振る舞いなので押さえようがありません。押さえられるのは**生成する IR に `nsw` が載ること**で、Fix のプログラムを `--emit-llvm` で建てて最適化前の `.ll` に `add nsw` が現れることを見る形になります。書いていません。

## この branch が持っていないもの

1. **`Document.md` と `Document-ja.md` の契約。**今どちらも overflow について 1 語も書いていません (`grep -i overflow Document.md` が 0 件)。案: 「An arithmetic operation on a signed integer type whose mathematical result falls outside the range of that type has no defined result. An operation on an unsigned integer type wraps around.」
2. **`CHANGELOG.md` の項目。**言語の規則が変わるので `### Changed` / `#### Language` に要ります。
3. **退行 4 件の追跡。**
4. **`nsw` を `Div` / `Rem` / シフトに広げるかの判断。**この branch は `Add`/`Sub`/`Mul`/`Neg` だけです。`I64::minimum / -1` も契約上は未定義になりますが、`build_int_signed_div` に `exact` を付ける話とは別で、触っていません。
5. **LangArena での再測。**speedtest 56 ケースだけです。
