### PR TITLE
Std の数える 16 ループを不等号で終わらせる

### DIFF
--- a/src/fixstd/std.fix
+++ b/src/fixstd/std.fix
@@ -335,7 +335,7 @@ namespace Array {
     find_by = |cond, arr| (
         let len = arr.@size;
         loop(0, |idx| (
-            if idx == len { break $ Option::none $ () };
+            if idx >= len { break $ Option::none $ () };
             if cond(arr.@(idx)) { break $ Option::some $ idx };
             continue $ idx + 1
         ))
@@ -570,7 +570,7 @@ namespace Array {
         range(start + 1, start + n).fold(arr, |i, arr| (
             let v = arr.@(i);
             loop((arr, i), |(arr, j)|
-                if j == start { 
+                if j <= start { 
                     break $ arr.set(start, v)
                 };
                 let w = arr.@(j-1);
@@ -710,8 +710,8 @@ namespace Array {
     // - `into`: The array to write the merged elements into.
     _merge_runs : ((a, a) -> Bool) -> I64 -> I64 -> I64 -> I64 -> I64 -> Array a -> Array a -> Array a;
     _merge_runs = |less_than, former_pos, former_end, latter_pos, latter_end, into_pos, from, into| (
-        if former_pos == former_end { into._unsafe_copy_range_bounds_unchecked(from, latter_pos, latter_end, into_pos) };
-        if latter_pos == latter_end { into._unsafe_copy_range_bounds_unchecked(from, former_pos, former_end, into_pos) };
+        if former_pos >= former_end { into._unsafe_copy_range_bounds_unchecked(from, latter_pos, latter_end, into_pos) };
+        if latter_pos >= latter_end { into._unsafe_copy_range_bounds_unchecked(from, former_pos, former_end, into_pos) };
         let former_elem = from.@(former_pos);
         let latter_elem = from.@(latter_pos);
         if !less_than((latter_elem, former_elem)) { // Essential for stability.
@@ -738,7 +738,7 @@ namespace Array {
     // - `dst`: The array to write the elements into.
     _unsafe_copy_range_bounds_unchecked : Array a -> I64 -> I64 -> I64 -> Array a -> Array a;
     _unsafe_copy_range_bounds_unchecked = |src, begin, end, dst_begin, dst| (
-        if begin == end { dst };
+        if begin >= end { dst };
         dst.unsafe_set_bounds_unchecked(dst_begin, src._unsafe_get_bounds_unchecked(begin))
            ._unsafe_copy_range_bounds_unchecked(src, begin + 1, end, dst_begin + 1)
     );
@@ -843,7 +843,7 @@ impl [a : Eq] Array a : Eq {
         if lhs.@size != rhs.@size { false };
         let len = lhs.@size;
         loop(0, |idx| (
-            if idx == len { break $ true };
+            if idx >= len { break $ true };
             if lhs.@(idx) != rhs.@(idx) { break $ false };
             continue $ idx + 1
         ))
@@ -856,9 +856,9 @@ impl [a : Eq] Array a : Eq {
 impl [a : Eq, a : LessThan] Array a : LessThan {
     less_than = |lhs, rhs| (
         loop(0, |i| (
-            if i == lhs.@size && i == rhs.@size { break $ false };
-            if i == lhs.@size { break $ true };
-            if i == rhs.@size { break $ false };
+            if i >= lhs.@size && i >= rhs.@size { break $ false };
+            if i >= lhs.@size { break $ true };
+            if i >= rhs.@size { break $ false };
             let l = lhs.@(i);
             let r = rhs.@(i);
             if l != r { break $ l < r };
@@ -873,9 +873,9 @@ impl [a : Eq, a : LessThan] Array a : LessThan {
 impl [a : Eq, a : LessThanOrEq] Array a : LessThanOrEq {
     less_than_or_eq = |lhs, rhs| (
         loop(0, |i| (
-            if i == lhs.@size && i == rhs.@size { break $ true };
-            if i == lhs.@size { break $ true };
-            if i == rhs.@size { break $ false };
+            if i >= lhs.@size && i >= rhs.@size { break $ true };
+            if i >= lhs.@size { break $ true };
+            if i >= rhs.@size { break $ false };
             let l = lhs.@(i);
             let r = rhs.@(i);
             if l != r { break $ l <= r };
@@ -889,7 +889,7 @@ impl Array : Functor {
         let n = arr.@size;
         let res = Array::empty(n);
         loop((0, res), |(i, res)| (
-            if i == n { break $ res };
+            if i >= n { break $ res };
             let e = f $ arr.@(i);
             continue $ (i+1, res.push_back(e))
         ))
@@ -902,7 +902,7 @@ impl Array : Monad {
         let size = arr.@size;
         let arr_arr = Array::empty(size);
         let (arr_arr, count) = loop((0, arr_arr, 0), |(idx, arr_arr, count)| (
-            if idx == size { break $ (arr_arr, count) };
+            if idx >= size { break $ (arr_arr, count) };
             let inner = f $ arr.@(idx);
             let count = count + inner.@size;
             let arr_arr = arr_arr.push_back(inner);
@@ -910,10 +910,10 @@ impl Array : Monad {
         ));
         let ret = Array::empty(count);
         loop((0, ret), |(i, ret)| (
-            if i == size { break $ ret };
+            if i >= size { break $ ret };
             let inner = arr_arr.@(i);
             continue $ loop((0, ret), |(j, ret)|(
-                if j == inner.@size {
+                if j >= inner.@size {
                     break $ (i + 1, ret)
                 } else {
                     let ret = ret.push_back(inner.@(j));
@@ -1357,7 +1357,7 @@ namespace IO {
         let argc = *get_arg_count;
         let args = Array::empty(argc);
         loop_m((args, 0), |(args, idx)| (
-            if idx == argc { break_m $ args };
+            if idx >= argc { break_m $ args };
             let arg = (*get_arg(idx)).as_some;
             continue_m $ (args.push_back(arg), idx + 1)
         ))
@@ -3037,7 +3037,7 @@ namespace String {
         type Item StringBytesIterator = U8;
         advance = |it| (
             let i = it.@_i;
-            if i == it.@_s.@size { none() };
+            if i >= it.@_s.@size { none() };
             let c = it.@_s[i].iget;
             let it = it[^_i].imod(add(1));
             (it, c).some
@@ -3158,7 +3158,7 @@ namespace String {
         advance = |iter| (
             let StringSplitIterator { idx: idx, str: str, strlen: strlen, sep: sep, sep_len: sep_len } = iter;
             if sep_len == 0 {
-                if idx == strlen { none() };
+                if idx >= strlen { none() };
                 let c_str = String::from_U8 $ str.get_bytes.@(idx);
                 some $ (iter.set_idx(idx + 1), c_str)
             };
@@ -3195,7 +3195,7 @@ namespace String {
         let len = str.@size;
         let bytes = str.get_bytes;
         let n = loop(0, |i| (
-            if i == len { break $ i };
+            if i >= len { break $ i };
             if !cond(bytes.@(i)) { break $ i };
             continue $ i + 1
         ));
@@ -3274,7 +3274,7 @@ namespace String {
         let end = template.@size - 1;
         let out = [];
         let (out, vi) = loop((out, 0, 0), |(out, i, vi)|
-            if i == end { break $ (out, vi) };
+            if i >= end { break $ (out, vi) };
             let c = template.@(i);
 
             // replace "{{" to "{"


### PR DESCRIPTION
この変更に対応する issue はありません。

Std の中で「カウンタが境界に等しくなったら終わる」と書かれている 16 か所を、「境界に届いたら終わる」に変えます。有効な入力に対する答えは変わりません。カウンタはどれも 1 ずつ動くので `>=` は同じ場所で止まり、加えて**行き過ぎたカウンタでも止まります**。

2026-07-18 に `ArrayIterator` / `RangeIterator` / `RangeStepIterator` の 3 つを同じ理由で `>=` にしています (`1a800c6c`)。あのときは境界検査が消えてベクトル化が効き、`sum_by_range_fold` が -67.7%、`sum_by_fold` が -80.0% でした。**これはそのとき取り残された 16 か所**です。

## 触った item

同じ 1 つの変更が次に入ります。括弧内は 1 つの item の中の箇所数です。

[`Array::find_by`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L335)、[`Array::_insertion_sort_by_ranged`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L567) (下へ数えるので `<=`)、[`Array::_merge_runs`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L712) (2)、[`Array::_unsafe_copy_range_bounds_unchecked`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L740)、[`Array : Eq`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L842)、[`Array : LessThan`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L857) (3)、[`Array : LessThanOrEq`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L874) (3)、[`Array : Functor`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L888)、[`Array : Monad`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L901) (3)、[`IO::get_args`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L1357)、[`StringBytesIterator::advance`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L3038)、[`StringSplitIterator::advance`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L3158)、[`String::strip_first_bytes`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L3194)、[`String::populate`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L3272)。

- **役割**: どれも配列・文字列・引数列を先頭から末尾まで数えて歩く。
- **変更**: 終了条件の `==` が `>=` (下へ数える 1 か所は `<=`) になる。
- **目的**: 終了条件をループ番人の形 `i < n` に揃えると、LLVM が要素の境界検査を冗長と証明できるようになる。これが 2026-07-18 に 3 つの反復子で効いた機構である。

[`String::populate`](https://github.com/tttmmmyyyy/fixlang/blob/31ee24dd1f7f8a23c8d374d299fb784ba265a645/src/fixstd/std.fix#L3272) だけはカウンタが 2 進む枝を持ちますが、その枝は `i + 1 < end` を確かめてから入るので、`==` でも今は行き過ぎません。`>=` はその前提に頼らなくなります。

```diff
     find_by = |cond, arr| (
         let len = arr.@size;
         loop(0, |idx| (
-            if idx == len { break $ Option::none $ () };
+            if idx >= len { break $ Option::none $ () };
             if cond(arr.@(idx)) { break $ Option::some $ idx };
             continue $ idx + 1
         ))
     );
```

## 測ったもの

**speedtest 56 ケースでは中立でした。** perf の `instructions:u`、3 回の最小値、幾何平均で **+0.01%**。境界検査の数 (最適化後 IR に残る `fixruntime_index_out_of_range` の呼び出し) も 291 個から動きません。

個別に動いたのは `sort_ordered` -0.84%、`cp_lib_unionfind` +0.46%、`sort` +0.38%、`sort_stable_ordered` +0.42% で、いずれもソートの経路 (`_merge_runs` と `_insertion_sort_by_ranged`) です。方向は両側に出ます。

2026-07-18 の 3 つと違って効かない理由は、**このコーパスがここで直した 16 か所をあまり通らない**からだと思います。`Array : Eq` や `String::populate` や `IO::get_args` を熱いループで回すケースがありません。

なので**性能の変更としてではなく、頑健さの変更として読んでください**: 行き過ぎたカウンタでも止まるようになり、3 つの反復子と書き方が揃います。

## テスト

**このブランチ単独ではスイートを走らせていません。**この commit を含む 3 つの変更をまとめて当てた状態で全スイート 1,690 + 185 / 0 failed を確認しています。機械が空き次第、このブランチ単独で走らせます。

テストは足していません。有効な入力に対する答えが変わらないので、押さえるべき新しい振る舞いがありません。既存のスイートが `Array::sort_stable` (`_merge_runs`)、`Array : Eq` / `LessThan`、`String::populate`、`IO::get_args` を通ります。

changelog の項目もありません。利用者から見える振る舞いが変わらないためです。

