### PR TITLE
バグハント: 半分どうしが同じメソッドに答える組を、smell として名指す

### DIFF
--- a/.claude/skills/bug-hunt/SKILL.md
+++ b/.claude/skills/bug-hunt/SKILL.md
@@ -157,6 +157,21 @@ The same information lives in two representations kept in sync by convention rat
 
 A hand-written declaration binds a separate code path with no compiler link between them — an ownership or borrow annotation a pass must match, an arity or field count, the order a match's arms must keep. Derive both the declaration and the code from the same monomorphized source and assert they agree, or inject a deliberate mismatch and see whether anything catches it before code generation. Where the two can drift, the drift is the bug.
 
+#### Read a pair by index where its two halves answer the same methods
+
+A tuple, or a list of them, whose components are different kinds that happen to share an accessor
+surface: a pattern and an expression that both answer `is_var()` and `get_var()`, a key and a value
+that both answer `name()`, a declared and an inferred type that both answer `to_string()`. `.0` and
+`.1` then both typecheck wherever either is meant, so reading the wrong half compiles, runs, and
+survives review: the reader checks that the right test is applied, and which half it lands on goes
+unread. Find the accesses written by index, read the contract the surrounding comment or doc states,
+and check the half against the tuple's own definition.
+
+A hit leaves a second question: which side is wrong, the code or the sentence describing it. Answer
+it from the siblings — the other arms of the same table, walk or match say what the quantity means,
+and they outvote one comment. Answering it backwards turns a one-character fix into a program-wide
+change in the wrong direction.
+
 #### Exploit a path no test reaches
 
 Untested code is where a latent bug survives, because a tested path carrying a bug would already have failed — so a gap in the suite is a map to where the bugs are. Enumerate the cases the target handles — the match arms, the error branches, the boundaries (empty, one element, the degenerate shape), the opt-level and config combinations — and cross off the ones a test exercises; a coverage tool (`cargo-llvm-cov`) mechanizes the same census. Craft the input that drives execution into what is left, run it, and read the result with a detector. This is the `test-sufficiency` review lens turned offensive: that aspect flags the gap for the author, a hunt shoots into it.


### PR DESCRIPTION
バグハントの技法節に smell を 1 件足す。第 57 波が出した欠陥のうち 1 件が、既存のどの項目にも
当たらない仕組みで生き延びていたため。

## 足した項目

**`#### Read a pair by index where its two halves answer the same methods`**

2 つの成分が別の種類でありながら同じアクセサを持つ組 — `is_var()` と `get_var()` の両方に答える
パターンと式、`name()` に答える鍵と値 — を添字で読むと、`.0` と `.1` のどちらを書いても型検査を
通る。取り違えはコンパイル・実行・レビューのすべてを素通りする。レビューアが確かめるのは
「正しい検査が当てられているか」であって、「どちらの半分に当たっているか」は読まれないからである。

項目は探し方 (添字で書かれたアクセスを拾い、周囲のコメントが述べる契約を読み、組の定義と
突き合わせる) と、当たったあとの二つ目の問い (コードと文のどちらが誤っているか) の答え方を述べる。
後者の答えは兄弟から出る — 同じ表・走査・match の他の腕がその量の意味を言い、一つのコメントより
強い。逆に答えると、1 文字の修正が向きを誤った全面的な変更になる。

## この項目を生んだ欠陥

`src/optimization/inline.rs` の `InlineCostCalculator::end_visit_match` は、コメントが腕の
**パターン**を述べている位置で腕の**値**を読んでいる。`get_match_pat_vals()` が返すのは
`Vec<(Arc<PatternNode>, Arc<ExprNode>)>` で、コードは `.1` を見る。`PatternNode` と `ExprNode` が
どちらも `is_var()` と `get_var().name` を持つため、`.0` と書いても `.1` と書いても通る。

どちらが正しいかは兄弟が言う。このコスト計算が測っているのは生成されるコードの量であり、
型注釈は 0 (「A type annotation counts nothing」)、ローカル変数の参照も 0 と数えられている。
その基準では、パターンが素の名前である 1 腕 `match` は何も生まないので 0、値を分解する `match` は
分解を生むので 0 ではない。つまりコメントの側が正しい。

## 既存の項目で覆われていない理由

**`#### Exploit a fact stored in two places`** は、同じ事実の 2 つの写しが規約でしか同期して
いない形を述べる。同波のもう 1 件 (RC IR dump の operand 順が operand index と食い違う、78 impl 中
19 件) はこの項目がそのまま当たる — 項目本文が「an operand name embedded in an operation and
repeated in its separate argument list」を例として挙げている。

**`#### Exploit a declaration divorced from the code that must honor it`** は、宣言とそれを守る
別経路の間にコンパイラの結び付きが無い形を述べる。

今回の形はどちらでもない。写しは 1 つしかなく、宣言と実装も離れていない。誤っているのは
**1 つのアクセスがどちらの半分を指すか**であり、それを型検査が捕まえない。
